### PR TITLE
fix: reduce excess vertical spacing in BookCard for consistent mobile…

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -18,7 +18,7 @@ export default function BookCard({ book, onClick }: BookCardProps) {
 
   return (
     <Card
-      className="cursor-pointer overflow-hidden pt-0 hover:ring-2 hover:ring-primary/40 transition-shadow"
+      className="cursor-pointer overflow-hidden pt-0 gap-0 pb-2 hover:ring-2 hover:ring-primary/40 transition-shadow"
       onClick={() => onClick(book)}
     >
       {/* Cover */}
@@ -42,7 +42,7 @@ export default function BookCard({ book, onClick }: BookCardProps) {
         )}
       </div>
 
-      <CardContent className="p-2 space-y-1 flex-1">
+      <CardContent className="p-2 space-y-1">
         <p className="text-sm font-medium leading-tight line-clamp-2">{book.title}</p>
         <p className="text-xs text-muted-foreground line-clamp-1">{book.author}</p>
         <Badge variant={statusVariant(book.status)} className="text-xs">


### PR DESCRIPTION
## Analysis

The root cause is excess vertical spacing inherited from the base `Card` component.

The shadcn/ui `Card` component applies `gap-4` (16px between flex children) and `py-4` (16px vertical padding). `BookCard` only overrode `pt-0` so the cover image sits flush at the top, but two sources of extra whitespace remained:

- **`gap-4`** — 16px gap between the cover image and the text content below it
- **`pb-4`** — 16px bottom padding below the `CardContent`

That's **32px of excess vertical chrome** per card. On desktop (4-column grid) this is barely noticeable because the cards are wide and the `aspect-[2/3]` cover is tall. On mobile (2-column grid), cards are narrower so the cover is proportionally shorter — making that fixed 32px a much larger fraction of total card height and producing the elongated appearance.

Additionally, `CardContent` had `flex-1`, which made the text area expand to fill any extra height when CSS grid stretched cards to match the tallest card in a row, amplifying the effect.

## Fix (`src/components/BookCard.tsx`)

1. **Added `gap-0 pb-2`** to the `Card` className — eliminates the 16px gap between cover and content, and reduces bottom padding from 16px to 8px. The `p-2` on `CardContent` already provides adequate internal spacing.

2. **Removed `flex-1`** from `CardContent` — the text area now takes only its natural height instead of expanding to fill grid-imposed extra space.

These two changes reduce excess vertical chrome by ~24px per card, keeping proportions consistent across mobile, tablet, and desktop breakpoints. The grid layout classes (`grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4`) were already identical between Dashboard and Library, so no grid changes were needed.

Closes #21 