### PR TITLE
fix: remove top padding gap above book cover image

### DIFF
--- a/doc/issue-10-book-card-top-corners.md
+++ b/doc/issue-10-book-card-top-corners.md
@@ -1,0 +1,25 @@
+# Issue #10 -- Book Card Top Corners
+
+## Problem
+
+A blank gap appeared above the book cover image inside the book card. The cover
+image did not extend to the top edge of the card, leaving visible padding between
+the card's top border and the image.
+
+## Root Cause
+
+The shadcn `Card` component applies `py-4` (1rem vertical padding) by default.
+It includes a conditional `has-[>img:first-child]:pt-0` rule that removes top
+padding when the first child is a direct `<img>` element, but in `BookCard.tsx`
+the first child is a `<div>` wrapper (the cover container), not a bare `<img>`.
+This meant the top padding was never removed, creating the gap.
+
+## Fix
+
+Added `pt-0` to the `Card` className in `src/components/BookCard.tsx` to
+explicitly remove the top padding. The card already had `overflow-hidden`, so the
+cover image is correctly clipped by the card's rounded top corners.
+
+### Changed file
+
+- `src/components/BookCard.tsx` -- added `pt-0` class to the `<Card>` element.

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -18,7 +18,7 @@ export default function BookCard({ book, onClick }: BookCardProps) {
 
   return (
     <Card
-      className="cursor-pointer overflow-hidden hover:ring-2 hover:ring-primary/40 transition-shadow"
+      className="cursor-pointer overflow-hidden pt-0 hover:ring-2 hover:ring-primary/40 transition-shadow"
       onClick={() => onClick(book)}
     >
       {/* Cover */}


### PR DESCRIPTION
## Summary

- Fixes the blank space above the book cover image on the book card by adding `pt-0` to the `<Card>` className in `BookCard.tsx`
- The shadcn Card component's default `py-4` padding was not being overridden because its built-in `has-[>img:first-child]:pt-0` rule only applies when the first child is a bare `<img>`, not the `<div>` wrapper used for the cover
- Added documentation in `doc/issue-10-book-card-top-corners.md`

Closes #10

## Test plan

- [x] Open the Library or Dashboard page and verify book cards show the cover image flush with the top edge
- [x] Verify the card's rounded top corners correctly clip the cover image
- [ ] Verify cards without a cover image (placeholder icon) also look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)