### PR TITLE
feat: allow editing book cover from detail dialog

### DIFF
--- a/doc/edit-book-cover.md
+++ b/doc/edit-book-cover.md
@@ -1,0 +1,38 @@
+# Feature: Edit Book Cover in Detail Dialog
+
+## Problem
+
+Once a cover was set for a book, there was no way to change it without deleting and re-adding the book. The cover thumbnail in the book detail dialog was display-only.
+
+## Solution
+
+### Cover editing UI (`BookDetailModal.tsx`)
+
+- The cover thumbnail in the dialog header is now a clickable `<label>` wrapping a hidden file input (`accept="image/*"`)
+- On hover, a semi-transparent overlay appears with an `ImagePlus` icon (or a spinner during upload)
+- Selecting a file triggers an immediate upload (same instant-feedback pattern as favorite/rating toggles)
+- Works for both adding a first cover and replacing an existing one
+
+### Cover update logic (`useBooks.ts`)
+
+Added `updateCover(id, file)` which:
+
+1. Deletes all old cover files from the `covers` storage bucket (best-effort, tries all valid extensions)
+2. Uploads the new file via `uploadCover()` with `upsert: true`
+3. Updates the book's `cover_url` in the database
+4. Updates local state so all views reflect the change
+
+### Stale `selectedBook` bug fix (`Library.tsx`, `Dashboard.tsx`)
+
+Both pages stored `selectedBook` as a `useState<Book | null>` snapshot captured on click. When `updateCover` (or any update) modified the `books` array in context, the dialog still displayed the stale snapshot.
+
+**Fix:** Store only `selectedBookId` and derive the book object from the live `books` array:
+
+```tsx
+const [selectedBookId, setSelectedBookId] = useState<string | null>(null);
+const selectedBook = selectedBookId
+  ? books.find((b) => b.id === selectedBookId) ?? null
+  : null;
+```
+
+This ensures the dialog always reflects the latest book state for all updates — not just covers, but also favorites, ratings, and form saves.

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useForm, Controller } from "react-hook-form";
-import { Heart, Star, BookOpen } from "lucide-react";
+import { Heart, Star, BookOpen, ImagePlus } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -53,6 +53,7 @@ interface BookDetailModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onUpdated: (id: string, payload: Partial<Book>) => Promise<void>;
+  onCoverChanged: (id: string, file: File) => Promise<void>;
   onDeleted: (id: string) => Promise<void>;
 }
 
@@ -70,6 +71,7 @@ export default function BookDetailModal({
   open,
   onOpenChange,
   onUpdated,
+  onCoverChanged,
   onDeleted,
 }: BookDetailModalProps) {
   const { series } = useSeries();
@@ -78,7 +80,9 @@ export default function BookDetailModal({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [uploadingCover, setUploadingCover] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const coverInputRef = useRef<HTMLInputElement>(null);
 
   const {
     register,
@@ -137,6 +141,23 @@ export default function BookDetailModal({
     const next = localRating === rating ? null : rating;
     setLocalRating(next);
     await onUpdated(book.id, { rating: next ?? undefined });
+  }
+
+  async function handleCoverChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (!book) return;
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      setUploadingCover(true);
+      setErrorMsg(null);
+      await onCoverChanged(book.id, file);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed to update cover");
+    } finally {
+      setUploadingCover(false);
+      // Reset input so the same file can be re-selected
+      if (coverInputRef.current) coverInputRef.current.value = "";
+    }
   }
 
   async function onSubmit(values: FormValues) {
@@ -200,7 +221,10 @@ export default function BookDetailModal({
         {/* Fixed header */}
         <DialogHeader className="shrink-0">
           <div className="flex items-start gap-3">
-            <div className="relative h-20 w-14 shrink-0 overflow-hidden rounded-md bg-muted">
+            <label
+              htmlFor="cover-change"
+              className="relative h-20 w-14 shrink-0 overflow-hidden rounded-md bg-muted cursor-pointer group"
+            >
               {book.cover_url ? (
                 <img
                   src={book.cover_url}
@@ -212,7 +236,23 @@ export default function BookDetailModal({
                   <BookOpen className="h-6 w-6 text-muted-foreground/40" />
                 </div>
               )}
-            </div>
+              <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity">
+                {uploadingCover ? (
+                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                ) : (
+                  <ImagePlus className="h-4 w-4 text-white" />
+                )}
+              </div>
+              <input
+                id="cover-change"
+                type="file"
+                accept="image/*"
+                className="sr-only"
+                ref={coverInputRef}
+                onChange={handleCoverChange}
+                disabled={uploadingCover}
+              />
+            </label>
             <div className="min-w-0 flex-1 space-y-1">
               <DialogTitle className="line-clamp-2 leading-tight">
                 {book.title}

--- a/src/context/BooksContext.tsx
+++ b/src/context/BooksContext.tsx
@@ -8,6 +8,7 @@ interface BooksContextValue {
   error: string | null;
   addBook: (payload: AddBookPayload, coverFile?: File) => Promise<void>;
   updateBook: (id: string, payload: Partial<Book>) => Promise<void>;
+  updateCover: (id: string, file: File) => Promise<void>;
   deleteBook: (id: string) => Promise<void>;
   reload: () => Promise<void>;
 }

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -60,6 +60,20 @@ export function useBooks() {
     []
   );
 
+  const updateCover = useCallback(
+    async (id: string, file: File): Promise<void> => {
+      if (!user) throw new Error("Not authenticated");
+      // Delete old cover files (best-effort)
+      await deleteCover(user.id, id).catch(() => {});
+      // Upload new cover
+      const cover_url = await uploadCover(user.id, id, file);
+      // Update book record in DB
+      const updated = await updateBookDb(id, { cover_url });
+      setBooks((prev) => prev.map((b) => (b.id === id ? updated : b)));
+    },
+    [user]
+  );
+
   const deleteBook = useCallback(
     async (id: string): Promise<void> => {
       if (!user) throw new Error("Not authenticated");
@@ -71,5 +85,5 @@ export function useBooks() {
     [user]
   );
 
-  return { books, loading, error, addBook, updateBook, deleteBook, reload: load };
+  return { books, loading, error, addBook, updateBook, updateCover, deleteBook, reload: load };
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -20,12 +20,13 @@ function SkeletonGrid() {
 }
 
 export default function Dashboard() {
-  const { books, loading, error, updateBook, deleteBook, reload } = useBooksContext();
-  const [selectedBook, setSelectedBook] = useState<Book | null>(null);
+  const { books, loading, error, updateBook, updateCover, deleteBook, reload } = useBooksContext();
+  const [selectedBookId, setSelectedBookId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
+  const selectedBook = selectedBookId ? books.find((b) => b.id === selectedBookId) ?? null : null;
 
   function openBook(book: Book) {
-    setSelectedBook(book);
+    setSelectedBookId(book.id);
     setModalOpen(true);
   }
 
@@ -101,6 +102,7 @@ export default function Dashboard() {
         open={modalOpen}
         onOpenChange={setModalOpen}
         onUpdated={updateBook}
+        onCoverChanged={updateCover}
         onDeleted={deleteBook}
       />
     </div>

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -31,13 +31,14 @@ function BooksGrid({ books, onBook }: { books: Book[]; onBook: (b: Book) => void
 }
 
 export default function Library() {
-  const { books, loading, error, updateBook, deleteBook, reload } = useBooksContext();
+  const { books, loading, error, updateBook, updateCover, deleteBook, reload } = useBooksContext();
   const { series } = useSeries();
-  const [selectedBook, setSelectedBook] = useState<Book | null>(null);
+  const [selectedBookId, setSelectedBookId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
+  const selectedBook = selectedBookId ? books.find((b) => b.id === selectedBookId) ?? null : null;
 
   function openBook(book: Book) {
-    setSelectedBook(book);
+    setSelectedBookId(book.id);
     setModalOpen(true);
   }
 
@@ -157,6 +158,7 @@ export default function Library() {
         open={modalOpen}
         onOpenChange={setModalOpen}
         onUpdated={updateBook}
+        onCoverChanged={updateCover}
         onDeleted={deleteBook}
       />
     </div>


### PR DESCRIPTION
## Summary
- The cover thumbnail in the book detail dialog is now clickable — hovering shows an overlay with an upload icon, and selecting a new image uploads it immediately (deleting the old cover from storage)
- Fixes a stale-state bug where `selectedBook` was a frozen snapshot captured on click, so in-dialog updates (cover, favorite, rating) were not reflected until the dialog was reopened
- Exposes `updateCover` through `useBooks` / `BooksContext` for reuse

## Test plan
- [ ] Open a book detail dialog and hover over the cover thumbnail — verify overlay with ImagePlus icon appears
- [ ] Click the cover and select a new image — verify both the dialog thumbnail and the background card update immediately
- [ ] Verify the old cover file is removed from the Supabase `covers` bucket after replacement
- [ ] Open a book with no cover — verify clicking the placeholder allows adding a cover
- [ ] Toggle favorite / change rating while dialog is open — verify changes reflect immediately in the dialog header (stale-state fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)