### PR TITLE
Remove chapter tracking fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Environment variables go in `.env` — Supabase URL and anon key from the Supaba
 
 ### Database Schema (Supabase/PostgreSQL)
 
-**`books`** — core entity: title, author, genre, status, cover_url (Supabase Storage), rating (1–5), is_favorite (heart toggle), current_page, total_pages, current_chapter, total_chapters, date_started, date_finished, language, belongs_to, format, series_id, volume_number, user_id
+**`books`** — core entity: title, author, genre, status, cover_url (Supabase Storage), rating (1–5), is_favorite (heart toggle), current_page, total_pages, date_started, date_finished, language, belongs_to, format, series_id, volume_number, user_id
 
 **`series`** — series name, overarching properties, journal content, user_id
 

--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -34,9 +34,7 @@ interface FormValues {
   format: BookFormat | "";
   belongs_to: BookBelongsTo | "";
   total_pages: string;
-  total_chapters: string;
   current_page: string;
-  current_chapter: string;
   date_started: string;
   date_finished: string;
   series_id: string;
@@ -175,9 +173,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
           format: (values.format as BookFormat) || undefined,
           belongs_to: (values.belongs_to as BookBelongsTo) || undefined,
           total_pages: values.total_pages ? Number(values.total_pages) : undefined,
-          total_chapters: values.total_chapters ? Number(values.total_chapters) : undefined,
           current_page: values.current_page ? Number(values.current_page) : undefined,
-          current_chapter: values.current_chapter ? Number(values.current_chapter) : undefined,
           date_started: values.date_started || undefined,
           date_finished: values.date_finished || undefined,
           series_id: values.series_id || undefined,
@@ -450,49 +446,27 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
                 />
               </div>
 
-              {/* Pages / Chapters */}
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1.5">
-                  <Label htmlFor="total_pages">Total pages</Label>
-                  <Input
-                    id="total_pages"
-                    type="number"
-                    min={1}
-                    {...register("total_pages")}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="total_chapters">Total chapters</Label>
-                  <Input
-                    id="total_chapters"
-                    type="number"
-                    min={1}
-                    {...register("total_chapters")}
-                  />
-                </div>
+              {/* Pages */}
+              <div className="space-y-1.5">
+                <Label htmlFor="total_pages">Total pages</Label>
+                <Input
+                  id="total_pages"
+                  type="number"
+                  min={1}
+                  {...register("total_pages")}
+                />
               </div>
 
               {/* Current progress (Reading only) */}
               {status === "Reading" && (
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="current_page">Current page</Label>
-                    <Input
-                      id="current_page"
-                      type="number"
-                      min={0}
-                      {...register("current_page")}
-                    />
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="current_chapter">Current chapter</Label>
-                    <Input
-                      id="current_chapter"
-                      type="number"
-                      min={0}
-                      {...register("current_chapter")}
-                    />
-                  </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="current_page">Current page</Label>
+                  <Input
+                    id="current_page"
+                    type="number"
+                    min={0}
+                    {...register("current_page")}
+                  />
                 </div>
               )}
 

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -39,9 +39,7 @@ interface FormValues {
   format: BookFormat | "";
   belongs_to: BookBelongsTo | "";
   total_pages: string;
-  total_chapters: string;
   current_page: string;
-  current_chapter: string;
   date_started: string;
   date_finished: string;
   series_id: string;
@@ -109,9 +107,7 @@ export default function BookDetailModal({
         format: book.format ?? "",
         belongs_to: book.belongs_to ?? "",
         total_pages: book.total_pages?.toString() ?? "",
-        total_chapters: book.total_chapters?.toString() ?? "",
         current_page: book.current_page?.toString() ?? "",
-        current_chapter: book.current_chapter?.toString() ?? "",
         date_started: book.date_started ?? "",
         date_finished: book.date_finished ?? "",
         series_id: book.series_id ?? "",
@@ -173,9 +169,7 @@ export default function BookDetailModal({
     if (dirtyFields.format) payload.format = (values.format as BookFormat) || undefined;
     if (dirtyFields.belongs_to) payload.belongs_to = (values.belongs_to as BookBelongsTo) || undefined;
     if (dirtyFields.total_pages) payload.total_pages = values.total_pages ? Number(values.total_pages) : undefined;
-    if (dirtyFields.total_chapters) payload.total_chapters = values.total_chapters ? Number(values.total_chapters) : undefined;
     if (dirtyFields.current_page) payload.current_page = values.current_page ? Number(values.current_page) : undefined;
-    if (dirtyFields.current_chapter) payload.current_chapter = values.current_chapter ? Number(values.current_chapter) : undefined;
     if (dirtyFields.date_started) payload.date_started = values.date_started || undefined;
     if (dirtyFields.date_finished) payload.date_finished = values.date_finished || undefined;
     if (dirtyFields.series_id) payload.series_id = values.series_id || undefined;
@@ -328,21 +322,6 @@ export default function BookDetailModal({
                             {...register("current_page")}
                           />
                         </div>
-                        <div className="space-y-1">
-                          <Label htmlFor="current_chapter" className="text-xs">
-                            Current chapter
-                            {book.total_chapters != null && (
-                              <span className="text-muted-foreground"> / {book.total_chapters}</span>
-                            )}
-                          </Label>
-                          <Input
-                            id="current_chapter"
-                            type="number"
-                            min={0}
-                            max={book.total_chapters ?? undefined}
-                            {...register("current_chapter")}
-                          />
-                        </div>
                       </div>
                     </div>
                   )}
@@ -486,16 +465,10 @@ export default function BookDetailModal({
                     />
                   </div>
 
-                  {/* Pages / Chapters */}
-                  <div className="grid grid-cols-2 gap-3">
-                    <div className="space-y-1.5">
-                      <Label htmlFor="detail-total_pages">Total pages</Label>
-                      <Input id="detail-total_pages" type="number" min={1} {...register("total_pages")} />
-                    </div>
-                    <div className="space-y-1.5">
-                      <Label htmlFor="detail-total_chapters">Total chapters</Label>
-                      <Input id="detail-total_chapters" type="number" min={1} {...register("total_chapters")} />
-                    </div>
+                  {/* Pages */}
+                  <div className="space-y-1.5">
+                    <Label htmlFor="detail-total_pages">Total pages</Label>
+                    <Input id="detail-total_pages" type="number" min={1} {...register("total_pages")} />
                   </div>
 
                   {/* Dates */}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,8 +31,6 @@ export interface Book {
   is_favorite: boolean;
   current_page?: number;
   total_pages?: number;
-  current_chapter?: number;
-  total_chapters?: number;
   date_started?: string;
   date_finished?: string;
   language?: BookLanguage;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -28,8 +28,6 @@ CREATE TABLE IF NOT EXISTS books (
   is_favorite     boolean NOT NULL DEFAULT false,
   current_page    integer CHECK (current_page >= 0),
   total_pages     integer CHECK (total_pages > 0),
-  current_chapter integer CHECK (current_chapter >= 0),
-  total_chapters  integer CHECK (total_chapters > 0),
   date_started    date,
   date_finished   date,
   language        text CHECK (language IN ('German','Spanish','English')),


### PR DESCRIPTION
## Summary
- Remove `current_chapter` and `total_chapters` from the database schema, TypeScript types, and both the Add Book and Book Detail forms
- Chapter fields added no analytics value — progress tracking, pacing prediction, and reading speed all use page-based data from `reading_logs`
- Simplifies forms by removing unused inputs

## Test plan
- [x] `npm run build` passes with no type errors
- [x] Verify Add Book dialog no longer shows chapter fields
- [x] Verify Book Detail modal no longer shows chapter fields in progress or properties tabs
- [x] Confirm existing books load correctly (columns already dropped from live DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)