### PR TITLE
feat: add Analytics tab to app navigation

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
 import { Link, Outlet, useLocation } from "react-router-dom";
-import { Plus, LogOut, LayoutDashboard, Library, KeyRound } from "lucide-react";
+import {
+  Plus,
+  LogOut,
+  LayoutDashboard,
+  Library,
+  KeyRound,
+  BarChart3,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BooksProvider } from "@/context/BooksContext";
 import { useAuth } from "@/context";
@@ -12,6 +19,7 @@ import readingJournalLogo from "@/assets/reading-journal-logo.png";
 const navLinks = [
   { to: "/", label: "Dashboard", icon: LayoutDashboard },
   { to: "/library", label: "Library", icon: Library },
+  { to: "/analytics", label: "Analytics", icon: BarChart3 },
 ];
 
 export default function AppLayout() {

--- a/src/lib/router.tsx
+++ b/src/lib/router.tsx
@@ -4,6 +4,7 @@ import AppLayout from "@/components/AppLayout";
 import Login from "@/pages/Login";
 import Dashboard from "@/pages/Dashboard";
 import Library from "@/pages/Library";
+import Analytics from "@/pages/Analytics";
 
 function NotFound() {
   return (
@@ -29,6 +30,7 @@ export const router = createBrowserRouter([
         children: [
           { path: "/", element: <Dashboard /> },
           { path: "/library", element: <Library /> },
+          { path: "/analytics", element: <Analytics /> },
         ],
       },
     ],

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,0 +1,45 @@
+import { BarChart3 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { useBooksContext } from "@/context/BooksContext";
+
+export default function Analytics() {
+  const { books } = useBooksContext();
+  const finishedBooks = books.filter((book) => book.status === "Finished").length;
+  const readingBooks = books.filter((book) => book.status === "Reading").length;
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Analytics</h1>
+
+      <Card>
+        <CardHeader className="space-y-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted">
+            <BarChart3 className="h-5 w-5" />
+          </div>
+          <div className="space-y-1">
+            <CardTitle>Global reading insights are coming soon</CardTitle>
+            <CardDescription>
+              This tab is now available and will soon include trends, pace tracking, and deeper analytics from all your books.
+            </CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="rounded-lg border p-4">
+              <p className="text-xs text-muted-foreground">Total books</p>
+              <p className="mt-1 text-2xl font-semibold">{books.length}</p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <p className="text-xs text-muted-foreground">Currently reading</p>
+              <p className="mt-1 text-2xl font-semibold">{readingBooks}</p>
+            </div>
+            <div className="rounded-lg border p-4">
+              <p className="text-xs text-muted-foreground">Finished</p>
+              <p className="mt-1 text-2xl font-semibold">{finishedBooks}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,4 +1,4 @@
 export { default as Login } from "./Login";
 export { default as Dashboard } from "./Dashboard";
 export { default as Library } from "./Library";
-
+export { default as Analytics } from "./Analytics";


### PR DESCRIPTION
## Summary
- add a new top-level `Analytics` page and register it in the protected router
- add `Analytics` to desktop and mobile navigation in the app layout
- scaffold the Analytics screen with a coming-soon card and basic aggregate counts from BooksContext

Closes #38