### PR TITLE
fix: store and display genres as tags

### DIFF
--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -23,13 +23,14 @@ import {
 } from "@/components/ui/select";
 import { useBooksContext } from "@/context/BooksContext";
 import { useSeries } from "@/hooks/useSeries";
+import { formatGenresInput, parseGenresInput } from "@/lib/utils";
 import type { BookStatus, BookLanguage, BookBelongsTo, BookFormat } from "@/types";
 
 interface FormValues {
   title: string;
   author: string;
   status: BookStatus;
-  genre: string;
+  genresInput: string;
   language: BookLanguage | "";
   format: BookFormat | "";
   belongs_to: BookBelongsTo | "";
@@ -119,7 +120,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
       setValue("title", bookData.title);
       setValue("author", bookData.author);
       if (bookData.totalPages) setValue("total_pages", String(bookData.totalPages));
-      if (bookData.genre) setValue("genre", bookData.genre);
+      if (bookData.genres) setValue("genresInput", formatGenresInput(bookData.genres));
       if (bookData.language) setValue("language", bookData.language as BookLanguage);
       if (bookData.format) setValue("format", bookData.format as BookFormat);
 
@@ -163,12 +164,13 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
 
   async function onSubmit(values: FormValues) {
     try {
+      const genres = parseGenresInput(values.genresInput);
       await addBook(
         {
           title: values.title,
           author: values.author,
           status: values.status,
-          genre: values.genre || undefined,
+          genres: genres.length > 0 ? genres : undefined,
           language: (values.language as BookLanguage) || undefined,
           format: (values.format as BookFormat) || undefined,
           belongs_to: (values.belongs_to as BookBelongsTo) || undefined,
@@ -366,10 +368,13 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
                 />
               </div>
 
-              {/* Genre */}
+              {/* Genres */}
               <div className="space-y-1.5">
-                <Label htmlFor="genre">Genre</Label>
-                <Input id="genre" {...register("genre")} />
+                <Label htmlFor="genresInput">Genres</Label>
+                <Input
+                  id="genresInput"
+                  {...register("genresInput")}
+                />
               </div>
 
               {/* Language */}

--- a/src/components/BookDetailModal.tsx
+++ b/src/components/BookDetailModal.tsx
@@ -21,7 +21,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useSeries } from "@/hooks/useSeries";
-import { statusVariant } from "@/lib/utils";
+import { formatGenresInput, parseGenresInput, statusVariant } from "@/lib/utils";
 import ReadingProgressPanel from "@/components/ReadingProgressPanel";
 import BookAnalyticsPanel from "@/components/BookAnalyticsPanel";
 import type {
@@ -36,7 +36,7 @@ interface FormValues {
   title: string;
   author: string;
   status: BookStatus;
-  genre: string;
+  genresInput: string;
   isbn: string;
   language: BookLanguage | "";
   format: BookFormat | "";
@@ -106,7 +106,7 @@ export default function BookDetailModal({
         title: book.title,
         author: book.author,
         status: book.status,
-        genre: book.genre ?? "",
+        genresInput: formatGenresInput(book.genres),
         isbn: book.isbn ?? "",
         language: book.language ?? "",
         format: book.format ?? "",
@@ -130,6 +130,8 @@ export default function BookDetailModal({
 
   const status = watch("status");
   const seriesId = watch("series_id");
+  const genresInput = watch("genresInput") ?? "";
+  const parsedGenres = parseGenresInput(genresInput);
   const showDateStarted = ["Reading", "Finished", "DNF"].includes(status);
   const showDateFinished = ["Finished", "DNF"].includes(status);
 
@@ -139,7 +141,7 @@ export default function BookDetailModal({
       title: book.title,
       author: book.author,
       status: book.status,
-      genre: book.genre ?? "",
+      genresInput: formatGenresInput(book.genres),
       isbn: book.isbn ?? "",
       language: book.language ?? "",
       format: book.format ?? "",
@@ -198,7 +200,10 @@ export default function BookDetailModal({
     if (dirtyFields.title) payload.title = values.title;
     if (dirtyFields.author) payload.author = values.author;
     if (dirtyFields.status) payload.status = values.status;
-    if (dirtyFields.genre) payload.genre = values.genre || undefined;
+    if (dirtyFields.genresInput) {
+      const genres = parseGenresInput(values.genresInput);
+      payload.genres = genres.length > 0 ? genres : undefined;
+    }
     if (dirtyFields.isbn) payload.isbn = values.isbn.trim() || undefined;
     if (dirtyFields.language) payload.language = (values.language as BookLanguage) || undefined;
     if (dirtyFields.format) payload.format = (values.format as BookFormat) || undefined;
@@ -425,10 +430,25 @@ export default function BookDetailModal({
                     />
                   </div>
 
-                  {/* Genre */}
+                  {/* Genres */}
                   <div className="space-y-1.5">
-                    <Label htmlFor="detail-genre">Genre</Label>
-                    <Input id="detail-genre" readOnly={!isEditMode} {...register("genre")} />
+                    <Label htmlFor="detail-genresInput">Genres</Label>
+                    {isEditMode ? (
+                      <Input
+                        id="detail-genresInput"
+                        {...register("genresInput")}
+                      />
+                    ) : (
+                      <div className="flex flex-wrap gap-1.5">
+                        {parsedGenres.length > 0 ? (
+                          parsedGenres.map((genre) => (
+                            <Badge key={genre} variant="outline">
+                              {genre}
+                            </Badge>
+                          ))
+                        ) : null}
+                      </div>
+                    )}
                   </div>
 
                   {/* Language */}

--- a/src/lib/bookLookup.ts
+++ b/src/lib/bookLookup.ts
@@ -2,7 +2,7 @@ export interface BookLookupResult {
   title: string;
   author: string;
   totalPages?: number;
-  genre?: string;
+  genres?: string[];
   language?: string;
   format?: string;
   coverUrl?: string;
@@ -66,7 +66,7 @@ export async function fetchBookByISBN(
     title: info.title ?? "Untitled",
     author: info.authors?.[0] ?? "Unknown",
     totalPages: info.pageCount,
-    genre: info.categories?.[0],
+    genres: info.categories?.map((genre) => genre.trim()).filter(Boolean),
     language: info.language ? languageMap[info.language] : undefined,
     coverUrl: coverUrl ?? undefined,
   };

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -1,6 +1,39 @@
 import { supabase } from "./supabase";
 import type { Book, Series, ReadingLog } from "@/types";
 
+type LegacyBookRow = Book & { genre?: string | null };
+
+function parseLegacyGenre(genre?: string | null): string[] | undefined {
+  if (!genre) return undefined;
+  const parsed = genre
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return parsed.length > 0 ? Array.from(new Set(parsed)) : undefined;
+}
+
+function normalizeBook(row: LegacyBookRow): Book {
+  const genres = row.genres ?? parseLegacyGenre(row.genre);
+  return {
+    ...row,
+    genres,
+  };
+}
+
+function toLegacyGenrePayload<T extends { genres?: string[] }>(payload: T): Omit<T, "genres"> & { genre?: string } {
+  const { genres, ...rest } = payload;
+  return {
+    ...rest,
+    genre: genres?.length ? genres.join(", ") : undefined,
+  };
+}
+
+function isMissingGenresColumnError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const message = "message" in error ? String((error as { message: unknown }).message) : "";
+  return message.toLowerCase().includes("genres") && message.toLowerCase().includes("column");
+}
+
 // ── Books ──────────────────────────────────────────────────────────────────
 
 export async function fetchBooks(): Promise<Book[]> {
@@ -9,7 +42,7 @@ export async function fetchBooks(): Promise<Book[]> {
     .select("*")
     .order("created_at", { ascending: false });
   if (error) throw error;
-  return data as Book[];
+  return ((data ?? []) as LegacyBookRow[]).map(normalizeBook);
 }
 
 export type BookInsert = Omit<Book, "created_at">;
@@ -20,8 +53,17 @@ export async function createBook(payload: BookInsert): Promise<Book> {
     .insert(payload)
     .select()
     .single();
-  if (error) throw error;
-  return data as Book;
+  if (!error) return normalizeBook(data as LegacyBookRow);
+
+  if (!isMissingGenresColumnError(error)) throw error;
+
+  const { data: legacyData, error: legacyError } = await supabase
+    .from("books")
+    .insert(toLegacyGenrePayload(payload))
+    .select()
+    .single();
+  if (legacyError) throw legacyError;
+  return normalizeBook(legacyData as LegacyBookRow);
 }
 
 export async function updateBook(
@@ -34,8 +76,18 @@ export async function updateBook(
     .eq("id", id)
     .select()
     .single();
-  if (error) throw error;
-  return data as Book;
+  if (!error) return normalizeBook(data as LegacyBookRow);
+
+  if (!isMissingGenresColumnError(error)) throw error;
+
+  const { data: legacyData, error: legacyError } = await supabase
+    .from("books")
+    .update(toLegacyGenrePayload(payload))
+    .eq("id", id)
+    .select()
+    .single();
+  if (legacyError) throw legacyError;
+  return normalizeBook(legacyData as LegacyBookRow);
 }
 
 export async function deleteBook(id: string): Promise<void> {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -14,3 +14,18 @@ export function statusVariant(
   if (status === "Up Next") return "secondary";
   return "outline";
 }
+
+export function parseGenresInput(input: string): string[] {
+  return Array.from(
+    new Set(
+      input
+        .split(/[,\n]/)
+        .map((genre) => genre.trim())
+        .filter(Boolean)
+    )
+  )
+}
+
+export function formatGenresInput(genres?: string[]): string {
+  return genres?.join(", ") ?? ""
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,7 +24,7 @@ export interface Book {
   id: string;
   title: string;
   author: string;
-  genre?: string;
+  genres?: string[];
   status: BookStatus;
   cover_url?: string;
   rating?: number; // 1–5

--- a/supabase/migrations/20260416_genres_as_tags.sql
+++ b/supabase/migrations/20260416_genres_as_tags.sql
@@ -1,0 +1,21 @@
+-- Convert books.genre (text) to books.genres (text[])
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'books'
+      AND column_name = 'genre'
+  ) THEN
+    ALTER TABLE public.books ADD COLUMN IF NOT EXISTS genres text[];
+
+    UPDATE public.books
+    SET genres = array_remove(regexp_split_to_array(genre, '\\s*,\\s*'), '')
+    WHERE genre IS NOT NULL
+      AND btrim(genre) <> ''
+      AND (genres IS NULL OR cardinality(genres) = 0);
+
+    ALTER TABLE public.books DROP COLUMN genre;
+  END IF;
+END $$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS books (
   user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   title           text NOT NULL,
   author          text NOT NULL,
-  genre           text,
+  genres          text[],
   status          text NOT NULL DEFAULT 'Wishlist'
                     CHECK (status IN ('Wishlist','Not Started','Up Next','Reading','Finished','DNF')),
   cover_url       text,


### PR DESCRIPTION
## Summary
- migrate book genre data from a single text value to `genres` arrays and render genres in the book detail dialog as individual tags
- update add/edit flows and ISBN lookup mapping to read/write multi-genre values, with empty genres shown as blank instead of placeholder text
- add a Supabase migration for `genre` -> `genres` and include a temporary compatibility fallback for projects that have not run the migration yet

Closes #31