### PR TITLE
feat: add GitHub-style reading activity heatmap

### DIFF
--- a/src/components/ReadingHeatmap.tsx
+++ b/src/components/ReadingHeatmap.tsx
@@ -1,0 +1,236 @@
+import { useMemo } from "react";
+import type { ReadingLog } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface ReadingHeatmapProps {
+  logs: ReadingLog[];
+}
+
+interface HeatmapCell {
+  dayKey: string;
+  date: Date;
+  visualMinutes: number;
+  trackedMinutes: number;
+  logsCount: number;
+  level: 0 | 1 | 2 | 3 | 4;
+  inRange: boolean;
+}
+
+function toLocalDayKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function getIntensityLevel(minutes: number): 0 | 1 | 2 | 3 | 4 {
+  if (minutes <= 0) return 0;
+  if (minutes <= 15) return 1;
+  if (minutes <= 30) return 2;
+  if (minutes <= 60) return 3;
+  return 4;
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function buildRange() {
+  const today = startOfLocalDay(new Date());
+  const start = new Date(today);
+  start.setFullYear(start.getFullYear() - 1);
+  start.setDate(start.getDate() + 1);
+  return { start, end: today };
+}
+
+export default function ReadingHeatmap({ logs }: ReadingHeatmapProps) {
+  const columnWidthPx = 16;
+  const { weeks, monthLabels, hasAnyReading } = useMemo(() => {
+    const { start, end } = buildRange();
+
+    const dayTotals = new Map<string, number>();
+    const dayLogCounts = new Map<string, number>();
+    for (const log of logs) {
+      const minutes = log.reading_time_minutes ?? 0;
+      const key = toLocalDayKey(new Date(log.logged_at));
+      dayLogCounts.set(key, (dayLogCounts.get(key) ?? 0) + 1);
+      if (minutes > 0) {
+        dayTotals.set(key, (dayTotals.get(key) ?? 0) + minutes);
+      }
+    }
+
+    const hasAnyReadingInRange = Array.from(dayLogCounts.entries()).some(([key, count]) => {
+      if (count <= 0) return false;
+      const [year, month, day] = key.split("-").map(Number);
+      const date = new Date(year, month - 1, day);
+      return date >= start && date <= end;
+    });
+
+    const gridStart = addDays(start, -start.getDay());
+    const daysToSaturday = 6 - end.getDay();
+    const gridEnd = addDays(end, daysToSaturday);
+
+    const allCells: HeatmapCell[] = [];
+    for (let cursor = new Date(gridStart); cursor <= gridEnd; cursor = addDays(cursor, 1)) {
+      const dayKey = toLocalDayKey(cursor);
+      const minutesLogged = dayTotals.get(dayKey) ?? 0;
+      const logsCount = dayLogCounts.get(dayKey) ?? 0;
+      const visualMinutes = minutesLogged > 0 ? minutesLogged : logsCount > 0 ? 1 : 0;
+      const inRange = cursor >= start && cursor <= end;
+      allCells.push({
+        dayKey,
+        date: new Date(cursor),
+        visualMinutes,
+        trackedMinutes: minutesLogged,
+        logsCount,
+        level: getIntensityLevel(visualMinutes),
+        inRange,
+      });
+    }
+
+    const weekCount = Math.ceil(allCells.length / 7);
+    const weekColumns: HeatmapCell[][] = Array.from({ length: weekCount }, () => []);
+    for (let i = 0; i < allCells.length; i += 1) {
+      const weekIndex = Math.floor(i / 7);
+      weekColumns[weekIndex].push(allCells[i]);
+    }
+
+    const labels = weekColumns
+      .map((week, index) => {
+        const monthStartCell = week.find(
+          (cell) => cell.inRange && cell.date.getDate() === 1
+        );
+        if (!monthStartCell) return null;
+        return {
+          index,
+          text: monthStartCell.date.toLocaleDateString(undefined, { month: "short" }),
+        };
+      })
+      .filter((entry): entry is { index: number; text: string } => Boolean(entry));
+
+    return {
+      weeks: weekColumns,
+      monthLabels: labels,
+      hasAnyReading: hasAnyReadingInRange,
+    };
+  }, [logs]);
+
+  const intensityClassByLevel: Record<HeatmapCell["level"], string> = {
+    0: "bg-muted border-border/70",
+    1: "bg-emerald-100 border-emerald-200",
+    2: "bg-emerald-200 border-emerald-300",
+    3: "bg-emerald-400 border-emerald-500",
+    4: "bg-emerald-600 border-emerald-700",
+  };
+
+  return (
+    <section className="space-y-4">
+      <div>
+        <h2 className="text-base font-semibold">Reading activity</h2>
+        <p className="text-sm text-muted-foreground">Last 12 months by day (minutes read)</p>
+      </div>
+
+      {hasAnyReading ? (
+        <div className="space-y-3">
+          <div className="overflow-x-auto pb-2">
+            <div className="min-w-[860px]">
+              <div className="grid grid-cols-[auto_1fr] gap-2 text-xs text-muted-foreground">
+                <div />
+                <div className="relative h-4">
+                  {monthLabels.map((label) => (
+                    <span
+                      key={`${label.text}-${label.index}`}
+                      className="absolute -translate-x-1/2"
+                      style={{ left: `${label.index * columnWidthPx + 8}px` }}
+                    >
+                      {label.text}
+                    </span>
+                  ))}
+                </div>
+
+                <div className="grid grid-rows-7 gap-1 pr-1 text-[11px]">
+                  <span className="h-3 leading-3" />
+                  <span className="h-3 leading-3">Mon</span>
+                  <span className="h-3 leading-3" />
+                  <span className="h-3 leading-3">Wed</span>
+                  <span className="h-3 leading-3" />
+                  <span className="h-3 leading-3">Fri</span>
+                  <span className="h-3 leading-3" />
+                </div>
+
+                <div className="grid auto-cols-max grid-flow-col gap-1">
+                  {weeks.map((week, weekIndex) => (
+                    <div key={weekIndex} className="grid grid-rows-7 gap-1">
+                      {week.map((cell) => {
+                        const title =
+                          cell.trackedMinutes > 0
+                            ? `${formatDate(cell.date)}: ${cell.trackedMinutes} minute${cell.trackedMinutes === 1 ? "" : "s"} read`
+                            : `${formatDate(cell.date)}: no reading activity`;
+                        const hasTimeTracked = cell.trackedMinutes > 0;
+                        const activityLabel =
+                          !cell.inRange
+                            ? title
+                            : hasTimeTracked
+                              ? title
+                              : cell.logsCount > 0
+                                ? `${formatDate(cell.date)}: progress logged (no reading time tracked)`
+                                : title;
+                        return (
+                          <button
+                            key={cell.dayKey}
+                            type="button"
+                            title={activityLabel}
+                            disabled={!cell.inRange}
+                            aria-label={activityLabel}
+                            className={cn(
+                              "h-3 w-3 rounded-[3px] border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+                              cell.inRange
+                                ? intensityClassByLevel[cell.level]
+                                : "border-transparent bg-transparent",
+                              cell.inRange && cell.level > 0 && "hover:brightness-95"
+                            )}
+                          />
+                        );
+                      })}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+            <p>Hover a day to see details.</p>
+            <div className="flex items-center gap-1.5">
+              <span>Less</span>
+              <span className={cn("h-3 w-3 rounded-[3px] border", intensityClassByLevel[0])} />
+              <span className={cn("h-3 w-3 rounded-[3px] border", intensityClassByLevel[1])} />
+              <span className={cn("h-3 w-3 rounded-[3px] border", intensityClassByLevel[2])} />
+              <span className={cn("h-3 w-3 rounded-[3px] border", intensityClassByLevel[3])} />
+              <span className={cn("h-3 w-3 rounded-[3px] border", intensityClassByLevel[4])} />
+              <span>More</span>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-muted/20 p-4 text-sm text-muted-foreground">
+          No reading activity yet. Log reading time from a book to populate the heatmap.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -202,3 +202,18 @@ export async function fetchReadingLogsForBook(
   if (error) throw error;
   return (data ?? []) as ReadingLog[];
 }
+
+export async function fetchReadingLogsInRange(
+  startIso: string,
+  endIso: string
+): Promise<ReadingLog[]> {
+  const { data, error } = await supabase
+    .from("reading_logs")
+    .select("*")
+    .gte("logged_at", startIso)
+    .lte("logged_at", endIso)
+    .order("logged_at", { ascending: true });
+
+  if (error) throw error;
+  return (data ?? []) as ReadingLog[];
+}

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,26 +1,61 @@
-import { BarChart3 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { BarChart3, RefreshCw } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import ReadingHeatmap from "@/components/ReadingHeatmap";
 import { useBooksContext } from "@/context/BooksContext";
+import { fetchReadingLogsInRange } from "@/lib/books";
+import type { ReadingLog } from "@/types";
+
+function getHeatmapRangeIso(): { startIso: string; endIso: string } {
+  const now = new Date();
+  const endDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+  const startDate = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate() + 1, 0, 0, 0, 0);
+  return {
+    startIso: startDate.toISOString(),
+    endIso: endDate.toISOString(),
+  };
+}
 
 export default function Analytics() {
   const { books } = useBooksContext();
   const finishedBooks = books.filter((book) => book.status === "Finished").length;
   const readingBooks = books.filter((book) => book.status === "Reading").length;
+  const [logs, setLogs] = useState<ReadingLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const range = useMemo(() => getHeatmapRangeIso(), []);
+
+  async function loadHeatmapLogs() {
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await fetchReadingLogsInRange(range.startIso, range.endIso);
+      setLogs(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load reading activity");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadHeatmapLogs();
+  }, []);
 
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold">Analytics</h1>
 
       <Card>
-        <CardHeader className="space-y-3">
+        <CardHeader className="space-y-2">
           <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted">
             <BarChart3 className="h-5 w-5" />
           </div>
-          <div className="space-y-1">
-            <CardTitle>Global reading insights are coming soon</CardTitle>
-            <CardDescription>
-              This tab is now available and will soon include trends, pace tracking, and deeper analytics from all your books.
-            </CardDescription>
+          <div>
+            <CardTitle>Reading overview</CardTitle>
+            <CardDescription>High-level stats from your library.</CardDescription>
           </div>
         </CardHeader>
         <CardContent>
@@ -38,6 +73,27 @@ export default function Analytics() {
               <p className="mt-1 text-2xl font-semibold">{finishedBooks}</p>
             </div>
           </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="pt-6">
+          {loading ? (
+            <div className="space-y-3">
+              <div className="h-5 w-48 animate-pulse rounded bg-muted/50" />
+              <div className="h-44 animate-pulse rounded-lg border bg-muted/30" />
+            </div>
+          ) : error ? (
+            <div className="space-y-3 py-1">
+              <p className="text-sm text-destructive">{error}</p>
+              <Button type="button" variant="outline" size="sm" onClick={loadHeatmapLogs}>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Retry
+              </Button>
+            </div>
+          ) : (
+            <ReadingHeatmap logs={logs} />
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- add a reusable `ReadingHeatmap` component for the Analytics page that renders a GitHub-style 12-month activity grid with month labels, weekday markers, intensity legend, and day tooltips
- replace the Analytics placeholder text with real activity content while keeping the existing `Total books`, `Currently reading`, and `Finished` overview cards
- add `fetchReadingLogsInRange` and load reading logs by date range so the heatmap reflects only the last 12 months and remains scoped by existing Supabase RLS
- include loading, error/retry, and empty-state handling for analytics data
- treat progress logs without tracked minutes as light activity so recent reading still appears in the heatmap

## Testing
- npm run typecheck
- npm run build

## Issue
- Closes #42