### PR TITLE
Add quick progress section to dashboard reading cards

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -1,16 +1,43 @@
+import { useState } from "react";
 import { BookOpen, Heart } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
+import ReadingProgressPanel from "@/components/ReadingProgressPanel";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useBooksContext } from "@/context/BooksContext";
 import { statusVariant } from "@/lib/utils";
 import type { Book } from "@/types";
 
 interface BookCardProps {
   book: Book;
   onClick: (book: Book) => void;
+  showQuickProgress?: boolean;
 }
 
-export default function BookCard({ book, onClick }: BookCardProps) {
+export default function BookCard({
+  book,
+  onClick,
+  showQuickProgress = false,
+}: BookCardProps) {
+  const { updateBook } = useBooksContext();
+  const [progressDialogOpen, setProgressDialogOpen] = useState(false);
+
+  const currentPage = Math.max(0, book.current_page ?? 0);
+  const totalPages = Math.max(0, book.total_pages ?? 0);
+  const hasTotalPages = totalPages > 0;
+  const progressPercent = hasTotalPages
+    ? Math.min(100, Math.max(0, Math.round((currentPage / totalPages) * 100)))
+    : 0;
+
+  const showDashboardQuickProgress = showQuickProgress && book.status === "Reading";
+
   const progress =
     book.status === "Reading" && book.current_page && book.total_pages
       ? Math.round((book.current_page / book.total_pages) * 100)
@@ -48,10 +75,54 @@ export default function BookCard({ book, onClick }: BookCardProps) {
         <Badge variant={statusVariant(book.status)} className="text-xs">
           {book.status}
         </Badge>
-        {progress !== null && (
+        {!showDashboardQuickProgress && progress !== null && (
           <Progress value={progress} className="h-1 mt-1" />
         )}
       </CardContent>
+
+      {showDashboardQuickProgress && (
+        <div className="border-t px-2 pb-2 pt-1.5 space-y-1.5">
+          <Progress value={progressPercent} className="h-1" />
+          <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2">
+            <p className="text-[11px] text-muted-foreground">{progressPercent}%</p>
+            <p className="text-[11px] text-center text-muted-foreground truncate">
+              {currentPage} / {hasTotalPages ? totalPages : "-"}
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 px-2 text-[11px]"
+              onClick={(event) => {
+                event.stopPropagation();
+                setProgressDialogOpen(true);
+              }}
+            >
+              Update Progress
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <Dialog open={progressDialogOpen} onOpenChange={setProgressDialogOpen}>
+        <DialogContent
+          className="sm:max-w-md"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <DialogHeader>
+            <DialogTitle>Update progress</DialogTitle>
+          </DialogHeader>
+          <ReadingProgressPanel
+            book={book}
+            defaultExpanded
+            hideTrigger
+            onProgressSaved={async (newPage) => {
+              await updateBook(book.id, { current_page: newPage });
+              setProgressDialogOpen(false);
+            }}
+          />
+        </DialogContent>
+      </Dialog>
     </Card>
   );
 }

--- a/src/components/ReadingProgressPanel.tsx
+++ b/src/components/ReadingProgressPanel.tsx
@@ -11,6 +11,8 @@ import type { Book, ReadingLog } from "@/types";
 interface ReadingProgressPanelProps {
   book: Book;
   onProgressSaved: (newCurrentPage: number) => void;
+  defaultExpanded?: boolean;
+  hideTrigger?: boolean;
 }
 
 function buildPageItems(min: number, max: number) {
@@ -39,9 +41,11 @@ const MINUTE_ITEMS = Array.from({ length: 12 }, (_, i) => ({
 export default function ReadingProgressPanel({
   book,
   onProgressSaved,
+  defaultExpanded = false,
+  hideTrigger = false,
 }: ReadingProgressPanelProps) {
   const { user } = useAuth();
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded);
   const [lastLog, setLastLog] = useState<ReadingLog | null>(null);
   const [loadingLog, setLoadingLog] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -148,7 +152,7 @@ export default function ReadingProgressPanel({
 
   return (
     <div className="space-y-3">
-      {!expanded && (
+      {!expanded && !hideTrigger && (
         <Button
           type="button"
           variant="outline"

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -74,7 +74,12 @@ export default function Dashboard() {
               <h2 className="text-lg font-medium">Currently Reading</h2>
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
                 {currentlyReading.map((book) => (
-                  <BookCard key={book.id} book={book} onClick={openBook} />
+                  <BookCard
+                    key={book.id}
+                    book={book}
+                    onClick={openBook}
+                    showQuickProgress
+                  />
                 ))}
               </div>
             </section>


### PR DESCRIPTION
## Summary
- add an opt-in quick progress footer to dashboard "Currently Reading" `BookCard`s with a progress bar, percentage, current/total page text, and an `Update Progress` action
- open progress updates from the card in a modal and reuse the existing `ReadingProgressPanel` save logic so updates refresh card values immediately
- handle books with missing/zero `total_pages` gracefully by showing stable `0%` progress and safe page display formatting

## Validation
- npm run typecheck
- npm run build

Closes #56