### PR TITLE
feat: Analytics tab in book detail dialog

### DIFF
--- a/doc/book-analytics-tab.md
+++ b/doc/book-analytics-tab.md
@@ -1,0 +1,191 @@
+# Feature: Book Detail Analytics Tab (Daily Pages Chart + Reading Log List)
+
+## Problem
+
+The `Analytics` tab in the book detail dialog is currently a stub. Users can log reading progress, but they cannot visually review daily reading output or inspect a history of progress entries in one place.
+
+## Goal
+
+Implement the Analytics tab with:
+
+1. A chart where:
+   - Horizontal axis = days
+   - Vertical axis = total pages read on that day
+2. A list of reading progress entries below the chart
+
+## Confirmed Product Decision
+
+- Include gap days in the chart timeline.
+- Days without entries must appear with `0` pages.
+
+## Existing Context
+
+- Reading logs are already stored in `reading_logs`.
+- Current helper functions:
+  - `createReadingLog(...)`
+  - `fetchLastReadingLog(...)`
+- Analytics tab currently stubbed in:
+  - `src/components/BookDetailModal.tsx`
+
+## Scope
+
+### In Scope
+
+- Fetch all reading logs for the selected book
+- Compute daily pages read from log deltas
+- Build continuous day range (with zero-filled gaps)
+- Render chart in Analytics tab
+- Render progress entry list below chart
+- Loading, empty, and error states
+
+### Out of Scope
+
+- Export/share analytics
+- Cross-book analytics
+- Additional chart types (speed trend, cumulative trend, etc.)
+- New dependency for charting libraries
+
+## Technical Plan
+
+### 1) Data access (`src/lib/books.ts`)
+
+Add:
+
+- `fetchReadingLogsForBook(bookId: string): Promise<ReadingLog[]>`
+  - Query `reading_logs`
+  - Filter by `book_id`
+  - Sort by `logged_at` ascending
+  - Throw on Supabase error
+
+Why ascending:
+- Delta calculation (`current - previous`) is deterministic in chronological order.
+
+### 2) Analytics UI component (`src/components/BookAnalyticsPanel.tsx`)
+
+Create a dedicated component to keep `BookDetailModal` clean.
+
+Props:
+- `book: Book`
+
+State:
+- `logs: ReadingLog[]`
+- `loading: boolean`
+- `errorMsg: string | null`
+
+Lifecycle:
+- On mount and when `book.id` changes, fetch logs.
+
+Derived data:
+- Per-log `pagesReadDelta = max(0, current_page - previous_current_page)`
+- Group deltas by local calendar day key (`YYYY-MM-DD`)
+- Build continuous day range from first log day to last log day
+- Fill missing days with `0`
+- Produce chart points:
+  - `{ dayKey, dayLabel, pagesRead }`
+
+### 3) Chart rendering (no new dependencies)
+
+Implement a lightweight custom chart in the panel:
+
+- Fixed chart area height (around `220px`)
+- Vertical bars for each day
+- Y scale from `0` to `max(pagesRead)` (safe fallback when max is `0`)
+- Day labels on X axis (short format, e.g. `Apr 12`)
+- Optional hover/focus tooltip can be deferred if needed
+
+Responsive behavior:
+- Works in dialog width on mobile and desktop
+- If many days, allow horizontal scrolling inside chart container
+
+### 4) Reading entries list (below chart)
+
+Render entries in reverse chronological order (newest first).
+
+Per row display:
+- Logged timestamp
+- "Reached page X"
+- `+N pages` compared to previous entry
+- Optional reading time if present (`reading_time_minutes`)
+
+List container:
+- Bounded height with internal scrolling as needed.
+
+### 5) Wire into tab (`src/components/BookDetailModal.tsx`)
+
+- Replace analytics stub inside `TabsContent value="analytics"` with `<BookAnalyticsPanel book={book} />`.
+
+## UX States
+
+### Loading
+- Skeleton or muted placeholders for chart + list.
+
+### Empty
+- Message: "No reading progress entries yet."
+- Short hint: "Log progress in the Properties tab to see analytics."
+
+### Error
+- Inline destructive text with retry button (optional).
+
+## Data/Calculation Details
+
+Given ordered logs `L0..Ln` by `logged_at`:
+
+- `delta(L0) = max(0, L0.current_page - 0)` (or clamp to `L0.current_page`)
+- `delta(Li) = max(0, Li.current_page - L(i-1).current_page)` for `i > 0`
+
+Group:
+- `dailyTotal[day(Li.logged_at)] += delta(Li)`
+
+Gap fill:
+- Iterate date by date from first day to last day
+- If day missing, set `pagesRead = 0`
+
+Notes:
+- Clamping avoids negative bars if historical data is inconsistent.
+
+## Acceptance Criteria
+
+1. Analytics tab no longer shows stub text.
+2. Chart displays daily pages read for the selected book.
+3. Gap days are visible with `0` pages.
+4. Reading log list appears below chart with newest first.
+5. Empty state shown when no logs exist.
+6. No new charting dependency added.
+7. TypeScript passes (`npm run typecheck`).
+
+## Validation Plan
+
+Manual checks:
+1. Book with no logs -> empty state.
+2. Book with one log -> one day shown, one list entry.
+3. Book with logs across non-consecutive dates -> gap days shown at `0`.
+4. Multiple logs same day -> bars reflect summed daily deltas.
+5. Dialog on mobile width -> chart/list remain usable and readable.
+
+Command:
+- `npm run typecheck`
+
+## Risks and Mitigations
+
+- **Timezone/day boundary mismatches**
+  Mitigation: Use a consistent local-date formatter for grouping and labels.
+- **Large day ranges causing cramped bars**
+  Mitigation: horizontal scroll container for chart plot area.
+- **Non-monotonic `current_page` data**
+  Mitigation: clamp negative deltas to `0`.
+
+## Files Expected to Change
+
+- `src/lib/books.ts` (new fetch helper)
+- `src/components/BookAnalyticsPanel.tsx` (new component)
+- `src/components/BookDetailModal.tsx` (use new component in Analytics tab)
+
+## Implementation Order
+
+1. Add `fetchReadingLogsForBook` in `src/lib/books.ts`
+2. Build `BookAnalyticsPanel` with fetch + derived data
+3. Add chart UI
+4. Add entries list UI
+5. Replace Analytics stub in `BookDetailModal`
+6. Run `npm run typecheck`
+7. Manual UI verification

--- a/src/components/BookAnalyticsPanel.tsx
+++ b/src/components/BookAnalyticsPanel.tsx
@@ -1,0 +1,343 @@
+import { useEffect, useMemo, useState } from "react";
+import { BarChart3 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { fetchReadingLogsForBook } from "@/lib/books";
+import type { Book, ReadingLog } from "@/types";
+
+interface BookAnalyticsPanelProps {
+  book: Book;
+}
+
+interface ChartPoint {
+  dayKey: string;
+  dayLabel: string;
+  pagesRead: number;
+}
+
+interface ReadingLogWithDelta extends ReadingLog {
+  pagesReadDelta: number;
+}
+
+function toLocalDayKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function dayFromKey(dayKey: string): Date {
+  const [year, month, day] = dayKey.split("-").map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function formatDayLabel(date: Date): string {
+  return String(date.getDate());
+}
+
+function formatFullDayLabel(dayKey: string): string {
+  return dayFromKey(dayKey).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatDateTime(value: string): string {
+  return new Date(value).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function formatReadingTime(minutes?: number): string | null {
+  if (!minutes || minutes <= 0) return null;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (hours > 0 && mins > 0) return `${hours}h ${mins}m`;
+  if (hours > 0) return `${hours}h`;
+  return `${mins}m`;
+}
+
+export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
+  const [logs, setLogs] = useState<ReadingLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [activeDayKey, setActiveDayKey] = useState<string | null>(null);
+
+  async function loadLogs() {
+    try {
+      setLoading(true);
+      setErrorMsg(null);
+      const data = await fetchReadingLogsForBook(book.id);
+      setLogs(data);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed to load analytics");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      try {
+        setLoading(true);
+        setErrorMsg(null);
+        const data = await fetchReadingLogsForBook(book.id);
+        if (!cancelled) {
+          setLogs(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setErrorMsg(err instanceof Error ? err.message : "Failed to load analytics");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [book.id]);
+
+  const logsWithDelta = useMemo<ReadingLogWithDelta[]>(() => {
+    let previousPage = 0;
+    return logs.map((log) => {
+      const pagesReadDelta = Math.max(0, log.current_page - previousPage);
+      previousPage = log.current_page;
+      return {
+        ...log,
+        pagesReadDelta,
+      };
+    });
+  }, [logs]);
+
+  const chartPoints = useMemo<ChartPoint[]>(() => {
+    if (logsWithDelta.length === 0) return [];
+
+    const dailyTotals = new Map<string, number>();
+    for (const log of logsWithDelta) {
+      const dayKey = toLocalDayKey(new Date(log.logged_at));
+      const current = dailyTotals.get(dayKey) ?? 0;
+      dailyTotals.set(dayKey, current + log.pagesReadDelta);
+    }
+
+    const keys = [...dailyTotals.keys()].sort();
+    const first = dayFromKey(keys[0]);
+    const last = dayFromKey(keys[keys.length - 1]);
+    const points: ChartPoint[] = [];
+
+    const cursor = new Date(first.getFullYear(), first.getMonth(), first.getDate());
+    while (cursor <= last) {
+      const dayKey = toLocalDayKey(cursor);
+      points.push({
+        dayKey,
+        dayLabel: formatDayLabel(cursor),
+        pagesRead: dailyTotals.get(dayKey) ?? 0,
+      });
+      cursor.setDate(cursor.getDate() + 1);
+    }
+
+    return points;
+  }, [logsWithDelta]);
+
+  const entries = useMemo(() => [...logsWithDelta].reverse(), [logsWithDelta]);
+
+  const totalPagesRead = useMemo(
+    () => chartPoints.reduce((sum, point) => sum + point.pagesRead, 0),
+    [chartPoints]
+  );
+
+  const activeDays = useMemo(
+    () => chartPoints.filter((point) => point.pagesRead > 0).length,
+    [chartPoints]
+  );
+
+  const avgPerDay = useMemo(() => {
+    if (chartPoints.length === 0) return 0;
+    return totalPagesRead / chartPoints.length;
+  }, [chartPoints.length, totalPagesRead]);
+
+  const labelStep = useMemo(() => {
+    if (chartPoints.length <= 14) return 1;
+    if (chartPoints.length <= 28) return 2;
+    if (chartPoints.length <= 42) return 3;
+    if (chartPoints.length <= 56) return 4;
+    return 7;
+  }, [chartPoints.length]);
+
+  const activePoint = useMemo(() => {
+    if (!activeDayKey || chartPoints.length === 0) return null;
+    return chartPoints.find((point) => point.dayKey === activeDayKey) ?? null;
+  }, [activeDayKey, chartPoints]);
+
+  const activePointIndex = useMemo(() => {
+    if (!activePoint) return -1;
+    return chartPoints.findIndex((point) => point.dayKey === activePoint.dayKey);
+  }, [activePoint, chartPoints]);
+
+  const tooltipLeft = useMemo(() => {
+    if (activePointIndex < 0) return 0;
+    const rawLeft = 20 + activePointIndex * 40;
+    const maxLeft = Math.max(44, chartPoints.length * 40 - 44);
+    return Math.min(Math.max(rawLeft, 44), maxLeft);
+  }, [activePointIndex, chartPoints.length]);
+
+  const maxPages = Math.max(...chartPoints.map((p) => p.pagesRead), 0);
+  const yAxisMax = maxPages > 0 ? maxPages : 1;
+  const yTicks = [yAxisMax, Math.ceil(yAxisMax / 2), 0];
+
+  if (loading) {
+    return (
+      <div className="space-y-3 py-2">
+        <div className="h-64 animate-pulse rounded-lg border bg-muted/30" />
+        <div className="h-44 animate-pulse rounded-lg border bg-muted/30" />
+      </div>
+    );
+  }
+
+  if (errorMsg) {
+    return (
+      <div className="py-3 space-y-3">
+        <p className="text-sm text-destructive">{errorMsg}</p>
+        <Button type="button" variant="outline" size="sm" onClick={loadLogs}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (logsWithDelta.length === 0) {
+    return (
+      <div className="flex h-48 flex-col items-center justify-center gap-2 text-center">
+        <BarChart3 className="h-8 w-8 text-muted-foreground/50" />
+        <p className="text-sm font-medium">No reading progress entries yet.</p>
+        <p className="text-xs text-muted-foreground">
+          Log progress in the Properties tab to see analytics.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="flex-1 min-h-0 pr-2">
+      <div className="space-y-3 py-2">
+      <section className="rounded-lg border bg-muted/20 p-3 space-y-3">
+        <div>
+          <p className="text-sm font-medium">Pages read per day</p>
+        </div>
+
+        <div className="grid grid-cols-3 gap-2">
+          <div className="rounded-md border bg-background/80 px-2 py-1.5">
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Total pages</p>
+            <p className="text-sm font-medium">{totalPagesRead}</p>
+          </div>
+          <div className="rounded-md border bg-background/80 px-2 py-1.5">
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Active days</p>
+            <p className="text-sm font-medium">{activeDays}</p>
+          </div>
+          <div className="rounded-md border bg-background/80 px-2 py-1.5">
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Avg/day</p>
+            <p className="text-sm font-medium">{avgPerDay.toFixed(1)}</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-[2rem_1fr] gap-2">
+          <div className="h-44 flex flex-col justify-between text-[10px] text-muted-foreground">
+            {yTicks.map((tick, index) => (
+              <span key={`${tick}-${index}`}>{tick}</span>
+            ))}
+          </div>
+
+          <div className="space-y-2">
+            <div className="relative h-44 overflow-x-auto">
+              <div className="pointer-events-none absolute inset-0 flex flex-col justify-between">
+                <div className="border-t border-border/70" />
+                <div className="border-t border-border/50" />
+                <div className="border-t border-border/70" />
+              </div>
+
+              <div className="relative flex h-full min-w-max items-end gap-2 px-1">
+                {activePoint && activePointIndex >= 0 && (
+                  <div
+                    className="pointer-events-none absolute top-2 z-10 -translate-x-1/2 rounded-md border bg-background/95 px-2 py-1 text-[11px] shadow-sm"
+                    style={{ left: `${tooltipLeft}px` }}
+                  >
+                    {formatFullDayLabel(activePoint.dayKey)}: {activePoint.pagesRead} page{activePoint.pagesRead === 1 ? "" : "s"}
+                  </div>
+                )}
+                {chartPoints.map((point) => {
+                  const chartHeightPx = 176; // h-44 = 11rem = 176px
+                  const normalizedHeight = Math.round((point.pagesRead / yAxisMax) * chartHeightPx);
+                  const barHeight = point.pagesRead > 0 ? Math.max(normalizedHeight, 4) : 0;
+                  return (
+                    <button
+                      key={point.dayKey}
+                      type="button"
+                      className="w-8 shrink-0 flex items-end rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                      onMouseEnter={() => setActiveDayKey(point.dayKey)}
+                      onMouseLeave={() => setActiveDayKey(null)}
+                      onFocus={() => setActiveDayKey(point.dayKey)}
+                      onBlur={() => setActiveDayKey(null)}
+                      aria-label={`${formatFullDayLabel(point.dayKey)}: ${point.pagesRead} page${point.pagesRead === 1 ? "" : "s"} read`}
+                    >
+                      <div
+                        className="w-full rounded-t-sm bg-primary/85 hover:bg-primary transition-colors"
+                        style={{ height: `${barHeight}px` }}
+                      />
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="overflow-x-auto">
+              <div className="min-w-max flex gap-2 px-1">
+                {chartPoints.map((point, index) => (
+                  <span
+                    key={point.dayKey}
+                    className="w-8 shrink-0 text-center text-[10px] text-muted-foreground"
+                  >
+                    {chartPoints.length <= 10 || index === 0 || index === chartPoints.length - 1 || index % labelStep === 0
+                      ? point.dayLabel
+                      : ""}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg border bg-muted/20 p-3">
+        <p className="text-sm font-medium">Reading progress entries</p>
+        <div className="mt-3 space-y-2 pb-1">
+          {entries.map((entry) => {
+            const timeLabel = formatReadingTime(entry.reading_time_minutes);
+            return (
+              <div
+                key={entry.id || `${entry.logged_at}-${entry.current_page}`}
+                className="rounded-md border bg-background/80 p-2.5"
+              >
+                <p className="text-xs text-muted-foreground">{formatDateTime(entry.logged_at)}</p>
+                <div className="mt-1 flex items-center justify-between gap-2">
+                  <p className="text-sm">Reached page {entry.current_page}</p>
+                  <p className="text-sm font-medium">+{entry.pagesReadDelta} pages</p>
+                </div>
+                {timeLabel && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">Reading time: {timeLabel}</p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </section>
+      </div>
+    </ScrollArea>
+  );
+}

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -23,6 +23,7 @@ import {
 import { useSeries } from "@/hooks/useSeries";
 import { statusVariant } from "@/lib/utils";
 import ReadingProgressPanel from "@/components/ReadingProgressPanel";
+import BookAnalyticsPanel from "@/components/BookAnalyticsPanel";
 import type {
   Book,
   BookStatus,
@@ -668,11 +669,8 @@ export default function BookDetailModal({
             </div>
           </TabsContent>
 
-          {/* Analytics stub */}
-          <TabsContent value="analytics" className="flex-1">
-            <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
-              Analytics coming in Phase 5
-            </div>
+          <TabsContent value="analytics" className="flex-1 min-h-0 flex flex-col">
+            <BookAnalyticsPanel book={book} />
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -136,3 +136,15 @@ export async function fetchLastReadingLog(
   if (error) throw error;
   return data as ReadingLog | null;
 }
+
+export async function fetchReadingLogsForBook(
+  bookId: string
+): Promise<ReadingLog[]> {
+  const { data, error } = await supabase
+    .from("reading_logs")
+    .select("*")
+    .eq("book_id", bookId)
+    .order("logged_at", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as ReadingLog[];
+}


### PR DESCRIPTION
## Summary

- Implements the Analytics tab in the book detail dialog (previously a stub)
- Adds a daily pages-read bar chart with gap days filled as `0` and an adaptive x-axis label density based on the range length
- Hovering or focusing a bar shows a tooltip with the full date and pages read for that day
- Shows a summary row with total pages read, active reading days, and average pages per day across the full timeline
- Adds a scrollable reading progress entry list below the chart (newest first), showing timestamp, reached page, page delta, and optional reading time
- Handles loading skeleton, empty state (no logs yet), and error/retry states
- No new dependencies — chart is pure SVG-free div/CSS

## Files changed

- `src/lib/books.ts` — new `fetchReadingLogsForBook()` helper
- `src/components/BookAnalyticsPanel.tsx` — new component
- `src/components/BookDetailModal.tsx` — wire in the panel, replace stub
- `doc/book-analytics-tab.md` — feature plan document