### PR TITLE
feat: add set password dialog for invite-link users

### DIFF
--- a/doc/set-password-feature.md
+++ b/doc/set-password-feature.md
@@ -1,0 +1,35 @@
+# Set Password Feature
+
+Invited users arrive via Supabase magic links and have an active session but no password. Previously they had to run `supabase.auth.updateUser({ password })` in the browser console. This feature adds a proper UI for setting a password.
+
+## How It Works
+
+Supabase's `auth.updateUser({ password })` updates the current user's password **without requiring the old password**. This is the key enabler — invited users have a valid session but never set a password, so a "current password" prompt would be a dead end.
+
+## Implementation
+
+### New: `src/components/SetPasswordDialog.tsx`
+
+A controlled dialog (`open` / `onOpenChange` props) following the same patterns as `AddBookDialog`:
+
+- **Form fields:** New password (min 8 characters) + Confirm password
+- **Validation:** react-hook-form inline `register` rules — required, minLength, and a `validate` function that checks passwords match
+- **Submit:** Calls `supabase.auth.updateUser({ password })` directly (no AuthContext changes needed)
+- **Success state:** Replaces the form with a confirmation message; form and state reset when the dialog closes
+- **Error handling:** Supabase errors displayed via `setError("root", ...)` (same pattern as `Login.tsx`)
+
+### Modified: `src/components/AppLayout.tsx`
+
+- Added a `KeyRound` icon button in the header between Add Book and Sign Out
+- Manages `passwordOpen` state and renders the `SetPasswordDialog`
+
+### Modified: `src/components/index.ts`
+
+- Added barrel export for `SetPasswordDialog`
+
+## Design Decisions
+
+- **Dialog over settings page:** The app has no settings page and creating one for a single action would be overkill. A dialog keeps the user in context.
+- **No "current password" field:** Invited users don't have one. Supabase allows password updates on an active session without it.
+- **Direct supabase import (not AuthContext):** This is a one-off action, not shared state. Adding it to the context would be unnecessary coupling.
+- **No new dependencies:** Uses existing react-hook-form, shadcn/ui Dialog, and lucide-react icons.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { Link, Outlet, useLocation } from "react-router-dom";
-import { Plus, LogOut, BookMarked, LayoutDashboard, Library } from "lucide-react";
+import { Plus, LogOut, BookMarked, LayoutDashboard, Library, KeyRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BooksProvider } from "@/context/BooksContext";
 import { useAuth } from "@/context";
 import AddBookDialog from "./AddBookDialog";
+import SetPasswordDialog from "./SetPasswordDialog";
 import { cn } from "@/lib/utils";
 
 const navLinks = [
@@ -16,6 +17,7 @@ export default function AppLayout() {
   const { signOut } = useAuth();
   const location = useLocation();
   const [addBookOpen, setAddBookOpen] = useState(false);
+  const [passwordOpen, setPasswordOpen] = useState(false);
 
   return (
     <BooksProvider>
@@ -68,6 +70,14 @@ export default function AppLayout() {
               <Button
                 size="icon"
                 variant="ghost"
+                onClick={() => setPasswordOpen(true)}
+                aria-label="Set password"
+              >
+                <KeyRound className="h-5 w-5" />
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
                 onClick={() => signOut()}
                 aria-label="Sign out"
               >
@@ -109,6 +119,7 @@ export default function AppLayout() {
       </div>
 
       <AddBookDialog open={addBookOpen} onOpenChange={setAddBookOpen} />
+      <SetPasswordDialog open={passwordOpen} onOpenChange={setPasswordOpen} />
     </BooksProvider>
   );
 }

--- a/src/components/SetPasswordDialog.tsx
+++ b/src/components/SetPasswordDialog.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { supabase } from "@/lib/supabase";
+
+interface SetPasswordFormValues {
+  password: string;
+  confirmPassword: string;
+}
+
+interface SetPasswordDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function SetPasswordDialog({ open, onOpenChange }: SetPasswordDialogProps) {
+  const [success, setSuccess] = useState(false);
+  const { register, handleSubmit, formState, setError, reset, getValues } =
+    useForm<SetPasswordFormValues>();
+
+  const handleClose = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      reset();
+      setSuccess(false);
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const onSubmit = async (values: SetPasswordFormValues) => {
+    const { error } = await supabase.auth.updateUser({ password: values.password });
+    if (error) {
+      setError("root", { message: error.message });
+    } else {
+      setSuccess(true);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Set password</DialogTitle>
+        </DialogHeader>
+
+        {success ? (
+          <div className="py-4">
+            <p className="text-sm text-muted-foreground">
+              Password updated successfully. You can now sign in with your new password.
+            </p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="new-password">New password</Label>
+              <Input
+                id="new-password"
+                type="password"
+                autoComplete="new-password"
+                {...register("password", {
+                  required: "Password is required",
+                  minLength: { value: 8, message: "Password must be at least 8 characters" },
+                })}
+              />
+              {formState.errors.password && (
+                <p className="text-sm text-destructive">{formState.errors.password.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirm-password">Confirm password</Label>
+              <Input
+                id="confirm-password"
+                type="password"
+                autoComplete="new-password"
+                {...register("confirmPassword", {
+                  required: "Please confirm your password",
+                  validate: (value) =>
+                    value === getValues("password") || "Passwords do not match",
+                })}
+              />
+              {formState.errors.confirmPassword && (
+                <p className="text-sm text-destructive">
+                  {formState.errors.confirmPassword.message}
+                </p>
+              )}
+            </div>
+
+            {formState.errors.root && (
+              <p className="text-sm text-destructive">{formState.errors.root.message}</p>
+            )}
+
+            <DialogFooter>
+              <Button type="submit" disabled={formState.isSubmitting} className="w-full">
+                {formState.isSubmitting ? "Updating…" : "Set password"}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as BookCard } from "./BookCard";
 export { default as AddBookDialog } from "./AddBookDialog";
 export { default as BookDetailModal } from "./BookDetailModal";
 export { default as AppLayout } from "./AppLayout";
+export { default as SetPasswordDialog } from "./SetPasswordDialog";


### PR DESCRIPTION
## Summary
- Add `SetPasswordDialog` component for invited users to set a password without needing the old one (uses `supabase.auth.updateUser()`)
- Add key icon button in the header between Add Book and Sign Out to open the dialog
- Add implementation docs in `doc/set-password-feature.md`

## Test plan
- [ ] Log in via invite link, click the key icon, set a password
- [ ] Verify validation: empty fields, short password, mismatched passwords
- [ ] Verify success message appears after setting password
- [ ] Sign out and sign back in with the new password
- [ ] Verify `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)