### PR TITLE
fix: allow decimal volume numbers

### DIFF
--- a/doc/issue-9-volume-number-decimals.md
+++ b/doc/issue-9-volume-number-decimals.md
@@ -1,0 +1,32 @@
+# Issue #9 -- volume_number doesn't accept decimal numbers
+
+## Problem
+
+The volume number field in both the Add Book dialog and the Book Detail modal only accepted integer values. Some book series use decimal volume numbers for novellas or side stories published between main entries (e.g., Stormlight Archive #3.5 for "Dawnshard").
+
+## Changes
+
+### Frontend
+
+- **`src/components/BookDetailModal.tsx`** -- Added `step="any"` to the volume number `<Input>` and changed `min` from `1` to `0.5` so the browser allows decimal input.
+- **`src/components/AddBookDialog.tsx`** -- Same change: added `step="any"` and changed `min` to `0.5`.
+
+No change was needed for the `Number()` conversion used when building the Supabase payload, since `Number("3.5")` already returns `3.5` (unlike `parseInt` which would truncate to `3`).
+
+### TypeScript types
+
+No change needed. `volume_number` in `src/types/index.ts` is already typed as `number`, which covers both integers and floats.
+
+### Database schema
+
+- **`supabase/schema.sql`** -- Changed the column type from `integer` to `numeric` so it can store decimal values.
+
+### Migration note
+
+There is no `supabase/migrations/` directory in this repository. If the production database column is still `integer`, run the following SQL manually (or via the Supabase SQL Editor):
+
+```sql
+ALTER TABLE books ALTER COLUMN volume_number TYPE numeric USING volume_number::numeric;
+```
+
+The existing `CHECK (volume_number > 0)` constraint remains valid for the `numeric` type.

--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -548,7 +548,8 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
                   <Input
                     id="volume_number"
                     type="number"
-                    min={1}
+                    min={0.5}
+                    step="any"
                     {...register("volume_number")}
                   />
                 </div>

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -497,7 +497,7 @@ export default function BookDetailModal({
                   {seriesId && (
                     <div className="space-y-1.5">
                       <Label htmlFor="detail-volume_number">Volume number</Label>
-                      <Input id="detail-volume_number" type="number" min={1} {...register("volume_number")} />
+                      <Input id="detail-volume_number" type="number" min={0.5} step="any" {...register("volume_number")} />
                     </div>
                   )}
                 </div>

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS books (
   format          text CHECK (format IN ('eBook','Audiobook','Paperback','Hardcover')),
   isbn            text,
   series_id       uuid REFERENCES series(id) ON DELETE SET NULL,
-  volume_number   integer CHECK (volume_number > 0),
+  volume_number   numeric CHECK (volume_number > 0),
   created_at      timestamptz NOT NULL DEFAULT now()
 );
 


### PR DESCRIPTION
## Summary

- Allow decimal values (e.g., 3.5) in the volume number field so in-between novellas can be numbered correctly (closes #9)
- Added `step="any"` to the number inputs in both `AddBookDialog` and `BookDetailModal`
- Changed the `volume_number` column type from `integer` to `numeric` in `supabase/schema.sql`

## Migration note

There is no `supabase/migrations/` directory in this repo. If the production DB column is still `integer`, run:

```sql
ALTER TABLE books ALTER COLUMN volume_number TYPE numeric USING volume_number::numeric;
```

## Test plan

- [x] Open the Add Book dialog, select a series, and enter a decimal volume number (e.g., 3.5) -- it should be accepted
- [x] Open the Book Detail modal for a book in a series, change its volume number to a decimal -- it should save successfully
- [x] Verify the Series Library view still sorts books correctly with mixed integer and decimal volume numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)