### PR TITLE
fix: set reading progress page picker granularity to 1

### DIFF
--- a/src/components/ReadingProgressPanel.tsx
+++ b/src/components/ReadingProgressPanel.tsx
@@ -13,24 +13,9 @@ interface ReadingProgressPanelProps {
 }
 
 function buildPageItems(min: number, max: number) {
-  const range = max - min;
-  let step = 1;
-  if (range > 1000) step = 10;
-  else if (range > 200) step = 5;
-
   const items: { value: number; label: string }[] = [];
-  // Always include the first page
-  items.push({ value: min, label: String(min) });
-  // Then step from the next clean multiple of step
-  const firstStep = step > 1 ? Math.ceil((min + 1) / step) * step : min + 1;
-  for (let p = firstStep; p <= max; p += step) {
-    if (p > min) {
-      items.push({ value: p, label: String(p) });
-    }
-  }
-  // Ensure max is always included
-  if (items[items.length - 1].value !== max) {
-    items.push({ value: max, label: String(max) });
+  for (let p = min; p <= max; p++) {
+    items.push({ value: p, label: String(p) });
   }
   return items;
 }


### PR DESCRIPTION
## Summary

- Removes the step-size logic in `buildPageItems` that grouped pages by 5 (range > 200) or 10 (range > 1000)
- Every page is now individually selectable in the "Read up to page" scroll picker

Fixes #17

## Test plan

- [x] Open a book with > 200 pages and log reading progress — verify every single page number is listed in the scroll picker
- [x] Open a book with > 1000 pages — same check

🤖 Generated with [Claude Code](https://claude.com/claude-code)