### PR TITLE
feat: add manual Supabase database backup workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ node_modules/
 dist/
 dist-ssr/
 
+# Local database backups
+backups/
+
 # Vite cache
 .vite/
 

--- a/README.md
+++ b/README.md
@@ -173,5 +173,27 @@ VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key
 ```
 
+#### Manual Database Backup (Schema + Data)
+
+You can create a local SQL backup (structure + data) from the project root:
+
+```bash
+SUPABASE_DB_URL=postgresql://postgres:password@db.your-project-ref.supabase.co:5432/postgres npm run backup:db
+```
+
+Prerequisites:
+- provide the Postgres connection string as `SUPABASE_DB_URL` (or pass it as first argument)
+- `pg_dump` is installed and available in your `PATH`
+
+The script creates both files in `backups/db/` using your local timestamp in `YYYY-MM-DD-HH-MM` format:
+- `structure-YYYY-MM-DD-HH-MM.sql`
+- `data-YYYY-MM-DD-HH-MM.sql`
+
+Example output files:
+- `backups/db/structure-2026-04-19-14-30.sql`
+- `backups/db/data-2026-04-19-14-30.sql`
+
+Credentials are read from runtime input/environment only. Do not commit real connection strings.
+
 ---
 *Generated for coding agent context based on the user's Reading Journal UI/UX specifications and technical requirements.*

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "invite": "tsx scripts/invite-user.ts"
+    "invite": "tsx scripts/invite-user.ts",
+    "backup:db": "tsx scripts/backup-db.ts"
   },
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.8",

--- a/scripts/backup-db.ts
+++ b/scripts/backup-db.ts
@@ -1,0 +1,79 @@
+/**
+ * Create a manual PostgreSQL backup for Supabase (schema + data).
+ *
+ * Usage:
+ *   SUPABASE_DB_URL=postgresql://... npm run backup:db
+ *   npm run backup:db -- postgresql://...
+ *
+ * Prerequisites:
+ *   - SUPABASE_DB_URL in environment, or DB URL passed as first argument
+ *   - pg_dump must be installed and available in PATH
+ *
+ * Output:
+ *   backups/db/structure-YYYY-MM-DD-HH-MM.sql
+ *   backups/db/data-YYYY-MM-DD-HH-MM.sql
+ */
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const connectionString = process.argv[2] ?? process.env.SUPABASE_DB_URL;
+
+if (!connectionString) {
+  console.error("Missing database URL.");
+  console.error("Provide it as SUPABASE_DB_URL env var or pass it as the first argument.");
+  console.error("Example: SUPABASE_DB_URL=postgresql://... npm run backup:db");
+  process.exit(1);
+}
+
+const pgDumpVersion = spawnSync("pg_dump", ["--version"], { stdio: "pipe" });
+
+if (pgDumpVersion.error || pgDumpVersion.status !== 0) {
+  console.error("pg_dump is required but was not found. Install PostgreSQL client tools and ensure pg_dump is in PATH.");
+  process.exit(1);
+}
+
+const now = new Date();
+
+const pad = (value: number): string => String(value).padStart(2, "0");
+
+const timestamp = [
+  now.getFullYear(),
+  pad(now.getMonth() + 1),
+  pad(now.getDate()),
+  pad(now.getHours()),
+  pad(now.getMinutes()),
+].join("-");
+
+const outputDir = join(process.cwd(), "backups", "db");
+mkdirSync(outputDir, { recursive: true });
+
+const structureFile = join(outputDir, `structure-${timestamp}.sql`);
+const dataFile = join(outputDir, `data-${timestamp}.sql`);
+
+const runDump = (args: string[], outputFile: string): void => {
+  const result = spawnSync("pg_dump", args, {
+    env: {
+      ...process.env,
+      DATABASE_URL: connectionString,
+    },
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    console.error(`Failed to run pg_dump for ${outputFile}: ${result.error.message}`);
+    process.exit(1);
+  }
+
+  if (result.status !== 0) {
+    console.error(`pg_dump exited with code ${result.status} while creating ${outputFile}`);
+    process.exit(result.status ?? 1);
+  }
+};
+
+runDump(["--schema-only", "--file", structureFile, connectionString], structureFile);
+runDump(["--data-only", "--inserts", "--file", dataFile, connectionString], dataFile);
+
+console.log("Database backup created successfully.");
+console.log(`Structure: ${structureFile}`);
+console.log(`Data: ${dataFile}`);


### PR DESCRIPTION
## Summary
- add `scripts/backup-db.ts` to export schema-only and data-only SQL dumps with a shared `YYYY-MM-DD-HH-MM` timestamp
- add `npm run backup:db` alias and clear validation errors for missing database URL / missing `pg_dump`
- document backup usage and prerequisites in `README.md`, and ignore generated `backups/` artifacts in git

## Validation
- ran `npm run typecheck`
- ran `npm run backup:db` to verify missing-URL error handling
- confirmed backup command works end-to-end with a valid Supabase Session Pooler connection string