### PR TITLE
feat: add reading habit insights to analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
+    "test": "tsx --test tests/**/*.test.ts",
     "invite": "tsx scripts/invite-user.ts",
     "backup:db": "tsx scripts/backup-db.ts"
   },

--- a/src/lib/readingHabits.ts
+++ b/src/lib/readingHabits.ts
@@ -91,6 +91,15 @@ function getWeekSpan(startIso: string, endIso: string): number {
   return Math.max(1, diffDays / 7);
 }
 
+function getEffectiveWeekSpan(logs: ReadingLog[], startIso: string, endIso: string): number {
+  if (logs.length === 0) return getWeekSpan(startIso, endIso);
+
+  const rangeStart = startOfLocalDay(new Date(startIso));
+  const firstLogStart = startOfLocalDay(new Date(logs[0].logged_at));
+  const effectiveStart = firstLogStart > rangeStart ? firstLogStart : rangeStart;
+  return getWeekSpan(effectiveStart.toISOString(), endIso);
+}
+
 function allocateMinutesByHour(
   end: Date,
   totalMinutes: number,
@@ -241,7 +250,7 @@ export function calculateReadingHabits(
   const dominantHour =
     maxHourCount > 0 ? hourMinutes.findIndex((count) => count === maxHourCount) : null;
 
-  const weekSpan = getWeekSpan(startIso, endIso);
+  const weekSpan = getEffectiveWeekSpan(sortedLogs, startIso, endIso);
   const weekdayStats: WeekdayStats[] = WEEKDAY_LABELS.map((weekdayLabel, index) => ({
     weekdayLabel,
     avgMinutesPerWeek: weekdayMinutesTotal[index] / weekSpan,

--- a/src/lib/readingHabits.ts
+++ b/src/lib/readingHabits.ts
@@ -21,7 +21,7 @@ type DayPartLabel = (typeof DAY_PARTS)[number]["label"];
 
 export interface DayPartStats {
   label: DayPartLabel;
-  sessions: number;
+  minutes: number;
   percentage: number;
 }
 
@@ -91,6 +91,30 @@ function getWeekSpan(startIso: string, endIso: string): number {
   return Math.max(1, diffDays / 7);
 }
 
+function allocateMinutesByHour(
+  end: Date,
+  totalMinutes: number,
+  onChunk: (chunkStart: Date, chunkMinutes: number) => void
+) {
+  let remaining = totalMinutes;
+  let cursor = new Date(end.getTime() - totalMinutes * 60 * 1000);
+
+  while (remaining > 0) {
+    const nextHour = new Date(cursor);
+    nextHour.setMinutes(0, 0, 0);
+    nextHour.setHours(nextHour.getHours() + 1);
+
+    const minutesUntilHourBoundary = (nextHour.getTime() - cursor.getTime()) / (60 * 1000);
+    const chunkMinutes = Math.min(remaining, minutesUntilHourBoundary);
+    if (chunkMinutes <= 0) break;
+
+    onChunk(cursor, chunkMinutes);
+
+    remaining -= chunkMinutes;
+    cursor = new Date(cursor.getTime() + chunkMinutes * 60 * 1000);
+  }
+}
+
 export function calculateReadingHabits(
   logs: ReadingLog[],
   startIso: string,
@@ -112,7 +136,7 @@ export function calculateReadingHabits(
       usualTime: {
         dayParts: DAY_PARTS.map((part) => ({
           label: part.label,
-          sessions: 0,
+          minutes: 0,
           percentage: 0,
         })),
         dominantHour: null,
@@ -139,8 +163,8 @@ export function calculateReadingHabits(
 
   let durationMinutesTotal = 0;
   let durationSessions = 0;
-  const dayPartSessionCounts = new Map<DayPartLabel, number>();
-  const hourCounts = new Array<number>(24).fill(0);
+  const dayPartMinutes = new Map<DayPartLabel, number>();
+  const hourMinutes = new Array<number>(24).fill(0);
 
   const weekdayMinutesTotal = new Array<number>(7).fill(0);
   const weekdaySessionsTotal = new Array<number>(7).fill(0);
@@ -149,11 +173,6 @@ export function calculateReadingHabits(
 
   for (const log of sortedLogs) {
     const loggedAt = new Date(log.logged_at);
-    const hour = loggedAt.getHours();
-    const dayPart = getDayPartLabel(hour);
-    dayPartSessionCounts.set(dayPart, (dayPartSessionCounts.get(dayPart) ?? 0) + 1);
-    hourCounts[hour] += 1;
-
     const weekdayIndex = toMondayFirstWeekdayIndex(loggedAt.getDay());
     weekdaySessionsTotal[weekdayIndex] += 1;
 
@@ -161,7 +180,16 @@ export function calculateReadingHabits(
     if (readingMinutes > 0) {
       durationMinutesTotal += readingMinutes;
       durationSessions += 1;
-      weekdayMinutesTotal[weekdayIndex] += readingMinutes;
+
+      allocateMinutesByHour(loggedAt, readingMinutes, (chunkStart, chunkMinutes) => {
+        const chunkHour = chunkStart.getHours();
+        const chunkDayPart = getDayPartLabel(chunkHour);
+        const chunkWeekdayIndex = toMondayFirstWeekdayIndex(chunkStart.getDay());
+
+        dayPartMinutes.set(chunkDayPart, (dayPartMinutes.get(chunkDayPart) ?? 0) + chunkMinutes);
+        hourMinutes[chunkHour] += chunkMinutes;
+        weekdayMinutesTotal[chunkWeekdayIndex] += chunkMinutes;
+      });
     }
 
     const list = logsByBook.get(log.book_id) ?? [];
@@ -197,18 +225,21 @@ export function calculateReadingHabits(
   }
 
   const totalSessions = sortedLogs.length;
+  const totalTrackedMinutes = dayPartMinutes.size
+    ? [...dayPartMinutes.values()].reduce((sum, minutes) => sum + minutes, 0)
+    : 0;
   const dayPartStats: DayPartStats[] = DAY_PARTS.map((part) => {
-    const sessions = dayPartSessionCounts.get(part.label) ?? 0;
+    const minutes = dayPartMinutes.get(part.label) ?? 0;
     return {
       label: part.label,
-      sessions,
-      percentage: totalSessions > 0 ? (sessions / totalSessions) * 100 : 0,
+      minutes,
+      percentage: totalTrackedMinutes > 0 ? (minutes / totalTrackedMinutes) * 100 : 0,
     };
   });
 
-  const maxHourCount = Math.max(...hourCounts);
+  const maxHourCount = Math.max(...hourMinutes);
   const dominantHour =
-    maxHourCount > 0 ? hourCounts.findIndex((count) => count === maxHourCount) : null;
+    maxHourCount > 0 ? hourMinutes.findIndex((count) => count === maxHourCount) : null;
 
   const weekSpan = getWeekSpan(startIso, endIso);
   const weekdayStats: WeekdayStats[] = WEEKDAY_LABELS.map((weekdayLabel, index) => ({

--- a/src/lib/readingHabits.ts
+++ b/src/lib/readingHabits.ts
@@ -1,0 +1,290 @@
+import type { ReadingLog } from "@/types";
+
+const DAY_PARTS = [
+  { label: "Morning", startHour: 6, endHour: 11 },
+  { label: "Afternoon", startHour: 12, endHour: 17 },
+  { label: "Evening", startHour: 18, endHour: 22 },
+  { label: "Night", startHour: 23, endHour: 5 },
+] as const;
+
+const WEEKDAY_LABELS = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+] as const;
+
+type DayPartLabel = (typeof DAY_PARTS)[number]["label"];
+
+export interface DayPartStats {
+  label: DayPartLabel;
+  sessions: number;
+  percentage: number;
+}
+
+export interface SpeedStats {
+  averagePagesPerHour: number | null;
+  sessionsUsed: number;
+  totalPages: number;
+  totalHours: number;
+}
+
+export interface DurationStats {
+  averageMinutes: number | null;
+  sessionsUsed: number;
+}
+
+export interface WeekdayStats {
+  weekdayLabel: (typeof WEEKDAY_LABELS)[number];
+  avgMinutesPerWeek: number;
+  avgSessionsPerWeek: number;
+  totalMinutes: number;
+  totalSessions: number;
+}
+
+export interface ReadingHabitsMetrics {
+  totalLogs: number;
+  duration: DurationStats;
+  speed: SpeedStats;
+  usualTime: {
+    dayParts: DayPartStats[];
+    dominantHour: number | null;
+    dominantHourLabel: string | null;
+  };
+  weekdays: {
+    weekSpan: number;
+    highest: WeekdayStats | null;
+    lowest: WeekdayStats | null;
+    all: WeekdayStats[];
+  };
+}
+
+function getDayPartLabel(hour: number): DayPartLabel {
+  if (hour >= 6 && hour <= 11) return "Morning";
+  if (hour >= 12 && hour <= 17) return "Afternoon";
+  if (hour >= 18 && hour <= 22) return "Evening";
+  return "Night";
+}
+
+function toMondayFirstWeekdayIndex(jsDayIndex: number): number {
+  return (jsDayIndex + 6) % 7;
+}
+
+function formatHourWindow(hour: number): string {
+  const start = String(hour).padStart(2, "0");
+  const end = String((hour + 1) % 24).padStart(2, "0");
+  return `${start}:00-${end}:00`;
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function getWeekSpan(startIso: string, endIso: string): number {
+  const start = startOfLocalDay(new Date(startIso));
+  const end = startOfLocalDay(new Date(endIso));
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const diffDays = Math.max(1, Math.floor((end.getTime() - start.getTime()) / msPerDay) + 1);
+  return Math.max(1, diffDays / 7);
+}
+
+export function calculateReadingHabits(
+  logs: ReadingLog[],
+  startIso: string,
+  endIso: string
+): ReadingHabitsMetrics {
+  if (logs.length === 0) {
+    return {
+      totalLogs: 0,
+      duration: {
+        averageMinutes: null,
+        sessionsUsed: 0,
+      },
+      speed: {
+        averagePagesPerHour: null,
+        sessionsUsed: 0,
+        totalPages: 0,
+        totalHours: 0,
+      },
+      usualTime: {
+        dayParts: DAY_PARTS.map((part) => ({
+          label: part.label,
+          sessions: 0,
+          percentage: 0,
+        })),
+        dominantHour: null,
+        dominantHourLabel: null,
+      },
+      weekdays: {
+        weekSpan: getWeekSpan(startIso, endIso),
+        highest: null,
+        lowest: null,
+        all: WEEKDAY_LABELS.map((weekdayLabel) => ({
+          weekdayLabel,
+          avgMinutesPerWeek: 0,
+          avgSessionsPerWeek: 0,
+          totalMinutes: 0,
+          totalSessions: 0,
+        })),
+      },
+    };
+  }
+
+  const sortedLogs = [...logs].sort(
+    (a, b) => new Date(a.logged_at).getTime() - new Date(b.logged_at).getTime()
+  );
+
+  let durationMinutesTotal = 0;
+  let durationSessions = 0;
+  const dayPartSessionCounts = new Map<DayPartLabel, number>();
+  const hourCounts = new Array<number>(24).fill(0);
+
+  const weekdayMinutesTotal = new Array<number>(7).fill(0);
+  const weekdaySessionsTotal = new Array<number>(7).fill(0);
+
+  const logsByBook = new Map<string, ReadingLog[]>();
+
+  for (const log of sortedLogs) {
+    const loggedAt = new Date(log.logged_at);
+    const hour = loggedAt.getHours();
+    const dayPart = getDayPartLabel(hour);
+    dayPartSessionCounts.set(dayPart, (dayPartSessionCounts.get(dayPart) ?? 0) + 1);
+    hourCounts[hour] += 1;
+
+    const weekdayIndex = toMondayFirstWeekdayIndex(loggedAt.getDay());
+    weekdaySessionsTotal[weekdayIndex] += 1;
+
+    const readingMinutes = log.reading_time_minutes ?? 0;
+    if (readingMinutes > 0) {
+      durationMinutesTotal += readingMinutes;
+      durationSessions += 1;
+      weekdayMinutesTotal[weekdayIndex] += readingMinutes;
+    }
+
+    const list = logsByBook.get(log.book_id) ?? [];
+    list.push(log);
+    logsByBook.set(log.book_id, list);
+  }
+
+  let speedTotalPages = 0;
+  let speedTotalHours = 0;
+  let speedSessions = 0;
+
+  for (const bookLogs of logsByBook.values()) {
+    const sortedBookLogs = [...bookLogs].sort(
+      (a, b) => new Date(a.logged_at).getTime() - new Date(b.logged_at).getTime()
+    );
+
+    for (let index = 1; index < sortedBookLogs.length; index += 1) {
+      const current = sortedBookLogs[index];
+      const previous = sortedBookLogs[index - 1];
+      const readingMinutes = current.reading_time_minutes ?? 0;
+      if (readingMinutes <= 0) continue;
+
+      const pagesReadDelta = current.current_page - previous.current_page;
+      if (pagesReadDelta <= 0) continue;
+
+      const hours = readingMinutes / 60;
+      if (hours <= 0) continue;
+
+      speedTotalPages += pagesReadDelta;
+      speedTotalHours += hours;
+      speedSessions += 1;
+    }
+  }
+
+  const totalSessions = sortedLogs.length;
+  const dayPartStats: DayPartStats[] = DAY_PARTS.map((part) => {
+    const sessions = dayPartSessionCounts.get(part.label) ?? 0;
+    return {
+      label: part.label,
+      sessions,
+      percentage: totalSessions > 0 ? (sessions / totalSessions) * 100 : 0,
+    };
+  });
+
+  const maxHourCount = Math.max(...hourCounts);
+  const dominantHour =
+    maxHourCount > 0 ? hourCounts.findIndex((count) => count === maxHourCount) : null;
+
+  const weekSpan = getWeekSpan(startIso, endIso);
+  const weekdayStats: WeekdayStats[] = WEEKDAY_LABELS.map((weekdayLabel, index) => ({
+    weekdayLabel,
+    avgMinutesPerWeek: weekdayMinutesTotal[index] / weekSpan,
+    avgSessionsPerWeek: weekdaySessionsTotal[index] / weekSpan,
+    totalMinutes: weekdayMinutesTotal[index],
+    totalSessions: weekdaySessionsTotal[index],
+  }));
+
+  const hasWeekdayActivity = weekdayStats.some((weekday) => weekday.totalSessions > 0);
+
+  const highest = hasWeekdayActivity
+    ? [...weekdayStats].sort((left, right) => {
+        if (right.avgMinutesPerWeek !== left.avgMinutesPerWeek) {
+          return right.avgMinutesPerWeek - left.avgMinutesPerWeek;
+        }
+        if (right.avgSessionsPerWeek !== left.avgSessionsPerWeek) {
+          return right.avgSessionsPerWeek - left.avgSessionsPerWeek;
+        }
+        return WEEKDAY_LABELS.indexOf(left.weekdayLabel) - WEEKDAY_LABELS.indexOf(right.weekdayLabel);
+      })[0]
+    : null;
+
+  const lowest = hasWeekdayActivity
+    ? [...weekdayStats].sort((left, right) => {
+        if (left.avgMinutesPerWeek !== right.avgMinutesPerWeek) {
+          return left.avgMinutesPerWeek - right.avgMinutesPerWeek;
+        }
+        if (left.avgSessionsPerWeek !== right.avgSessionsPerWeek) {
+          return left.avgSessionsPerWeek - right.avgSessionsPerWeek;
+        }
+        return WEEKDAY_LABELS.indexOf(left.weekdayLabel) - WEEKDAY_LABELS.indexOf(right.weekdayLabel);
+      })[0]
+    : null;
+
+  return {
+    totalLogs: totalSessions,
+    duration: {
+      averageMinutes: durationSessions > 0 ? durationMinutesTotal / durationSessions : null,
+      sessionsUsed: durationSessions,
+    },
+    speed: {
+      averagePagesPerHour: speedTotalHours > 0 ? speedTotalPages / speedTotalHours : null,
+      sessionsUsed: speedSessions,
+      totalPages: speedTotalPages,
+      totalHours: speedTotalHours,
+    },
+    usualTime: {
+      dayParts: dayPartStats,
+      dominantHour,
+      dominantHourLabel: dominantHour === null ? null : formatHourWindow(dominantHour),
+    },
+    weekdays: {
+      weekSpan,
+      highest,
+      lowest,
+      all: weekdayStats,
+    },
+  };
+}
+
+export function formatDurationMinutes(minutes: number): string {
+  const rounded = Math.round(minutes);
+  return `${rounded} min`;
+}
+
+export function formatPagesPerHour(pagesPerHour: number): string {
+  return `${pagesPerHour.toFixed(1)} pages/hr`;
+}
+
+export function formatMinutesCompact(minutes: number): string {
+  const rounded = Math.round(minutes);
+  const hours = Math.floor(rounded / 60);
+  const mins = rounded % 60;
+  if (hours > 0 && mins > 0) return `${hours}h ${mins}m`;
+  if (hours > 0) return `${hours}h`;
+  return `${mins}m`;
+}

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -2,10 +2,17 @@ import { useEffect, useMemo, useState } from "react";
 import { BarChart3, RefreshCw } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import ReadingHeatmap from "@/components/ReadingHeatmap";
 import GenreDistributionChart from "@/components/GenreDistributionChart";
 import { useBooksContext } from "@/context/BooksContext";
 import { fetchReadingLogsInRange } from "@/lib/books";
+import {
+  calculateReadingHabits,
+  formatDurationMinutes,
+  formatMinutesCompact,
+  formatPagesPerHour,
+} from "@/lib/readingHabits";
 import type { ReadingLog } from "@/types";
 
 function getHeatmapRangeIso(): { startIso: string; endIso: string } {
@@ -27,6 +34,10 @@ export default function Analytics() {
   const [heatmapError, setHeatmapError] = useState<string | null>(null);
 
   const range = useMemo(() => getHeatmapRangeIso(), []);
+  const habits = useMemo(
+    () => calculateReadingHabits(logs, range.startIso, range.endIso),
+    [logs, range.endIso, range.startIso]
+  );
 
   async function loadHeatmapLogs() {
     try {
@@ -94,6 +105,137 @@ export default function Analytics() {
             </div>
           ) : (
             <ReadingHeatmap logs={logs} />
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Reading habits</CardTitle>
+          <CardDescription>Patterns from your logged sessions in the last 12 months.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="h-28 animate-pulse rounded-lg border bg-muted/30" />
+              <div className="h-28 animate-pulse rounded-lg border bg-muted/30" />
+              <div className="h-36 animate-pulse rounded-lg border bg-muted/30 sm:col-span-2" />
+            </div>
+          ) : heatmapError ? (
+            <div className="space-y-3">
+              <p className="text-sm text-destructive">{heatmapError}</p>
+              <Button type="button" variant="outline" size="sm" onClick={loadHeatmapLogs}>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                Retry
+              </Button>
+            </div>
+          ) : habits.totalLogs === 0 ? (
+            <div className="rounded-lg border bg-muted/20 p-4 text-sm text-muted-foreground">
+              No reading logs in this range yet. Add progress entries to unlock reading habit insights.
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="rounded-lg border p-4">
+                <p className="text-xs text-muted-foreground">Average reading duration</p>
+                {habits.duration.averageMinutes === null ? (
+                  <p className="mt-2 text-sm text-muted-foreground">No tracked reading time yet.</p>
+                ) : (
+                  <>
+                    <p className="mt-1 text-2xl font-semibold">
+                      {formatDurationMinutes(habits.duration.averageMinutes)}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Typical session: {formatMinutesCompact(habits.duration.averageMinutes)} across{" "}
+                      {habits.duration.sessionsUsed} session
+                      {habits.duration.sessionsUsed === 1 ? "" : "s"}
+                    </p>
+                  </>
+                )}
+              </div>
+
+              <div className="rounded-lg border p-4">
+                <p className="text-xs text-muted-foreground">Average reading speed</p>
+                {habits.speed.averagePagesPerHour === null ? (
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Not enough page-progress and reading-time data for speed yet.
+                  </p>
+                ) : (
+                  <>
+                    <p className="mt-1 text-2xl font-semibold">
+                      {formatPagesPerHour(habits.speed.averagePagesPerHour)}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Weighted by reading time from {habits.speed.sessionsUsed} session
+                      {habits.speed.sessionsUsed === 1 ? "" : "s"}
+                    </p>
+                  </>
+                )}
+              </div>
+
+              <div className="rounded-lg border p-4 sm:col-span-2">
+                <p className="text-xs text-muted-foreground">Usual reading time</p>
+                <p className="mt-1 text-lg font-semibold">
+                  {habits.usualTime.dominantHourLabel
+                    ? `${habits.usualTime.dominantHourLabel} is your most common hour window`
+                    : "No dominant reading hour yet"}
+                </p>
+                <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  {habits.usualTime.dayParts.map((part) => (
+                    <div key={part.label} className="rounded-md border bg-muted/20 px-3 py-2">
+                      <p className="text-xs text-muted-foreground">{part.label}</p>
+                      <p className="text-base font-medium">{part.sessions}</p>
+                      <p className="text-[11px] text-muted-foreground">{part.percentage.toFixed(0)}% of sessions</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="rounded-lg border p-4 sm:col-span-2">
+                <p className="text-xs text-muted-foreground">Weekday patterns (average per week)</p>
+                {habits.weekdays.highest && habits.weekdays.lowest ? (
+                  <div className="mt-3 rounded-md border">
+                      <div className="grid grid-cols-[minmax(0,1fr)_5.5rem_7.5rem] gap-2 border-b bg-muted/20 px-3 py-2 text-[11px] uppercase tracking-wide text-muted-foreground">
+                        <p>Weekday</p>
+                        <p className="text-right">Min/week</p>
+                        <p className="text-right">Sessions/week</p>
+                      </div>
+                      {habits.weekdays.all.map((day) => {
+                        const isMost = day.weekdayLabel === habits.weekdays.highest?.weekdayLabel;
+                        const isLeast = day.weekdayLabel === habits.weekdays.lowest?.weekdayLabel;
+                        return (
+                          <div
+                            key={day.weekdayLabel}
+                            className="grid grid-cols-[minmax(0,1fr)_5.5rem_7.5rem] items-center gap-2 border-b bg-background px-3 py-2 text-sm last:border-b-0"
+                          >
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium">{day.weekdayLabel}</span>
+                              {isMost && isLeast ? (
+                                <Badge variant="outline" className="text-[10px]">
+                                  Most & least
+                                </Badge>
+                              ) : isMost ? (
+                                <Badge variant="outline" className="text-[10px]">
+                                  Most active
+                                </Badge>
+                              ) : isLeast ? (
+                                <Badge variant="outline" className="text-[10px]">
+                                  Least active
+                                </Badge>
+                              ) : null}
+                            </div>
+                            <p className="text-right font-medium tabular-nums">{day.avgMinutesPerWeek.toFixed(1)}</p>
+                            <p className="text-right font-medium tabular-nums">{day.avgSessionsPerWeek.toFixed(1)}</p>
+                          </div>
+                        );
+                      })}
+                  </div>
+                ) : (
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Add more reading sessions to establish weekday trends.
+                  </p>
+                )}
+              </div>
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -192,8 +192,8 @@ export default function Analytics() {
                       <p className="text-xs text-muted-foreground">
                         {part.label} ({DAY_PART_HOUR_RANGES[part.label]})
                       </p>
-                      <p className="text-base font-medium">{part.sessions}</p>
-                      <p className="text-[11px] text-muted-foreground">{part.percentage.toFixed(0)}% of sessions</p>
+                      <p className="text-base font-medium">{formatMinutesCompact(part.minutes)}</p>
+                      <p className="text-[11px] text-muted-foreground">{part.percentage.toFixed(0)}% of tracked minutes</p>
                     </div>
                   ))}
                 </div>

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -15,6 +15,13 @@ import {
 } from "@/lib/readingHabits";
 import type { ReadingLog } from "@/types";
 
+const DAY_PART_HOUR_RANGES: Record<string, string> = {
+  Morning: "06:00-11:59",
+  Afternoon: "12:00-17:59",
+  Evening: "18:00-22:59",
+  Night: "23:00-05:59",
+};
+
 function getHeatmapRangeIso(): { startIso: string; endIso: string } {
   const now = new Date();
   const endDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
@@ -176,13 +183,15 @@ export default function Analytics() {
                 <p className="text-xs text-muted-foreground">Usual reading time</p>
                 <p className="mt-1 text-lg font-semibold">
                   {habits.usualTime.dominantHourLabel
-                    ? `${habits.usualTime.dominantHourLabel} is your most common hour window`
+                    ? habits.usualTime.dominantHourLabel
                     : "No dominant reading hour yet"}
                 </p>
                 <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
                   {habits.usualTime.dayParts.map((part) => (
                     <div key={part.label} className="rounded-md border bg-muted/20 px-3 py-2">
-                      <p className="text-xs text-muted-foreground">{part.label}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {part.label} ({DAY_PART_HOUR_RANGES[part.label]})
+                      </p>
                       <p className="text-base font-medium">{part.sessions}</p>
                       <p className="text-[11px] text-muted-foreground">{part.percentage.toFixed(0)}% of sessions</p>
                     </div>

--- a/tests/readingHabits.test.ts
+++ b/tests/readingHabits.test.ts
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { calculateReadingHabits } from "../src/lib/readingHabits";
+import type { ReadingLog } from "../src/types";
+
+function makeLog(
+  id: string,
+  bookId: string,
+  loggedAt: string,
+  currentPage: number,
+  readingMinutes?: number
+): ReadingLog {
+  return {
+    id,
+    book_id: bookId,
+    user_id: "user-1",
+    current_page: currentPage,
+    reading_time_minutes: readingMinutes,
+    logged_at: loggedAt,
+  };
+}
+
+test("returns empty metrics for no logs", () => {
+  const metrics = calculateReadingHabits([], "2026-01-01T00:00:00", "2026-01-31T23:59:59");
+
+  assert.equal(metrics.totalLogs, 0);
+  assert.equal(metrics.duration.averageMinutes, null);
+  assert.equal(metrics.speed.averagePagesPerHour, null);
+  assert.equal(metrics.usualTime.dominantHourLabel, null);
+  assert.equal(metrics.weekdays.highest, null);
+  assert.equal(metrics.weekdays.lowest, null);
+});
+
+test("computes weighted speed and excludes each book's first in-range log", () => {
+  const logs: ReadingLog[] = [
+    makeLog("a1", "book-a", "2026-01-01T08:00:00", 50, 30),
+    makeLog("a2", "book-a", "2026-01-02T08:00:00", 80, 30),
+    makeLog("a3", "book-a", "2026-01-03T08:00:00", 100, 60),
+    makeLog("b1", "book-b", "2026-01-01T21:00:00", 120, 20),
+    makeLog("b2", "book-b", "2026-01-02T21:00:00", 180, 40),
+  ];
+
+  const metrics = calculateReadingHabits(logs, "2026-01-01T00:00:00", "2026-01-31T23:59:59");
+
+  assert.equal(metrics.duration.averageMinutes, 36);
+  assert.equal(metrics.duration.sessionsUsed, 5);
+
+  assert.equal(metrics.speed.sessionsUsed, 3);
+  assert.equal(metrics.speed.totalPages, 110);
+  assert.ok(metrics.speed.totalHours);
+  assert.ok(metrics.speed.averagePagesPerHour);
+  assert.equal(metrics.speed.totalHours.toFixed(2), "2.17");
+  assert.equal(metrics.speed.averagePagesPerHour.toFixed(1), "50.8");
+});
+
+test("ignores zero minutes and non-positive page deltas for speed", () => {
+  const logs: ReadingLog[] = [
+    makeLog("a1", "book-a", "2026-01-01T10:00:00", 50, 25),
+    makeLog("a2", "book-a", "2026-01-02T10:00:00", 60, 0),
+    makeLog("a3", "book-a", "2026-01-03T10:00:00", 58, 20),
+    makeLog("a4", "book-a", "2026-01-04T10:00:00", 70, 30),
+  ];
+
+  const metrics = calculateReadingHabits(logs, "2026-01-01T00:00:00", "2026-01-31T23:59:59");
+
+  assert.equal(metrics.speed.sessionsUsed, 1);
+  assert.equal(metrics.speed.totalPages, 12);
+  assert.equal(metrics.speed.totalHours, 0.5);
+  assert.equal(metrics.speed.averagePagesPerHour, 24);
+});
+
+test("computes usual reading time and dominant hour in local time", () => {
+  const logs: ReadingLog[] = [
+    makeLog("l1", "book-a", "2026-01-01T06:15:00", 10, 15),
+    makeLog("l2", "book-a", "2026-01-02T06:45:00", 20, 15),
+    makeLog("l3", "book-a", "2026-01-03T13:00:00", 30, 15),
+    makeLog("l4", "book-a", "2026-01-04T20:30:00", 40, 15),
+    makeLog("l5", "book-a", "2026-01-05T23:30:00", 50, 15),
+  ];
+
+  const metrics = calculateReadingHabits(logs, "2026-01-01T00:00:00", "2026-01-31T23:59:59");
+  const morning = metrics.usualTime.dayParts.find((part) => part.label === "Morning");
+
+  assert.equal(metrics.usualTime.dominantHourLabel, "06:00-07:00");
+  assert.ok(morning);
+  assert.equal(morning?.sessions, 2);
+  assert.equal(Math.round(morning?.percentage ?? 0), 40);
+});
+
+test("normalizes weekday metrics per week and uses sessions as tie-breaker", () => {
+  const logs: ReadingLog[] = [
+    makeLog("m1", "book-a", "2026-01-05T09:00:00", 10, 30),
+    makeLog("m2", "book-a", "2026-01-05T20:00:00", 20, 30),
+    makeLog("t1", "book-a", "2026-01-06T09:00:00", 30, 30),
+    makeLog("w1", "book-a", "2026-01-07T09:00:00", 40, 10),
+  ];
+
+  const metrics = calculateReadingHabits(logs, "2026-01-01T00:00:00", "2026-01-31T23:59:59");
+
+  assert.equal(metrics.weekdays.highest?.weekdayLabel, "Monday");
+  assert.equal(metrics.weekdays.lowest?.weekdayLabel, "Thursday");
+  assert.ok(metrics.weekdays.weekSpan > 4);
+});

--- a/tests/readingHabits.test.ts
+++ b/tests/readingHabits.test.ts
@@ -83,8 +83,20 @@ test("computes usual reading time and dominant hour in local time", () => {
 
   assert.equal(metrics.usualTime.dominantHourLabel, "06:00-07:00");
   assert.ok(morning);
-  assert.equal(morning?.sessions, 2);
+  assert.equal(morning?.minutes, 30);
   assert.equal(Math.round(morning?.percentage ?? 0), 40);
+});
+
+test("splits reading minutes across day-part boundaries", () => {
+  const logs: ReadingLog[] = [makeLog("l1", "book-a", "2026-01-08T18:15:00", 120, 30)];
+
+  const metrics = calculateReadingHabits(logs, "2026-01-01T00:00:00", "2026-01-31T23:59:59");
+  const afternoon = metrics.usualTime.dayParts.find((part) => part.label === "Afternoon");
+  const evening = metrics.usualTime.dayParts.find((part) => part.label === "Evening");
+
+  assert.equal(afternoon?.minutes, 15);
+  assert.equal(evening?.minutes, 15);
+  assert.equal(metrics.usualTime.dominantHourLabel, "17:00-18:00");
 });
 
 test("normalizes weekday metrics per week and uses sessions as tie-breaker", () => {

--- a/tests/readingHabits.test.ts
+++ b/tests/readingHabits.test.ts
@@ -111,5 +111,5 @@ test("normalizes weekday metrics per week and uses sessions as tie-breaker", () 
 
   assert.equal(metrics.weekdays.highest?.weekdayLabel, "Monday");
   assert.equal(metrics.weekdays.lowest?.weekdayLabel, "Thursday");
-  assert.ok(metrics.weekdays.weekSpan > 4);
+  assert.equal(metrics.weekdays.weekSpan.toFixed(2), "3.86");
 });


### PR DESCRIPTION
## Summary
- add a new Reading Habits section on `Analytics` with average session duration, weighted reading speed, usual reading time, and weekday patterns
- add memoized reading-habit metric utilities with local-time grouping and deterministic handling of empty/partial log data
- add unit tests for reading-habit calculations and a `test` npm script using Node's built-in test runner via `tsx`

## Testing
- npm run typecheck
- npm run test

Closes #74