### PR TITLE
docs: add Supabase config and UAT testing findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,54 @@ Data visualizations displayed on the Start Page and dedicated wrap-ups:
   - Reading habit analytics (e.g., "You read mostly on Sunday mornings").
   - Total hours read and pages turned.
 
+### Supabase Configuration
+
+#### Database Schema
+
+Run `supabase/schema.sql` in the Supabase SQL Editor (Dashboard > SQL Editor > New query) to create all tables, indexes, and RLS policies.
+
+#### Storage: `covers` Bucket
+
+Cover images are stored in Supabase Storage. The bucket must be created manually:
+
+1. **Dashboard > Storage > New bucket**
+   - Name: `covers`
+   - Public: **yes** (cover URLs are used directly in `<img src>` tags, no signed URLs needed)
+
+2. **Add RLS policies** — run in the SQL Editor:
+
+```sql
+-- Allow authenticated users to upload covers to their own folder
+CREATE POLICY "covers: owner insert"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'covers'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+
+-- Allow authenticated users to delete/replace their own covers
+CREATE POLICY "covers: owner delete"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'covers'
+  AND (storage.foldername(name))[1] = auth.uid()::text
+);
+```
+
+The upload path format is `covers/{user_id}/{book_id}.{ext}`, so these policies ensure users can only write to their own folder. No SELECT policy is needed since the bucket is public.
+
+#### Environment Variables
+
+Create a `.env` file in the project root with your Supabase credentials:
+
+```
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+```
+
 ---
 *Generated for coding agent context based on the user's Reading Journal UI/UX specifications and technical requirements.*


### PR DESCRIPTION
## Summary

- Adds a **Supabase Configuration** section to the README documenting the required Storage bucket setup (`covers`) and its RLS policies
- Documents the database schema setup and environment variables

## UAT Testing Results

A full round of manual testing was performed on the locally running app. Here are the results:

| Test | Status | Notes |
|------|--------|-------|
| Dashboard empty state | PASS | Correct empty message, nav and action buttons present |
| Add Book flow | PASS | Validation, conditional fields (status=Reading), loading state all work |
| Library view | PASS | All Books/TBR/Series tabs, book count, standalone grouping |
| Book detail modal | PASS | Properties/Journal/Analytics tabs, favorite toggle, rating, progress update, dirty-state save button |
| Dashboard with active books | PASS | Currently Reading section, book card with progress bar |
| Set password dialog | PASS | Min-length and mismatch validation |
| Sign out | PASS | Redirects to login |
| Protected routing | PASS | Unauthenticated `/library` redirects to `/login` |
| **Cover upload (Add Book)** | **FAIL** | `"new row violates row-level security policy"` — missing Storage RLS policies |
| Cover change (existing book) | N/A | No cover upload option in the book detail modal |

### Bug: Cover image upload fails

**Steps to reproduce:** Add Book > upload a cover image > fill required fields > click "Add Book"
**Expected:** Book is created with the cover image
**Actual:** Red error: "new row violates row-level security policy"
**Root cause:** The `covers` Storage bucket is missing INSERT/DELETE RLS policies for authenticated users. The fix is documented in the new README section.

### Feature gap noted

There is no way to add or change a book's cover image after creation — the detail modal has no cover upload control.

## Test plan

- [ ] Verify the documented SQL policies fix the cover upload issue when applied in Supabase Dashboard
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)