### PR TITLE
Code review: fix 8 bugs and 4 quality improvements

### DIFF
--- a/doc/code-review-fixes.md
+++ b/doc/code-review-fixes.md
@@ -1,0 +1,117 @@
+# Code Review: Fixes & Improvements
+
+A comprehensive code review of the Phase 3 implementation identified 8 bugs and 7 code quality improvements. This document summarizes every change made.
+
+## Bug Fixes
+
+### 1. Rating stars don't update visually after clicking
+
+**Problem:** Rating stars rendered based on the stale `book.rating` prop passed to `BookDetailModal`. Clicking a star called `onUpdated()` which updated the books array in context, but the `book` prop held by the parent's `selectedBook` state was never refreshed — so the stars appeared unchanged until the modal was closed and reopened.
+
+**Fix:** Added `localRating` state (mirroring the existing `isFavorite` pattern) that updates immediately on click. Also enables clearing a rating by clicking the same star again.
+
+**Files:** `src/components/BookDetailModal.tsx`
+
+---
+
+### 2. Header badge shows stale status
+
+**Problem:** The status badge in the modal header used `book.status` (stale prop) instead of the form's watched `status` value. Changing the status dropdown had no visible effect on the badge.
+
+**Fix:** Replaced `book.status` with the already-watched `status` form variable in both the badge text and variant calculation.
+
+**Files:** `src/components/BookDetailModal.tsx`
+
+---
+
+### 3. Progress inputs hidden when total pages not set
+
+**Problem:** The "Update progress" section in BookDetailModal was conditionally rendered with `{book.total_pages && (...)}`, which hid the current page input entirely when a "Reading" book had no `total_pages` set. Users couldn't enter any progress at all.
+
+**Fix:** Removed the `book.total_pages` / `book.total_chapters` guards. Progress inputs now always appear when status is "Reading", with an optional "/ total" suffix shown only when the total is known.
+
+**Files:** `src/components/BookDetailModal.tsx`
+
+---
+
+### 4. Save and delete errors silently swallowed
+
+**Problem:** `onSubmit` and `handleDelete` in BookDetailModal used `try/finally` with no `catch` block. If `onUpdated` or `onDeleted` threw, the error was an unhandled rejection and the user saw no feedback.
+
+**Fix:** Added `catch` blocks that set an `errorMsg` state displayed in the modal footer. Also added error rollback to `toggleFavorite` — the optimistic `setIsFavorite` is now reverted if the update fails.
+
+**Files:** `src/components/BookDetailModal.tsx`
+
+---
+
+### 5. Select dropdowns can't be cleared
+
+**Problem:** Radix Select doesn't support empty string as a value. Once a Language, Format, Belongs To, or Series was selected, there was no way to unset it.
+
+**Fix:** Added a "Not set" (or "None" for Series) option with a `__none__` sentinel value to every clearable Select, mapped back to empty string in the form state. Applied to both `AddBookDialog` and `BookDetailModal`.
+
+**Files:** `src/components/AddBookDialog.tsx`, `src/components/BookDetailModal.tsx`
+
+---
+
+### 6. Login redirect race condition
+
+**Problem:** After successful sign-in, two competing redirects could fire: the `useEffect` (which always navigated to `/`) and the `onSubmit` handler (which correctly used `location.state.from`). If the Supabase auth listener updated the user state before `onSubmit`'s navigate executed, the user always landed on `/` instead of their intended page.
+
+**Fix:** The `useEffect` now reads `location.state.from`, and `onSubmit` delegates redirect entirely to the `useEffect` — eliminating the race.
+
+**Files:** `src/pages/Login.tsx`
+
+---
+
+### 7. useSeries silently swallows fetch errors
+
+**Problem:** `useSeries` caught fetch errors with `.catch(() => {})`, giving users no indication when series failed to load (the dropdown just appeared empty).
+
+**Fix:** Added an `error` state to the hook that captures and exposes fetch failures for consumers to display.
+
+**Files:** `src/hooks/useSeries.ts`
+
+---
+
+### 8. Cover upload accepts any file type
+
+**Problem:** `uploadCover` extracted the file extension from the filename without validation. While the HTML input's `accept="image/*"` provides a hint, it's not enforced.
+
+**Fix:** Added validation against a whitelist of image extensions (`jpg`, `jpeg`, `png`, `webp`, `avif`) before uploading to Supabase Storage.
+
+**Files:** `src/lib/books.ts`
+
+---
+
+## Code Quality Improvements
+
+### 9. Extract duplicated `statusVariant` function
+
+`statusVariant` was defined identically in `BookCard.tsx` and `BookDetailModal.tsx`. Moved to `src/lib/utils.ts` and imported from both components.
+
+**Files:** `src/lib/utils.ts`, `src/components/BookCard.tsx`, `src/components/BookDetailModal.tsx`
+
+---
+
+### 10. Display error state in Dashboard and Library
+
+`useBooks` tracked an `error` state, but neither `Dashboard` nor `Library` read or displayed it. A failed `fetchBooks()` resulted in infinite loading skeletons or a silent empty state. Added error banners with a "Try again" button that calls `reload()`.
+
+**Files:** `src/pages/Dashboard.tsx`, `src/pages/Library.tsx`
+
+---
+
+### 11. Current page/chapter inputs in Add Book dialog
+
+When adding a book with status "Reading", there was no way to set the current page or chapter — users had to create the book and then immediately edit it. Now shows current page/chapter inputs when status is "Reading".
+
+**Files:** `src/components/AddBookDialog.tsx`
+
+---
+
+### 12. Standalone typecheck script
+
+Vite only transpiles TypeScript without checking types. Added `npm run typecheck` (`tsc --noEmit`) so developers can catch type errors during development without running a full production build.
+
+**Files:** `package.json`

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
     "invite": "tsx scripts/invite-user.ts"
   },
   "dependencies": {

--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -249,11 +249,12 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
                   name="language"
                   control={control}
                   render={({ field }) => (
-                    <Select value={field.value} onValueChange={field.onChange}>
+                    <Select value={field.value || "__none__"} onValueChange={(v) => field.onChange(v === "__none__" ? "" : v)}>
                       <SelectTrigger>
                         <SelectValue placeholder="Select language" />
                       </SelectTrigger>
                       <SelectContent>
+                        <SelectItem value="__none__">Not set</SelectItem>
                         {(["German", "Spanish", "English"] as BookLanguage[]).map((l) => (
                           <SelectItem key={l} value={l}>
                             {l}
@@ -272,11 +273,12 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
                   name="format"
                   control={control}
                   render={({ field }) => (
-                    <Select value={field.value} onValueChange={field.onChange}>
+                    <Select value={field.value || "__none__"} onValueChange={(v) => field.onChange(v === "__none__" ? "" : v)}>
                       <SelectTrigger>
                         <SelectValue placeholder="Select format" />
                       </SelectTrigger>
                       <SelectContent>
+                        <SelectItem value="__none__">Not set</SelectItem>
                         {(["eBook", "Audiobook", "Paperback", "Hardcover"] as BookFormat[]).map(
                           (f) => (
                             <SelectItem key={f} value={f}>
@@ -297,11 +299,12 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
                   name="belongs_to"
                   control={control}
                   render={({ field }) => (
-                    <Select value={field.value} onValueChange={field.onChange}>
+                    <Select value={field.value || "__none__"} onValueChange={(v) => field.onChange(v === "__none__" ? "" : v)}>
                       <SelectTrigger>
                         <SelectValue placeholder="Select owner" />
                       </SelectTrigger>
                       <SelectContent>
+                        <SelectItem value="__none__">Not set</SelectItem>
                         {(["Me", "Family", "Friends", "Library"] as BookBelongsTo[]).map((b) => (
                           <SelectItem key={b} value={b}>
                             {b}
@@ -357,10 +360,12 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
                   control={control}
                   render={({ field }) => (
                     <Select
-                      value={field.value}
+                      value={field.value || "__none__"}
                       onValueChange={(v) => {
                         if (v === "__new__") {
                           setAddingNewSeries(true);
+                        } else if (v === "__none__") {
+                          field.onChange("");
                         } else {
                           field.onChange(v);
                         }
@@ -370,6 +375,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
                         <SelectValue placeholder="None" />
                       </SelectTrigger>
                       <SelectContent>
+                        <SelectItem value="__none__">None</SelectItem>
                         {series.map((s) => (
                           <SelectItem key={s.id} value={s.id}>
                             {s.name}

--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -33,6 +33,8 @@ interface FormValues {
   belongs_to: BookBelongsTo | "";
   total_pages: string;
   total_chapters: string;
+  current_page: string;
+  current_chapter: string;
   date_started: string;
   date_finished: string;
   series_id: string;
@@ -119,6 +121,8 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
           belongs_to: (values.belongs_to as BookBelongsTo) || undefined,
           total_pages: values.total_pages ? Number(values.total_pages) : undefined,
           total_chapters: values.total_chapters ? Number(values.total_chapters) : undefined,
+          current_page: values.current_page ? Number(values.current_page) : undefined,
+          current_chapter: values.current_chapter ? Number(values.current_chapter) : undefined,
           date_started: values.date_started || undefined,
           date_finished: values.date_finished || undefined,
           series_id: values.series_id || undefined,
@@ -337,6 +341,30 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
                   />
                 </div>
               </div>
+
+              {/* Current progress (Reading only) */}
+              {status === "Reading" && (
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="current_page">Current page</Label>
+                    <Input
+                      id="current_page"
+                      type="number"
+                      min={0}
+                      {...register("current_page")}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="current_chapter">Current chapter</Label>
+                    <Input
+                      id="current_chapter"
+                      type="number"
+                      min={0}
+                      {...register("current_chapter")}
+                    />
+                  </div>
+                </div>
+              )}
 
               {/* Dates (conditional) */}
               {showDateStarted && (

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -2,16 +2,8 @@ import { BookOpen, Heart } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import type { Book, BookStatus } from "@/types";
-
-function statusVariant(
-  status: BookStatus
-): "default" | "secondary" | "outline" | "destructive" {
-  if (status === "Reading") return "default";
-  if (status === "DNF") return "destructive";
-  if (status === "Up Next") return "secondary";
-  return "outline";
-}
+import { statusVariant } from "@/lib/utils";
+import type { Book } from "@/types";
 
 interface BookCardProps {
   book: Book;

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -86,6 +86,7 @@ export default function BookDetailModal({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const {
     register,
@@ -102,6 +103,7 @@ export default function BookDetailModal({
       setIsFavorite(book.is_favorite);
       setLocalRating(book.rating ?? null);
       setConfirmDelete(false);
+      setErrorMsg(null);
       reset({
         title: book.title,
         author: book.author,
@@ -131,7 +133,11 @@ export default function BookDetailModal({
     if (!book) return;
     const next = !isFavorite;
     setIsFavorite(next);
-    await onUpdated(book.id, { is_favorite: next });
+    try {
+      await onUpdated(book.id, { is_favorite: next });
+    } catch {
+      setIsFavorite(!next);
+    }
   }
 
   async function handleRating(rating: number) {
@@ -166,8 +172,11 @@ export default function BookDetailModal({
 
     try {
       setSaving(true);
+      setErrorMsg(null);
       await onUpdated(book.id, payload);
       reset(values); // reset dirty state
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed to save changes");
     } finally {
       setSaving(false);
     }
@@ -181,8 +190,11 @@ export default function BookDetailModal({
     }
     try {
       setDeleting(true);
+      setErrorMsg(null);
       await onDeleted(book.id);
       onOpenChange(false);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed to delete book");
     } finally {
       setDeleting(false);
     }
@@ -487,6 +499,9 @@ export default function BookDetailModal({
                 </div>
               </ScrollArea>
 
+              {errorMsg && (
+                <p className="text-sm text-destructive mt-2">{errorMsg}</p>
+              )}
               <div className="mt-3 shrink-0 flex justify-between gap-2 border-t pt-3">
                 <Button
                   type="button"

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -82,6 +82,7 @@ export default function BookDetailModal({
 }: BookDetailModalProps) {
   const { series } = useSeries();
   const [isFavorite, setIsFavorite] = useState(false);
+  const [localRating, setLocalRating] = useState<number | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -99,6 +100,7 @@ export default function BookDetailModal({
   useEffect(() => {
     if (book) {
       setIsFavorite(book.is_favorite);
+      setLocalRating(book.rating ?? null);
       setConfirmDelete(false);
       reset({
         title: book.title,
@@ -134,7 +136,9 @@ export default function BookDetailModal({
 
   async function handleRating(rating: number) {
     if (!book) return;
-    await onUpdated(book.id, { rating });
+    const next = localRating === rating ? null : rating;
+    setLocalRating(next);
+    await onUpdated(book.id, { rating: next ?? undefined });
   }
 
   async function onSubmit(values: FormValues) {
@@ -304,7 +308,7 @@ export default function BookDetailModal({
                         >
                           <Star
                             className={`h-5 w-5 ${
-                              book.rating && n <= book.rating
+                              localRating && n <= localRating
                                 ? "fill-amber-400 text-amber-400"
                                 : "text-muted-foreground"
                             }`}

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSeries } from "@/hooks/useSeries";
+import { statusVariant } from "@/lib/utils";
 import type {
   Book,
   BookStatus,
@@ -63,15 +64,6 @@ const STATUS_OPTIONS: BookStatus[] = [
   "Finished",
   "DNF",
 ];
-
-function statusVariant(
-  status: BookStatus
-): "default" | "secondary" | "outline" | "destructive" {
-  if (status === "Reading") return "default";
-  if (status === "DNF") return "destructive";
-  if (status === "Up Next") return "secondary";
-  return "outline";
-}
 
 export default function BookDetailModal({
   book,

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -258,38 +258,36 @@ export default function BookDetailModal({
                     <div className="rounded-lg border bg-muted/40 p-3 space-y-2">
                       <p className="text-sm font-medium">Update progress</p>
                       <div className="grid grid-cols-2 gap-3">
-                        {book.total_pages && (
-                          <div className="space-y-1">
-                            <Label htmlFor="current_page" className="text-xs">
-                              Current page
-                              {book.total_pages && (
-                                <span className="text-muted-foreground"> / {book.total_pages}</span>
-                              )}
-                            </Label>
-                            <Input
-                              id="current_page"
-                              type="number"
-                              min={0}
-                              max={book.total_pages}
-                              {...register("current_page")}
-                            />
-                          </div>
-                        )}
-                        {book.total_chapters && (
-                          <div className="space-y-1">
-                            <Label htmlFor="current_chapter" className="text-xs">
-                              Current chapter
+                        <div className="space-y-1">
+                          <Label htmlFor="current_page" className="text-xs">
+                            Current page
+                            {book.total_pages != null && (
+                              <span className="text-muted-foreground"> / {book.total_pages}</span>
+                            )}
+                          </Label>
+                          <Input
+                            id="current_page"
+                            type="number"
+                            min={0}
+                            max={book.total_pages ?? undefined}
+                            {...register("current_page")}
+                          />
+                        </div>
+                        <div className="space-y-1">
+                          <Label htmlFor="current_chapter" className="text-xs">
+                            Current chapter
+                            {book.total_chapters != null && (
                               <span className="text-muted-foreground"> / {book.total_chapters}</span>
-                            </Label>
-                            <Input
-                              id="current_chapter"
-                              type="number"
-                              min={0}
-                              max={book.total_chapters}
-                              {...register("current_chapter")}
-                            />
-                          </div>
-                        )}
+                            )}
+                          </Label>
+                          <Input
+                            id="current_chapter"
+                            type="number"
+                            min={0}
+                            max={book.total_chapters ?? undefined}
+                            {...register("current_chapter")}
+                          />
+                        </div>
                       </div>
                     </div>
                   )}

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -215,7 +215,7 @@ export default function BookDetailModal({
               </DialogTitle>
               <p className="text-sm text-muted-foreground">{book.author}</p>
               <div className="flex items-center gap-2">
-                <Badge variant={statusVariant(book.status)}>{book.status}</Badge>
+                <Badge variant={statusVariant(status)}>{status}</Badge>
                 <button
                   type="button"
                   onClick={toggleFavorite}

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -368,11 +368,12 @@ export default function BookDetailModal({
                       name="language"
                       control={control}
                       render={({ field }) => (
-                        <Select value={field.value} onValueChange={field.onChange}>
+                        <Select value={field.value || "__none__"} onValueChange={(v) => field.onChange(v === "__none__" ? "" : v)}>
                           <SelectTrigger>
                             <SelectValue placeholder="Not set" />
                           </SelectTrigger>
                           <SelectContent>
+                            <SelectItem value="__none__">Not set</SelectItem>
                             {(["German", "Spanish", "English"] as BookLanguage[]).map((l) => (
                               <SelectItem key={l} value={l}>
                                 {l}
@@ -391,11 +392,12 @@ export default function BookDetailModal({
                       name="format"
                       control={control}
                       render={({ field }) => (
-                        <Select value={field.value} onValueChange={field.onChange}>
+                        <Select value={field.value || "__none__"} onValueChange={(v) => field.onChange(v === "__none__" ? "" : v)}>
                           <SelectTrigger>
                             <SelectValue placeholder="Not set" />
                           </SelectTrigger>
                           <SelectContent>
+                            <SelectItem value="__none__">Not set</SelectItem>
                             {(["eBook", "Audiobook", "Paperback", "Hardcover"] as BookFormat[]).map(
                               (f) => (
                                 <SelectItem key={f} value={f}>
@@ -416,11 +418,12 @@ export default function BookDetailModal({
                       name="belongs_to"
                       control={control}
                       render={({ field }) => (
-                        <Select value={field.value} onValueChange={field.onChange}>
+                        <Select value={field.value || "__none__"} onValueChange={(v) => field.onChange(v === "__none__" ? "" : v)}>
                           <SelectTrigger>
                             <SelectValue placeholder="Not set" />
                           </SelectTrigger>
                           <SelectContent>
+                            <SelectItem value="__none__">Not set</SelectItem>
                             {(["Me", "Family", "Friends", "Library"] as BookBelongsTo[]).map((b) => (
                               <SelectItem key={b} value={b}>
                                 {b}
@@ -465,11 +468,12 @@ export default function BookDetailModal({
                       name="series_id"
                       control={control}
                       render={({ field }) => (
-                        <Select value={field.value} onValueChange={field.onChange}>
+                        <Select value={field.value || "__none__"} onValueChange={(v) => field.onChange(v === "__none__" ? "" : v)}>
                           <SelectTrigger>
                             <SelectValue placeholder="None" />
                           </SelectTrigger>
                           <SelectContent>
+                            <SelectItem value="__none__">None</SelectItem>
                             {series.map((s) => (
                               <SelectItem key={s.id} value={s.id}>
                                 {s.name}

--- a/src/hooks/useSeries.ts
+++ b/src/hooks/useSeries.ts
@@ -7,12 +7,16 @@ export function useSeries() {
   const { user } = useAuth();
   const [series, setSeries] = useState<Series[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!user) return;
+    setError(null);
     fetchSeries()
       .then(setSeries)
-      .catch(() => {})
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Failed to load series");
+      })
       .finally(() => setLoading(false));
   }, [user]);
 
@@ -23,5 +27,5 @@ export function useSeries() {
     return created;
   }, [user]);
 
-  return { series, loading, addSeries };
+  return { series, loading, error, addSeries };
 }

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -49,12 +49,17 @@ function coverPath(userId: string, bookId: string, ext: string): string {
   return `covers/${userId}/${bookId}.${ext}`;
 }
 
+const VALID_IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "webp", "avif"];
+
 export async function uploadCover(
   userId: string,
   bookId: string,
   file: File
 ): Promise<string> {
-  const ext = file.name.split(".").pop() ?? "jpg";
+  const ext = file.name.split(".").pop()?.toLowerCase() ?? "";
+  if (!VALID_IMAGE_EXTENSIONS.includes(ext)) {
+    throw new Error(`Invalid file type ".${ext}". Allowed: ${VALID_IMAGE_EXTENSIONS.join(", ")}`);
+  }
   const path = coverPath(userId, bookId, ext);
   const { error } = await supabase.storage
     .from("covers")

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,16 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import type { BookStatus } from "@/types"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function statusVariant(
+  status: BookStatus
+): "default" | "secondary" | "outline" | "destructive" {
+  if (status === "Reading") return "default";
+  if (status === "DNF") return "destructive";
+  if (status === "Up Next") return "secondary";
+  return "outline";
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { BookOpen } from "lucide-react";
+import { BookOpen, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { useBooksContext } from "@/context/BooksContext";
 import BookCard from "@/components/BookCard";
 import BookDetailModal from "@/components/BookDetailModal";
@@ -19,7 +20,7 @@ function SkeletonGrid() {
 }
 
 export default function Dashboard() {
-  const { books, loading, updateBook, deleteBook } = useBooksContext();
+  const { books, loading, error, updateBook, deleteBook, reload } = useBooksContext();
   const [selectedBook, setSelectedBook] = useState<Book | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -36,6 +37,21 @@ export default function Dashboard() {
       <div className="space-y-8">
         <h1 className="text-2xl font-semibold">Dashboard</h1>
         <SkeletonGrid />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-8">
+        <h1 className="text-2xl font-semibold">Dashboard</h1>
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <p className="text-sm text-destructive">{error}</p>
+          <Button variant="outline" size="sm" onClick={() => reload()}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Try again
+          </Button>
+        </div>
       </div>
     );
   }

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import { BookOpen } from "lucide-react";
+import { BookOpen, RefreshCw } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { useBooksContext } from "@/context/BooksContext";
@@ -30,7 +31,7 @@ function BooksGrid({ books, onBook }: { books: Book[]; onBook: (b: Book) => void
 }
 
 export default function Library() {
-  const { books, loading, updateBook, deleteBook } = useBooksContext();
+  const { books, loading, error, updateBook, deleteBook, reload } = useBooksContext();
   const { series } = useSeries();
   const [selectedBook, setSelectedBook] = useState<Book | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
@@ -64,6 +65,16 @@ export default function Library() {
           {loading ? "…" : `${books.length} book${books.length !== 1 ? "s" : ""}`}
         </span>
       </div>
+
+      {error && (
+        <div className="flex flex-col items-center gap-3 py-8 text-center">
+          <p className="text-sm text-destructive">{error}</p>
+          <Button variant="outline" size="sm" onClick={() => reload()}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Try again
+          </Button>
+        </div>
+      )}
 
       <Tabs defaultValue="all">
         <TabsList className="w-full">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -18,11 +18,12 @@ export default function Login() {
   const { register, handleSubmit, formState, setError } = useForm<LoginFormValues>();
 
   // Already authenticated — redirect away from login
+  const from = (location.state as { from?: { pathname: string } })?.from?.pathname ?? "/";
   useEffect(() => {
     if (!loading && user) {
-      navigate("/", { replace: true });
+      navigate(from, { replace: true });
     }
-  }, [user, loading, navigate]);
+  }, [user, loading, navigate, from]);
 
   if (loading) {
     return (
@@ -36,11 +37,8 @@ export default function Login() {
     const { error } = await signIn(values.email, values.password);
     if (error) {
       setError("root", { message: error.message });
-      return;
     }
-    // Redirect back to the page the user was trying to reach, or home
-    const from = (location.state as { from?: { pathname: string } })?.from?.pathname ?? "/";
-    navigate(from, { replace: true });
+    // Redirect is handled by the useEffect above when user state updates
   };
 
   return (


### PR DESCRIPTION
## Summary

Comprehensive code review of the Phase 3 implementation. Each fix is its own commit for easy review.

### Bug Fixes
- **Rating stars** don't update visually after clicking (stale prop)
- **Header badge** shows stale status instead of form value
- **Progress inputs** hidden when total_pages not set on Reading books
- **Save/delete errors** silently swallowed in BookDetailModal
- **Select dropdowns** (language, format, belongs to, series) can't be cleared once set
- **Login redirect** race condition loses intended destination
- **useSeries** silently swallows fetch errors
- **Cover upload** accepts any file type without validation

### Quality Improvements
- Extract duplicated `statusVariant` to shared utils
- Display error state with retry in Dashboard and Library
- Allow setting current page/chapter when adding a Reading book
- Add `npm run typecheck` script for dev-time type checking

See `doc/code-review-fixes.md` for full details on each change.

## Test plan
- [x] Click rating star in modal — fills immediately, click again to clear
- [x] Change status dropdown in modal — header badge updates in real time
- [ ] Open "Reading" book with no total_pages — progress inputs still visible
- [ ] Simulate network error on save — error message shown in modal
- [x] Select a language, then clear it via "Not set" option
- [ ] Login redirect to intended page after auth (not always `/`)
- [ ] Failed `fetchBooks()` shows error banner with retry button
- [ ] Try uploading a `.txt` file as cover — rejected with error

🤖 Generated with [Claude Code](https://claude.com/claude-code)