### PR TITLE
fix: prevent book card cover distortion in grid layouts

### DIFF
--- a/doc/issue-14-book-card-layout.md
+++ b/doc/issue-14-book-card-layout.md
@@ -1,0 +1,30 @@
+# Issue #14 — Inconsistent Book Card Layout in Library View
+
+## Problem
+
+Book cards in the Library grid appeared distorted and inconsistent in size.
+When cards with different content lengths (title, author) shared a grid row,
+CSS Grid's default `align-items: stretch` forced them to the same height.
+Because the `Card` component uses `flex flex-col`, the extra height was
+distributed to flex children — stretching the cover image container beyond
+its intended 2:3 aspect ratio.
+
+The Dashboard was less affected because books in the same section
+("Currently Reading", "Up Next") tend to have similar content lengths.
+
+## Fix
+
+Two Tailwind classes added to `BookCard.tsx`:
+
+| Element          | Class added      | Purpose                                              |
+|------------------|------------------|------------------------------------------------------|
+| Cover container  | `flex-shrink-0`  | Prevents the aspect-ratio div from growing/shrinking |
+| `CardContent`    | `flex-1`         | Absorbs any extra row height in the text area        |
+
+This keeps cover images at a uniform 2:3 size across all cards in a row,
+with the content area stretching instead when grid rows are taller than
+a card's natural height.
+
+## Files Changed
+
+- `src/components/BookCard.tsx` — cover div and CardContent class updates

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -22,7 +22,7 @@ export default function BookCard({ book, onClick }: BookCardProps) {
       onClick={() => onClick(book)}
     >
       {/* Cover */}
-      <div className="relative aspect-[2/3] w-full bg-muted">
+      <div className="relative aspect-[2/3] w-full bg-muted flex-shrink-0">
         {book.cover_url ? (
           <img
             src={book.cover_url}
@@ -42,7 +42,7 @@ export default function BookCard({ book, onClick }: BookCardProps) {
         )}
       </div>
 
-      <CardContent className="p-2 space-y-1">
+      <CardContent className="p-2 space-y-1 flex-1">
         <p className="text-sm font-medium leading-tight line-clamp-2">{book.title}</p>
         <p className="text-xs text-muted-foreground line-clamp-1">{book.author}</p>
         <Badge variant={statusVariant(book.status)} className="text-xs">


### PR DESCRIPTION
## Summary
- Fixes the inconsistent book card sizing in the Library grid view reported in #14
- Adds `flex-shrink-0` to the cover container so the 2:3 aspect ratio is never stretched by CSS Grid row alignment
- Adds `flex-1` to `CardContent` so extra row height is absorbed by the text area, not the cover

## Test plan
- [x] Verified with 4 books in Library — covers are uniform across grid rows
- [x] Dashboard layout unaffected
- [x] Production build passes

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/claude-code)