### PR TITLE
fix: unify update progress dialog across dashboard and book details

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -1,15 +1,8 @@
-import { useState } from "react";
 import { BookOpen, Heart } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import ReadingProgressPanel from "@/components/ReadingProgressPanel";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import ReadingProgressDialog from "@/components/ReadingProgressDialog";
 import { Button } from "@/components/ui/button";
 import { useBooksContext } from "@/context/BooksContext";
 import { statusVariant } from "@/lib/utils";
@@ -27,7 +20,6 @@ export default function BookCard({
   showQuickProgress = false,
 }: BookCardProps) {
   const { updateBook } = useBooksContext();
-  const [progressDialogOpen, setProgressDialogOpen] = useState(false);
 
   const currentPage = Math.max(0, book.current_page ?? 0);
   const totalPages = Math.max(0, book.total_pages ?? 0);
@@ -88,41 +80,28 @@ export default function BookCard({
             <p className="hidden text-[11px] text-center text-muted-foreground truncate sm:block">
               {currentPage} / {hasTotalPages ? totalPages : "-"}
             </p>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="h-7 px-2 text-[11px]"
-              onClick={(event) => {
-                event.stopPropagation();
-                setProgressDialogOpen(true);
+            <ReadingProgressDialog
+              book={book}
+              onProgressSaved={async (newPage) => {
+                await updateBook(book.id, { current_page: newPage });
               }}
-            >
-              Update Progress
-            </Button>
+              trigger={
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-7 px-2 text-[11px]"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                  }}
+                >
+                  Update Progress
+                </Button>
+              }
+            />
           </div>
         </div>
       )}
-
-      <Dialog open={progressDialogOpen} onOpenChange={setProgressDialogOpen}>
-        <DialogContent
-          className="sm:max-w-md"
-          onClick={(event) => event.stopPropagation()}
-        >
-          <DialogHeader>
-            <DialogTitle>Update progress</DialogTitle>
-          </DialogHeader>
-          <ReadingProgressPanel
-            book={book}
-            defaultExpanded
-            hideTrigger
-            onProgressSaved={async (newPage) => {
-              await updateBook(book.id, { current_page: newPage });
-              setProgressDialogOpen(false);
-            }}
-          />
-        </DialogContent>
-      </Dialog>
     </Card>
   );
 }

--- a/src/components/ReadingProgressDialog.tsx
+++ b/src/components/ReadingProgressDialog.tsx
@@ -1,0 +1,48 @@
+import { useState, type ReactNode } from "react";
+import ReadingProgressPanel from "@/components/ReadingProgressPanel";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import type { Book } from "@/types";
+
+interface ReadingProgressDialogProps {
+  book: Book;
+  trigger: ReactNode;
+  onProgressSaved: (newCurrentPage: number) => Promise<void> | void;
+}
+
+export default function ReadingProgressDialog({
+  book,
+  trigger,
+  onProgressSaved,
+}: ReadingProgressDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent
+        className="sm:max-w-md"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <DialogHeader>
+          <DialogTitle>Update progress</DialogTitle>
+        </DialogHeader>
+        <ReadingProgressPanel
+          book={book}
+          defaultExpanded
+          hideTrigger
+          onCancel={() => setOpen(false)}
+          onProgressSaved={async (newPage) => {
+            await onProgressSaved(newPage);
+            setOpen(false);
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ReadingProgressPanel.tsx
+++ b/src/components/ReadingProgressPanel.tsx
@@ -13,6 +13,7 @@ interface ReadingProgressPanelProps {
   onProgressSaved: (newCurrentPage: number) => void;
   defaultExpanded?: boolean;
   hideTrigger?: boolean;
+  onCancel?: () => void;
 }
 
 function buildPageItems(min: number, max: number) {
@@ -43,6 +44,7 @@ export default function ReadingProgressPanel({
   onProgressSaved,
   defaultExpanded = false,
   hideTrigger = false,
+  onCancel,
 }: ReadingProgressPanelProps) {
   const { user } = useAuth();
   const [expanded, setExpanded] = useState(defaultExpanded);
@@ -233,7 +235,13 @@ export default function ReadingProgressPanel({
               variant="ghost"
               size="sm"
               disabled={saving}
-              onClick={() => setExpanded(false)}
+              onClick={() => {
+                if (onCancel) {
+                  onCancel();
+                  return;
+                }
+                setExpanded(false);
+              }}
             >
               Cancel
             </Button>

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -27,7 +27,7 @@ import {
 import { useBooksContext } from "@/context/BooksContext";
 import { useSeries } from "@/hooks/useSeries";
 import { formatGenresInput, parseGenresInput, statusVariant } from "@/lib/utils";
-import ReadingProgressPanel from "@/components/ReadingProgressPanel";
+import ReadingProgressDialog from "@/components/ReadingProgressDialog";
 import BookAnalyticsPanel from "@/components/BookAnalyticsPanel";
 import type {
   Book,
@@ -401,11 +401,16 @@ export default function BookDetails() {
             </div>
             <Progress value={progressPercent} className="h-1.5" />
             {status === "Reading" && (
-              <ReadingProgressPanel
+              <ReadingProgressDialog
                 book={book}
                 onProgressSaved={async (newPage) => {
                   await updateBook(book.id, { current_page: newPage });
                 }}
+                trigger={
+                  <Button type="button" variant="outline" size="sm">
+                    Update progress
+                  </Button>
+                }
               />
             )}
           </section>


### PR DESCRIPTION
## Summary
- replace separate dashboard and book-details update-progress experiences with one shared `ReadingProgressDialog` component
- keep `ReadingProgressPanel` as the form body so validation, save/loading behavior, reading-log creation, and total-pages empty state remain unchanged
- fix cancel behavior and event propagation so closing the dialog returns users to their starting page (dashboard or book details) without accidental navigation

## Testing
- npm run build