### PR TITLE
fix: repair broken scroll in book detail dialog

### DIFF
--- a/doc/scroll-fix.md
+++ b/doc/scroll-fix.md
@@ -1,0 +1,31 @@
+# Fix: Book Detail Dialog Scroll
+
+## Problem
+
+The book detail dialog's Properties tab was not scrollable. When the form content exceeded the dialog's `max-h-[90svh]` constraint, fields below the fold (Belongs to, Total pages, Date started, Series) were clipped and unreachable.
+
+## Root Cause
+
+Two issues combined to break the scroll:
+
+### 1. Broken flex height chain at `TabsContent`
+
+`TabsContent` had `flex-1 min-h-0` making it a flex **item**, but it was not itself a flex **container**. The inner `<form>` used `h-full` (percentage-based height), which cannot resolve against a parent whose height is determined by flex layout rather than an explicit `height` property.
+
+### 2. Radix ScrollArea viewport ignoring parent height
+
+The ScrollArea component's viewport used `size-full` (`width: 100%; height: 100%`). CSS percentage heights do not resolve against flex-computed parent heights — the viewport expanded to its full content size (860px) instead of being constrained to the root's flex-computed height (571px). With no height difference between viewport and content, there was nothing to scroll.
+
+## Fix
+
+### `src/components/BookDetailModal.tsx`
+
+- Added `flex flex-col` to `TabsContent` so it becomes a flex container
+- Changed the form from `h-full` to `flex-1` for flex-based sizing instead of percentage-based
+
+### `src/components/ui/scroll-area.tsx`
+
+- Made the ScrollArea root a flex container (`flex flex-col`) so the viewport can use flex-based sizing
+- Changed the viewport from `size-full` to `w-full flex-1 min-h-0`, replacing the broken `height: 100%` with flex grow/shrink behavior
+
+Both changes ensure the entire height chain from `DialogContent` down to the scroll viewport uses flex layout, avoiding the CSS percentage-height-vs-flex-computed-height pitfall.

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -253,8 +253,8 @@ export default function BookDetailModal({
           </TabsList>
 
           {/* Properties tab */}
-          <TabsContent value="properties" className="flex-1 min-h-0">
-            <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col h-full min-h-0">
+          <TabsContent value="properties" className="flex-1 min-h-0 flex flex-col">
+            <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col flex-1 min-h-0">
               <ScrollArea className="flex-1 min-h-0 pr-2">
                 <div className="space-y-4 py-1">
                   {/* Progress update (Reading only) */}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -13,12 +13,12 @@ function ScrollArea({
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
-      className={cn("relative", className)}
+      className={cn("relative overflow-hidden flex flex-col", className)}
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+        className="w-full flex-1 min-h-0 rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
## Summary

The book detail dialog's properties tab was not scrollable — long forms were clipped instead of scrolling within the modal. Two issues were found and fixed:

1. **Broken flex height chain at `TabsContent`** — It was a flex *item* (`flex-1`) but not a flex *container*, so the inner form couldn't resolve its height. Fixed by adding `flex flex-col` to `TabsContent` and switching the form from `h-full` to `flex-1`.

2. **Radix ScrollArea viewport ignoring parent height** — The viewport used `height: 100%` (via `size-full`), but CSS percentage heights don't resolve against flex-computed parent heights. The viewport expanded to full content size (860px) instead of being constrained to the root (571px). Fixed by making the ScrollArea root a flex container and switching the viewport from `size-full` to `w-full flex-1 min-h-0`.

## Test plan

- [x] Open any book's detail dialog
- [x] Verify the properties tab scrolls when content overflows
- [x] Verify all fields are reachable by scrolling (Belongs to, Total pages, Date started, Series)
- [x] Verify the fixed footer (Delete / Save Changes buttons) remains visible
- [x] Verify the Journal and Analytics tabs still render correctly
- [x] Verify the Add Book dialog scroll still works (also uses ScrollArea)

🤖 Generated with [Claude Code](https://claude.com/claude-code)