### PR TITLE
feat: barcode scanner + ISBN auto-fill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.103.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "html5-qrcode": "^2.3.8",
         "lucide-react": "^1.8.0",
         "radix-ui": "^1.4.3",
         "react": "^18.3.1",
@@ -5227,6 +5228,12 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html5-qrcode": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
+      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@supabase/supabase-js": "^2.103.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "html5-qrcode": "^2.3.8",
     "lucide-react": "^1.8.0",
     "radix-ui": "^1.4.3",
     "react": "^18.3.1",

--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -1,6 +1,8 @@
 import { useRef, useState, useEffect } from "react";
 import { useForm, Controller } from "react-hook-form";
-import { ImagePlus } from "lucide-react";
+import { ImagePlus, ScanBarcode, Loader2 } from "lucide-react";
+import BarcodeScanner from "@/components/BarcodeScanner";
+import { fetchBookByISBN } from "@/lib/openLibrary";
 import {
   Dialog,
   DialogContent,
@@ -65,6 +67,12 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
   const [addingNewSeries, setAddingNewSeries] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const [showScanner, setShowScanner] = useState(false);
+  const [manualIsbn, setManualIsbn] = useState("");
+  const [isbnStatus, setIsbnStatus] = useState<"idle" | "looking-up" | "error">("idle");
+  const [isbnError, setIsbnError] = useState<string | null>(null);
+  const [scannedIsbn, setScannedIsbn] = useState<string | null>(null);
+
   const {
     register,
     control,
@@ -94,6 +102,53 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
     if (coverPreview) URL.revokeObjectURL(coverPreview);
     setCoverFile(file);
     setCoverPreview(URL.createObjectURL(file));
+  }
+
+  async function handleIsbnLookup(isbn: string) {
+    setShowScanner(false);
+    setIsbnStatus("looking-up");
+    setIsbnError(null);
+
+    try {
+      const bookData = await fetchBookByISBN(isbn.trim());
+      if (!bookData) {
+        setIsbnStatus("error");
+        setIsbnError(`No book found for ISBN ${isbn}`);
+        return;
+      }
+
+      setScannedIsbn(isbn.trim());
+      setValue("title", bookData.title);
+      setValue("author", bookData.author);
+      if (bookData.totalPages) setValue("total_pages", String(bookData.totalPages));
+      if (bookData.genre) setValue("genre", bookData.genre);
+      if (bookData.language) setValue("language", bookData.language as BookLanguage);
+      if (bookData.format) setValue("format", bookData.format as BookFormat);
+
+      // Download cover image as a File for the existing upload flow
+      if (bookData.coverUrl) {
+        try {
+          const res = await fetch(bookData.coverUrl);
+          if (res.ok) {
+            const blob = await res.blob();
+            // Only use the cover if it's a real image (not a 1x1 placeholder)
+            if (blob.size > 1000) {
+              const file = new File([blob], `cover-${isbn}.jpg`, { type: "image/jpeg" });
+              if (coverPreview) URL.revokeObjectURL(coverPreview);
+              setCoverFile(file);
+              setCoverPreview(URL.createObjectURL(file));
+            }
+          }
+        } catch {
+          // Non-critical — text fields are still filled
+        }
+      }
+
+      setIsbnStatus("idle");
+    } catch {
+      setIsbnStatus("error");
+      setIsbnError("Failed to look up book. Please try again or enter details manually.");
+    }
   }
 
   async function handleAddNewSeries() {
@@ -127,6 +182,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
           date_finished: values.date_finished || undefined,
           series_id: values.series_id || undefined,
           volume_number: values.volume_number ? Number(values.volume_number) : undefined,
+          isbn: scannedIsbn || undefined,
           is_favorite: false,
         },
         coverFile ?? undefined
@@ -134,6 +190,11 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
       reset();
       setCoverFile(null);
       setCoverPreview(null);
+      setShowScanner(false);
+      setManualIsbn("");
+      setIsbnStatus("idle");
+      setIsbnError(null);
+      setScannedIsbn(null);
       onOpenChange(false);
     } catch (err) {
       const message =
@@ -149,8 +210,24 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
   const showDateStarted = ["Reading", "Finished", "DNF"].includes(status);
   const showDateFinished = ["Finished", "DNF"].includes(status);
 
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      reset();
+      setCoverFile(null);
+      setCoverPreview(null);
+      setShowScanner(false);
+      setManualIsbn("");
+      setIsbnStatus("idle");
+      setIsbnError(null);
+      setScannedIsbn(null);
+      setAddingNewSeries(false);
+      setNewSeriesName("");
+    }
+    onOpenChange(nextOpen);
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Add Book</DialogTitle>
@@ -159,6 +236,59 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
         <form onSubmit={handleSubmit(onSubmit)}>
           <ScrollArea className="max-h-[60vh] pr-4">
             <div className="space-y-4 py-1">
+              {/* ISBN Scanner */}
+              {showScanner ? (
+                <BarcodeScanner
+                  onScan={handleIsbnLookup}
+                  onClose={() => setShowScanner(false)}
+                />
+              ) : (
+                <div className="space-y-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-full gap-2"
+                    onClick={() => { setShowScanner(true); setIsbnError(null); }}
+                    disabled={isbnStatus === "looking-up"}
+                  >
+                    <ScanBarcode className="h-4 w-4" />
+                    Scan ISBN barcode
+                  </Button>
+                  <div className="flex gap-2">
+                    <Input
+                      placeholder="Or enter ISBN manually"
+                      value={manualIsbn}
+                      onChange={(e) => setManualIsbn(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          if (manualIsbn.trim()) handleIsbnLookup(manualIsbn);
+                        }
+                      }}
+                    />
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={!manualIsbn.trim() || isbnStatus === "looking-up"}
+                      onClick={() => handleIsbnLookup(manualIsbn)}
+                    >
+                      Look up
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {isbnStatus === "looking-up" && (
+                <p className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Looking up book…
+                </p>
+              )}
+
+              {isbnError && (
+                <p className="text-sm text-destructive text-center">{isbnError}</p>
+              )}
+
               {/* Cover upload */}
               <div className="flex items-center gap-4">
                 <label

--- a/src/components/BarcodeScanner.tsx
+++ b/src/components/BarcodeScanner.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+
+interface BarcodeScannerProps {
+  onScan: (isbn: string) => void;
+  onClose: () => void;
+}
+
+function stopScanner(scanner: any): Promise<void> {
+  try {
+    const result = scanner.stop();
+    if (result && typeof result.catch === "function") {
+      return result.catch(() => {});
+    }
+    return Promise.resolve();
+  } catch {
+    return Promise.resolve();
+  }
+}
+
+export default function BarcodeScanner({ onScan, onClose }: BarcodeScannerProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scannerRef = useRef<any>(null);
+  const scannedRef = useRef(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Stable ref so the effect doesn't re-run when onScan changes identity
+  const onScanRef = useRef(onScan);
+  onScanRef.current = onScan;
+
+  const startScanner = useCallback(async (stopped: () => boolean) => {
+    const { Html5Qrcode, Html5QrcodeSupportedFormats } = await import(
+      "html5-qrcode"
+    );
+
+    if (stopped() || !containerRef.current) return;
+
+    const scannerId = containerRef.current.id;
+    const scanner = new Html5Qrcode(scannerId, {
+      formatsToSupport: [
+        Html5QrcodeSupportedFormats.EAN_13,
+        Html5QrcodeSupportedFormats.EAN_8,
+      ],
+      verbose: false,
+    });
+    scannerRef.current = scanner;
+
+    const config = { fps: 10, qrbox: { width: 280, height: 160 } };
+
+    const onSuccess = async (decodedText: string) => {
+      // Guard against multiple firings
+      if (scannedRef.current) return;
+      scannedRef.current = true;
+
+      await stopScanner(scanner);
+      onScanRef.current(decodedText);
+    };
+
+    try {
+      await scanner.start(
+        { facingMode: { exact: "environment" } },
+        config,
+        onSuccess,
+        () => {},
+      );
+    } catch {
+      try {
+        await scanner.start(
+          { facingMode: "environment" },
+          config,
+          onSuccess,
+          () => {},
+        );
+      } catch (err) {
+        if (!stopped()) {
+          setError(
+            err instanceof Error && err.message.includes("Permission")
+              ? "Camera permission was denied. Please allow camera access and try again."
+              : "Could not access camera. You can enter the ISBN manually instead.",
+          );
+        }
+      }
+    }
+
+    if (!stopped()) setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    let isStopped = false;
+    scannedRef.current = false;
+
+    startScanner(() => isStopped);
+
+    return () => {
+      isStopped = true;
+      if (scannerRef.current) {
+        stopScanner(scannerRef.current);
+      }
+    };
+  }, [startScanner]);
+
+  return (
+    <div className="space-y-3">
+      <div
+        id="isbn-scanner"
+        ref={containerRef}
+        className="relative w-full aspect-[4/3] bg-black rounded-lg overflow-hidden"
+      />
+
+      {loading && !error && (
+        <p className="text-sm text-muted-foreground text-center">
+          Starting camera…
+        </p>
+      )}
+
+      {error && (
+        <p className="text-sm text-destructive text-center">{error}</p>
+      )}
+
+      {!loading && !error && (
+        <p className="text-xs text-muted-foreground text-center">
+          Point your camera at the book's barcode
+        </p>
+      )}
+
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        onClick={onClose}
+      >
+        Cancel
+      </Button>
+    </div>
+  );
+}

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useForm, Controller } from "react-hook-form";
-import { Heart, Star, BookOpen, ImagePlus } from "lucide-react";
+import { Heart, Star, BookOpen, ImagePlus, ExternalLink } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -258,6 +258,17 @@ export default function BookDetailModal({
                 {book.title}
               </DialogTitle>
               <p className="text-sm text-muted-foreground">{book.author}</p>
+              {book.isbn && (
+                <a
+                  href={`https://openlibrary.org/isbn/${book.isbn}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Open Library
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              )}
               <div className="flex items-center gap-2">
                 <Badge variant={statusVariant(status)}>{status}</Badge>
                 <button

--- a/src/lib/openLibrary.ts
+++ b/src/lib/openLibrary.ts
@@ -1,0 +1,105 @@
+export interface OpenLibraryBookData {
+  title: string;
+  author: string;
+  totalPages?: number;
+  genre?: string;
+  language?: string;
+  format?: string;
+  coverUrl?: string;
+}
+
+interface OpenLibraryEdition {
+  title?: string;
+  authors?: { key: string }[];
+  works?: { key: string }[];
+  number_of_pages?: number;
+  subjects?: string[];
+  languages?: { key: string }[];
+  physical_format?: string;
+}
+
+interface OpenLibraryWork {
+  authors?: { author: { key: string } }[];
+  subjects?: string[];
+}
+
+interface OpenLibraryAuthor {
+  name?: string;
+}
+
+async function resolveAuthorName(authorKey: string): Promise<string | null> {
+  try {
+    const res = await fetch(`https://openlibrary.org${authorKey}.json`);
+    if (!res.ok) return null;
+    const data: OpenLibraryAuthor = await res.json();
+    return data.name ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchBookByISBN(
+  isbn: string,
+): Promise<OpenLibraryBookData | null> {
+  const editionRes = await fetch(
+    `https://openlibrary.org/isbn/${isbn}.json`,
+  );
+  if (!editionRes.ok) return null;
+
+  const edition: OpenLibraryEdition = await editionRes.json();
+
+  // Fetch the work record for author/subject fallback
+  let work: OpenLibraryWork | null = null;
+  const workKey = edition.works?.[0]?.key;
+  if (workKey) {
+    try {
+      const workRes = await fetch(`https://openlibrary.org${workKey}.json`);
+      if (workRes.ok) work = await workRes.json();
+    } catch {
+      // non-critical
+    }
+  }
+
+  // Resolve author: edition.authors → work.authors fallback
+  let author = "Unknown";
+  const authorKey =
+    edition.authors?.[0]?.key ?? work?.authors?.[0]?.author?.key;
+  if (authorKey) {
+    const name = await resolveAuthorName(authorKey);
+    if (name) author = name;
+  }
+
+  // Subjects: prefer edition, fall back to work
+  const subjects = edition.subjects ?? work?.subjects;
+
+  // Map Open Library language key to app language
+  const languageMap: Record<string, string> = {
+    "/languages/eng": "English",
+    "/languages/spa": "Spanish",
+    "/languages/ger": "German",
+    "/languages/fre": "French",
+  };
+  const langKey = edition.languages?.[0]?.key;
+  const language = langKey ? languageMap[langKey] : undefined;
+
+  // Map Open Library physical_format to app format
+  const formatMap: Record<string, string> = {
+    paperback: "Paperback",
+    hardcover: "Hardcover",
+    "mass market paperback": "Paperback",
+    ebook: "eBook",
+    "e-book": "eBook",
+  };
+  const rawFormat = edition.physical_format?.toLowerCase();
+  const format = rawFormat ? formatMap[rawFormat] : undefined;
+
+  return {
+    title: edition.title ?? "Untitled",
+    author,
+    totalPages: edition.number_of_pages ?? undefined,
+    genre: subjects?.[0] ?? undefined,
+    language,
+    format,
+    coverUrl: `https://covers.openlibrary.org/b/isbn/${isbn}-L.jpg`,
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,7 @@ export interface Book {
   language?: BookLanguage;
   belongs_to?: BookBelongsTo;
   format?: BookFormat;
+  isbn?: string;
   series_id?: string;
   volume_number?: number;
   user_id: string;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS books (
   language        text CHECK (language IN ('German','Spanish','English')),
   belongs_to      text CHECK (belongs_to IN ('Me','Family','Friends','Library')),
   format          text CHECK (format IN ('eBook','Audiobook','Paperback','Hardcover')),
+  isbn            text,
   series_id       uuid REFERENCES series(id) ON DELETE SET NULL,
   volume_number   integer CHECK (volume_number > 0),
   created_at      timestamptz NOT NULL DEFAULT now()


### PR DESCRIPTION
## Summary
- Add browser-based barcode scanning (`html5-qrcode`) and Open Library API integration to the Add Book dialog
- Users can scan a book's ISBN barcode with their phone camera or enter it manually to auto-fill the form (title, author, genre, language, format, pages, cover)
- The ISBN is persisted on the book record and a link to the Open Library page is shown in the book detail modal

## Changes
- **New:** `src/components/BarcodeScanner.tsx` — camera scanner component with lazy-loaded `html5-qrcode`, rear camera default, permission error handling
- **New:** `src/lib/openLibrary.ts` — Open Library API client with edition + work-level fallback for author/subject resolution
- **Modified:** `src/components/AddBookDialog.tsx` — scan button, manual ISBN input, auto-fill logic, dialog reset on close
- **Modified:** `src/components/BookDetailModal.tsx` — Open Library external link in header when ISBN is available
- **Modified:** `src/types/index.ts` — added `isbn` field to `Book` interface
- **Modified:** `supabase/schema.sql` — added `isbn text` column to books table

## DB migration required
```sql
ALTER TABLE books ADD COLUMN isbn text;
```

## Test plan
- [x] Manual ISBN entry (e.g. `9780141439518`) auto-fills all fields correctly
- [x] Cover image downloads from Open Library and uploads to Supabase Storage
- [x] Author resolved via work-level fallback when not on edition record
- [x] Invalid ISBN shows "No book found" error, form stays editable
- [x] Dialog resets cleanly on close (no stale scanner/form state)
- [x] Mobile layout: full-width buttons, adequate tap targets, rear camera default
- [x] Open Library link appears in book detail modal for books with ISBN
- [x] Books without ISBN show no link (backwards compatible)
- [x] `html5-qrcode` is code-split via dynamic import (~650KB separate chunk)
- [x] Production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)