### PR TITLE
fix: require INVITE_REDIRECT_URL to prevent localhost links in invite emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ VITE_SUPABASE_ANON_KEY=your-publishable-key-here
 # Used ONLY by scripts/invite-user.ts. Never prefix with VITE_ or use in src/.
 SUPABASE_SERVICE_ROLE_KEY=your-secret-key-here
 
-# Base URL used in invite emails. Defaults to http://localhost:5173 if not set.
-# Set to your production URL before deploying (e.g. https://your-app.vercel.app).
+# Base URL used in invite emails (required by scripts/invite-user.ts).
+# Use http://localhost:5173 for local dev, your production URL for real invites.
 # The URL must also be added to Supabase → Auth → URL Configuration → Redirect URLs.
-# INVITE_REDIRECT_URL=https://your-app.vercel.app
+INVITE_REDIRECT_URL=http://localhost:5173

--- a/scripts/invite-user.ts
+++ b/scripts/invite-user.ts
@@ -16,10 +16,11 @@ import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const inviteRedirectUrl = process.env.INVITE_REDIRECT_URL;
 
-if (!supabaseUrl || !serviceRoleKey) {
+if (!supabaseUrl || !serviceRoleKey || !inviteRedirectUrl) {
   console.error(
-    "Missing env vars. Ensure VITE_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are set in .env",
+    "Missing env vars. Ensure VITE_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, and INVITE_REDIRECT_URL are set in .env",
   );
   process.exit(1);
 }
@@ -40,7 +41,7 @@ if (!email) {
   process.exit(1);
 }
 
-const redirectTo = `${process.env.INVITE_REDIRECT_URL ?? "http://localhost:5173"}/login`;
+const redirectTo = `${inviteRedirectUrl}/login`;
 
 const { data, error } = await adminClient.auth.admin.inviteUserByEmail(email, { redirectTo });
 


### PR DESCRIPTION
## Summary
- Make `INVITE_REDIRECT_URL` a required env var in the invite script instead of silently falling back to `http://localhost:5173`
- The script now exits with a clear error message if the variable is missing, preventing invite emails with broken localhost links
- Updated `.env.example` to reflect that the variable is required

Closes #27

## Test plan
- [x] Remove `INVITE_REDIRECT_URL` from `.env` and run `npm run invite test@example.com` — should fail with a clear error
- [x] Set `INVITE_REDIRECT_URL=https://your-app.vercel.app` and run the invite — email link should point to production URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)