### PR TITLE
feat: reading progress logging with scroll picker

### DIFF
--- a/doc/reading-progress-logging.md
+++ b/doc/reading-progress-logging.md
@@ -1,0 +1,58 @@
+# Feature: Reading Progress Logging with iOS-Style Scroll Picker
+
+## Problem
+
+The book detail dialog had a basic number input for updating the current page. There was no way to log reading sessions (page reached + time spent), and the UX felt utilitarian rather than tactile. The `reading_logs` table existed in the database but had no frontend integration.
+
+## Solution
+
+### iOS-style scroll wheel picker (`src/components/ui/scroll-wheel-picker.tsx`)
+
+A reusable vertical scroll picker component inspired by the iOS alarm clock picker:
+
+- Uses CSS `scroll-snap-type: y mandatory` for native-feeling snap behavior
+- Items fade in opacity based on distance from the selection center
+- Gradient overlays at top and bottom create the characteristic fade effect
+- Horizontal border lines mark the selected item
+- Scrollbar is hidden; touch scrolling with momentum works natively
+- `overscrollBehavior: contain` prevents parent scroll interference
+
+### Reading progress panel (`src/components/ReadingProgressPanel.tsx`)
+
+Self-contained component replacing the old number input, with two states:
+
+**Collapsed:** Shows current progress ("Page X of Y") and an "Update progress" button.
+
+**Expanded:** Three scroll wheel pickers:
+- **Page picker** -- range from last logged page + 1 to total pages. For books with >200 pages, steps by 5; for >1000 pages, steps by 10. Always includes the first and last page.
+- **Hours picker** -- 0h to 6h
+- **Minutes picker** -- 00m to 55m in 5-minute increments
+
+On save:
+1. Creates a `reading_log` entry in Supabase (page + optional time)
+2. Updates the book's `current_page` via the parent callback
+3. Collapses back and updates the minimum page for the next log
+
+### Supabase functions (`src/lib/books.ts`)
+
+- `createReadingLog(bookId, userId, currentPage, readingTimeMinutes?)` -- inserts into the `reading_logs` table
+- `fetchLastReadingLog(bookId)` -- fetches the most recent log to determine the minimum page value
+
+### BookDetailModal changes (`src/components/BookDetailModal.tsx`)
+
+- Replaced the old `current_page` number input (lines 305-327) with `<ReadingProgressPanel>`
+- Removed `current_page` from the react-hook-form since it's now managed exclusively through the reading log flow
+- The panel is decoupled from the main form save -- it has its own Save/Cancel buttons
+
+## Database
+
+Uses the existing `reading_logs` table:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | uuid | Auto-generated |
+| `book_id` | uuid | FK to books |
+| `user_id` | uuid | FK to auth.users, scoped via RLS |
+| `current_page` | integer | Page reached in this session |
+| `reading_time_minutes` | integer | Optional, must be positive |
+| `logged_at` | timestamptz | Auto-set to now() |

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/select";
 import { useSeries } from "@/hooks/useSeries";
 import { statusVariant } from "@/lib/utils";
+import ReadingProgressPanel from "@/components/ReadingProgressPanel";
 import type {
   Book,
   BookStatus,
@@ -39,7 +40,6 @@ interface FormValues {
   format: BookFormat | "";
   belongs_to: BookBelongsTo | "";
   total_pages: string;
-  current_page: string;
   date_started: string;
   date_finished: string;
   series_id: string;
@@ -107,7 +107,6 @@ export default function BookDetailModal({
         format: book.format ?? "",
         belongs_to: book.belongs_to ?? "",
         total_pages: book.total_pages?.toString() ?? "",
-        current_page: book.current_page?.toString() ?? "",
         date_started: book.date_started ?? "",
         date_finished: book.date_finished ?? "",
         series_id: book.series_id ?? "",
@@ -169,7 +168,6 @@ export default function BookDetailModal({
     if (dirtyFields.format) payload.format = (values.format as BookFormat) || undefined;
     if (dirtyFields.belongs_to) payload.belongs_to = (values.belongs_to as BookBelongsTo) || undefined;
     if (dirtyFields.total_pages) payload.total_pages = values.total_pages ? Number(values.total_pages) : undefined;
-    if (dirtyFields.current_page) payload.current_page = values.current_page ? Number(values.current_page) : undefined;
     if (dirtyFields.date_started) payload.date_started = values.date_started || undefined;
     if (dirtyFields.date_finished) payload.date_finished = values.date_finished || undefined;
     if (dirtyFields.series_id) payload.series_id = values.series_id || undefined;
@@ -304,26 +302,12 @@ export default function BookDetailModal({
                 <div className="space-y-4 py-1">
                   {/* Progress update (Reading only) */}
                   {status === "Reading" && (
-                    <div className="rounded-lg border bg-muted/40 p-3 space-y-2">
-                      <p className="text-sm font-medium">Update progress</p>
-                      <div className="grid grid-cols-2 gap-3">
-                        <div className="space-y-1">
-                          <Label htmlFor="current_page" className="text-xs">
-                            Current page
-                            {book.total_pages != null && (
-                              <span className="text-muted-foreground"> / {book.total_pages}</span>
-                            )}
-                          </Label>
-                          <Input
-                            id="current_page"
-                            type="number"
-                            min={0}
-                            max={book.total_pages ?? undefined}
-                            {...register("current_page")}
-                          />
-                        </div>
-                      </div>
-                    </div>
+                    <ReadingProgressPanel
+                      book={book}
+                      onProgressSaved={async (newPage) => {
+                        await onUpdated(book.id, { current_page: newPage });
+                      }}
+                    />
                   )}
 
                   {/* Rating */}

--- a/src/components/ReadingProgressPanel.tsx
+++ b/src/components/ReadingProgressPanel.tsx
@@ -1,0 +1,228 @@
+import { useState, useEffect, useMemo } from "react";
+import { BookOpen } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { ScrollWheelPicker } from "@/components/ui/scroll-wheel-picker";
+import { createReadingLog, fetchLastReadingLog } from "@/lib/books";
+import { useAuth } from "@/context/AuthContext";
+import type { Book, ReadingLog } from "@/types";
+
+interface ReadingProgressPanelProps {
+  book: Book;
+  onProgressSaved: (newCurrentPage: number) => void;
+}
+
+function buildPageItems(min: number, max: number) {
+  const range = max - min;
+  let step = 1;
+  if (range > 1000) step = 10;
+  else if (range > 200) step = 5;
+
+  const items: { value: number; label: string }[] = [];
+  // Always include the first page
+  items.push({ value: min, label: String(min) });
+  // Then step from the next clean multiple of step
+  const firstStep = step > 1 ? Math.ceil((min + 1) / step) * step : min + 1;
+  for (let p = firstStep; p <= max; p += step) {
+    if (p > min) {
+      items.push({ value: p, label: String(p) });
+    }
+  }
+  // Ensure max is always included
+  if (items[items.length - 1].value !== max) {
+    items.push({ value: max, label: String(max) });
+  }
+  return items;
+}
+
+const HOUR_ITEMS = Array.from({ length: 7 }, (_, i) => ({
+  value: i,
+  label: `${i}h`,
+}));
+
+const MINUTE_ITEMS = Array.from({ length: 12 }, (_, i) => ({
+  value: i * 5,
+  label: `${(i * 5).toString().padStart(2, "0")}m`,
+}));
+
+export default function ReadingProgressPanel({
+  book,
+  onProgressSaved,
+}: ReadingProgressPanelProps) {
+  const { user } = useAuth();
+  const [expanded, setExpanded] = useState(false);
+  const [lastLog, setLastLog] = useState<ReadingLog | null>(null);
+  const [loadingLog, setLoadingLog] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const currentPage = book.current_page ?? 0;
+  const totalPages = book.total_pages ?? 0;
+
+  // Initial page value: start one step above current
+  const minPage = Math.max(currentPage, lastLog?.current_page ?? 0);
+  const startPage = Math.min(minPage + 1, totalPages);
+
+  const [selectedPage, setSelectedPage] = useState(startPage);
+  const [selectedHours, setSelectedHours] = useState(0);
+  const [selectedMinutes, setSelectedMinutes] = useState(0);
+
+  // Fetch last reading log on mount
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const log = await fetchLastReadingLog(book.id);
+        if (!cancelled) setLastLog(log);
+      } catch {
+        // silently ignore — we'll just use book.current_page as min
+      } finally {
+        if (!cancelled) setLoadingLog(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [book.id]);
+
+  // Reset picker values when expanding or when lastLog loads
+  useEffect(() => {
+    if (expanded) {
+      const min = Math.max(currentPage, lastLog?.current_page ?? 0);
+      setSelectedPage(Math.min(min + 1, totalPages));
+      setSelectedHours(0);
+      setSelectedMinutes(0);
+      setErrorMsg(null);
+    }
+  }, [expanded, lastLog, currentPage, totalPages]);
+
+  const pageItems = useMemo(
+    () => buildPageItems(minPage + 1, totalPages),
+    [minPage, totalPages]
+  );
+
+  async function handleSave() {
+    if (!user) return;
+    try {
+      setSaving(true);
+      setErrorMsg(null);
+      const timeMinutes = selectedHours * 60 + selectedMinutes;
+      await createReadingLog(
+        book.id,
+        user.id,
+        selectedPage,
+        timeMinutes > 0 ? timeMinutes : undefined
+      );
+      await onProgressSaved(selectedPage);
+      // Update lastLog locally so the min page updates
+      setLastLog({
+        id: "",
+        book_id: book.id,
+        user_id: user.id,
+        current_page: selectedPage,
+        logged_at: new Date().toISOString(),
+      });
+      setExpanded(false);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed to save progress");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (totalPages === 0) {
+    return (
+      <div className="rounded-lg border bg-muted/40 p-3">
+        <p className="text-sm text-muted-foreground">
+          Set the total pages to track progress.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border bg-muted/40 p-3 space-y-3">
+      {/* Header with current progress */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-0.5">
+          <p className="text-sm font-medium">Reading progress</p>
+          <p className="text-xs text-muted-foreground">
+            Page {currentPage} of {totalPages}
+          </p>
+        </div>
+        {!expanded && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={loadingLog}
+            onClick={() => setExpanded(true)}
+          >
+            <BookOpen className="h-3.5 w-3.5 mr-1.5" />
+            Update progress
+          </Button>
+        )}
+      </div>
+
+      {/* Expanded picker panel */}
+      {expanded && (
+        <div className="space-y-4 pt-1">
+          {/* Page picker */}
+          <div className="space-y-1.5">
+            <Label className="text-xs">Read up to page</Label>
+            <ScrollWheelPicker
+              items={pageItems}
+              selectedValue={selectedPage}
+              onChange={setSelectedPage}
+            />
+          </div>
+
+          {/* Time picker */}
+          <div className="space-y-1.5">
+            <Label className="text-xs text-muted-foreground">
+              Time spent reading (optional)
+            </Label>
+            <div className="flex gap-2">
+              <ScrollWheelPicker
+                items={HOUR_ITEMS}
+                selectedValue={selectedHours}
+                onChange={setSelectedHours}
+                className="flex-1"
+              />
+              <ScrollWheelPicker
+                items={MINUTE_ITEMS}
+                selectedValue={selectedMinutes}
+                onChange={setSelectedMinutes}
+                className="flex-1"
+              />
+            </div>
+          </div>
+
+          {errorMsg && (
+            <p className="text-xs text-destructive">{errorMsg}</p>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex gap-2 justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={saving}
+              onClick={() => setExpanded(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={saving}
+              onClick={handleSave}
+            >
+              {saving ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/scroll-wheel-picker.tsx
+++ b/src/components/ui/scroll-wheel-picker.tsx
@@ -1,0 +1,143 @@
+import { useRef, useEffect, useCallback, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface ScrollWheelPickerItem {
+  value: number;
+  label: string;
+}
+
+interface ScrollWheelPickerProps {
+  items: ScrollWheelPickerItem[];
+  selectedValue: number;
+  onChange: (value: number) => void;
+  height?: number;
+  itemHeight?: number;
+  className?: string;
+}
+
+export function ScrollWheelPicker({
+  items,
+  selectedValue,
+  onChange,
+  height = 150,
+  itemHeight = 40,
+  className,
+}: ScrollWheelPickerProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isUserScrolling = useRef(false);
+  const scrollTimeout = useRef<ReturnType<typeof setTimeout>>();
+  const [centerIndex, setCenterIndex] = useState(() => {
+    const idx = items.findIndex((i) => i.value === selectedValue);
+    return idx >= 0 ? idx : 0;
+  });
+
+  const spacer = (height - itemHeight) / 2;
+
+  // Compute selected index from scroll position
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    isUserScrolling.current = true;
+    const index = Math.round(el.scrollTop / itemHeight);
+    const clamped = Math.max(0, Math.min(index, items.length - 1));
+    setCenterIndex(clamped);
+
+    // Debounce the onChange call to fire after scroll settles
+    clearTimeout(scrollTimeout.current);
+    scrollTimeout.current = setTimeout(() => {
+      isUserScrolling.current = false;
+      if (items[clamped] && items[clamped].value !== selectedValue) {
+        onChange(items[clamped].value);
+      }
+    }, 100);
+  }, [items, itemHeight, onChange, selectedValue]);
+
+  // Scroll to selected value on mount or when selectedValue changes externally
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || isUserScrolling.current) return;
+
+    const idx = items.findIndex((i) => i.value === selectedValue);
+    if (idx < 0) return;
+
+    setCenterIndex(idx);
+    // Use requestAnimationFrame to ensure DOM is ready
+    requestAnimationFrame(() => {
+      el.scrollTo({ top: idx * itemHeight, behavior: "auto" });
+    });
+  }, [selectedValue, items, itemHeight]);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => clearTimeout(scrollTimeout.current);
+  }, []);
+
+  function itemOpacity(index: number): string {
+    const dist = Math.abs(index - centerIndex);
+    if (dist === 0) return "opacity-100";
+    if (dist === 1) return "opacity-50";
+    return "opacity-25";
+  }
+
+  return (
+    <div
+      className={cn("relative overflow-hidden rounded-lg", className)}
+      style={{ height }}
+    >
+      {/* Gradient overlay top */}
+      <div
+        className="absolute top-0 left-0 right-0 z-10 pointer-events-none bg-gradient-to-b from-background to-transparent"
+        style={{ height: spacer }}
+      />
+
+      {/* Selection indicator */}
+      <div
+        className="absolute left-2 right-2 z-10 pointer-events-none border-t border-b border-border rounded-sm"
+        style={{ top: spacer, height: itemHeight }}
+      />
+
+      {/* Scrollable list */}
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="h-full overflow-y-auto snap-y snap-mandatory"
+        style={{
+          scrollbarWidth: "none",
+          overscrollBehavior: "contain",
+          WebkitOverflowScrolling: "touch",
+        }}
+      >
+        {/* Top spacer */}
+        <div style={{ height: spacer }} />
+
+        {items.map((item, index) => (
+          <div
+            key={item.value}
+            className={cn(
+              "snap-center flex items-center justify-center transition-opacity duration-150 select-none text-sm font-medium",
+              itemOpacity(index)
+            )}
+            style={{ height: itemHeight }}
+          >
+            {item.label}
+          </div>
+        ))}
+
+        {/* Bottom spacer */}
+        <div style={{ height: spacer }} />
+      </div>
+
+      {/* Gradient overlay bottom */}
+      <div
+        className="absolute bottom-0 left-0 right-0 z-10 pointer-events-none bg-gradient-to-t from-background to-transparent"
+        style={{ height: spacer }}
+      />
+
+      {/* Hide webkit scrollbar */}
+      <style>{`
+        div[class*="snap-y"]::-webkit-scrollbar { display: none; }
+      `}</style>
+    </div>
+  );
+}

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -1,5 +1,5 @@
 import { supabase } from "./supabase";
-import type { Book, Series } from "@/types";
+import type { Book, Series, ReadingLog } from "@/types";
 
 // ── Books ──────────────────────────────────────────────────────────────────
 
@@ -99,4 +99,40 @@ export async function createSeries(userId: string, name: string): Promise<Series
     .single();
   if (error) throw error;
   return data as Series;
+}
+
+// ── Reading Logs ──────────────────────────────────────────────────────────
+
+export async function createReadingLog(
+  bookId: string,
+  userId: string,
+  currentPage: number,
+  readingTimeMinutes?: number
+): Promise<ReadingLog> {
+  const { data, error } = await supabase
+    .from("reading_logs")
+    .insert({
+      book_id: bookId,
+      user_id: userId,
+      current_page: currentPage,
+      reading_time_minutes: readingTimeMinutes,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data as ReadingLog;
+}
+
+export async function fetchLastReadingLog(
+  bookId: string
+): Promise<ReadingLog | null> {
+  const { data, error } = await supabase
+    .from("reading_logs")
+    .select("*")
+    .eq("book_id", bookId)
+    .order("logged_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data as ReadingLog | null;
 }


### PR DESCRIPTION
## Summary
- Replace the plain number input for page progress with an iOS-style scroll wheel picker component (`ScrollWheelPicker`)
- Add a `ReadingProgressPanel` that logs each reading session (page reached + optional time spent) to the `reading_logs` table
- Add Supabase functions `createReadingLog` and `fetchLastReadingLog` for reading log persistence

## Test plan
- [x] Open a book with status "Reading" — verify the collapsed panel shows current page and "Update progress" button
- [x] Click "Update progress" — verify scroll pickers appear for page number and time (hours + minutes)
- [x] Scroll the page picker — verify snap behavior, gradient fade, and selection indicator
- [x] Save a progress entry — verify reading_log row created in Supabase, book's current_page updated, panel collapses
- [x] Re-open the picker — verify the page minimum has advanced past the last logged page
- [x] Save without setting time — verify reading_time_minutes is null in the log
- [x] Click Cancel — verify panel collapses without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)