### PR TITLE
feat: support multiple authors per book

### DIFF
--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -23,12 +23,17 @@ import {
 } from "@/components/ui/select";
 import { useBooksContext } from "@/context/BooksContext";
 import { useSeries } from "@/hooks/useSeries";
-import { formatGenresInput, parseGenresInput } from "@/lib/utils";
+import {
+  formatAuthorsInput,
+  formatGenresInput,
+  parseAuthorsInput,
+  parseGenresInput,
+} from "@/lib/utils";
 import type { BookStatus, BookLanguage, BookBelongsTo, BookFormat } from "@/types";
 
 interface FormValues {
   title: string;
-  author: string;
+  authorsInput: string;
   status: BookStatus;
   genresInput: string;
   language: BookLanguage | "";
@@ -85,7 +90,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
     clearErrors,
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
-    defaultValues: { status: "Not Started" },
+    defaultValues: { status: "Not Started", authorsInput: "" },
   });
 
   const status = watch("status");
@@ -134,7 +139,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
 
       setScannedIsbn(isbn.trim());
       setValue("title", bookData.title);
-      setValue("author", bookData.author);
+      setValue("authorsInput", formatAuthorsInput(bookData.authors), { shouldValidate: true });
       if (bookData.totalPages) setValue("total_pages", String(bookData.totalPages));
       if (bookData.genres) setValue("genresInput", formatGenresInput(bookData.genres));
       if (bookData.language) setValue("language", bookData.language as BookLanguage);
@@ -187,11 +192,16 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
 
   async function onSubmit(values: FormValues) {
     try {
+      const authors = parseAuthorsInput(values.authorsInput);
+      if (authors.length === 0) {
+        setError("authorsInput", { message: "At least one author is required" });
+        return;
+      }
       const genres = parseGenresInput(values.genresInput);
       await addBook(
         {
           title: values.title,
-          author: values.author,
+          authors,
           status: values.status,
           genres: genres.length > 0 ? genres : undefined,
           language: (values.language as BookLanguage) || undefined,
@@ -357,16 +367,19 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
                 )}
               </div>
 
-              {/* Author */}
+              {/* Authors */}
               <div className="space-y-1.5">
-                <Label htmlFor="author">Author *</Label>
+                <Label htmlFor="authorsInput">Authors *</Label>
                 <Input
-                  id="author"
-                  {...register("author", { required: "Author is required" })}
-                  aria-invalid={!!errors.author}
+                  id="authorsInput"
+                  {...register("authorsInput", {
+                    validate: (value) =>
+                      parseAuthorsInput(value).length > 0 || "At least one author is required",
+                  })}
+                  aria-invalid={!!errors.authorsInput}
                 />
-                {errors.author && (
-                  <p className="text-xs text-destructive">{errors.author.message}</p>
+                {errors.authorsInput && (
+                  <p className="text-xs text-destructive">{errors.authorsInput.message}</p>
                 )}
               </div>
 

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -64,7 +64,7 @@ export default function BookCard({
 
       <CardContent className="p-2 space-y-1">
         <p className="text-sm font-medium leading-tight line-clamp-2">{book.title}</p>
-        <p className="text-xs text-muted-foreground line-clamp-1">{book.author}</p>
+        <p className="text-xs text-muted-foreground line-clamp-1">{book.authors.join(", ")}</p>
         <GenreTags
           genres={book.genres}
           className="gap-x-2 gap-y-1"

--- a/src/lib/bookLookup.ts
+++ b/src/lib/bookLookup.ts
@@ -1,6 +1,6 @@
 export interface BookLookupResult {
   title: string;
-  author: string;
+  authors: string[];
   totalPages?: number;
   genres?: string[];
   language?: string;
@@ -61,10 +61,13 @@ export async function fetchBookByISBN(
   if (!items || items.length === 0) return null;
 
   const info = items[0].volumeInfo;
+  const authors = Array.from(
+    new Set((info.authors ?? []).map((author) => author.trim()).filter(Boolean)),
+  );
 
   return {
     title: info.title ?? "Untitled",
-    author: info.authors?.[0] ?? "Unknown",
+    authors: authors.length > 0 ? authors : ["Unknown"],
     totalPages: info.pageCount,
     genres: info.categories?.map((genre) => genre.trim()).filter(Boolean),
     language: info.language ? languageMap[info.language] : undefined,

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -1,7 +1,11 @@
 import { supabase } from "./supabase";
 import type { Book, Series, ReadingLog } from "@/types";
 
-type LegacyBookRow = Book & { genre?: string | null };
+type LegacyAuthorBookRow = Omit<Book, "authors"> & {
+  authors?: string[] | null;
+  author?: string | null;
+  genre?: string | null;
+};
 
 function parseLegacyGenre(genre?: string | null): string[] | undefined {
   if (!genre) return undefined;
@@ -12,10 +16,32 @@ function parseLegacyGenre(genre?: string | null): string[] | undefined {
   return parsed.length > 0 ? Array.from(new Set(parsed)) : undefined;
 }
 
-function normalizeBook(row: LegacyBookRow): Book {
+function parseLegacyAuthorList(author?: string | null): string[] {
+  if (!author) return [];
+  return Array.from(
+    new Set(
+      author
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function normalizeBook(row: LegacyAuthorBookRow): Book {
   const genres = row.genres ?? parseLegacyGenre(row.genre);
+  const normalizedAuthors = row.authors?.map((value) => value.trim()).filter(Boolean) ?? [];
+  const legacyAuthors = parseLegacyAuthorList(row.author);
+  const authors =
+    normalizedAuthors.length > 0
+      ? normalizedAuthors
+      : legacyAuthors.length > 0
+        ? legacyAuthors
+        : ["Unknown"];
+
   return {
     ...row,
+    authors,
     genres,
   };
 }
@@ -34,6 +60,28 @@ function isMissingGenresColumnError(error: unknown): boolean {
   return message.toLowerCase().includes("genres") && message.toLowerCase().includes("column");
 }
 
+function toLegacyAuthorPayload<T extends { authors?: string[] }>(
+  payload: T,
+): Omit<T, "authors"> & { author?: string } {
+  const { authors, ...rest } = payload;
+  if (!authors) {
+    return {
+      ...rest,
+    };
+  }
+
+  return {
+    ...rest,
+    author: authors.join(", "),
+  };
+}
+
+function isMissingAuthorsColumnError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const message = "message" in error ? String((error as { message: unknown }).message) : "";
+  return message.toLowerCase().includes("authors") && message.toLowerCase().includes("column");
+}
+
 // ── Books ──────────────────────────────────────────────────────────────────
 
 export async function fetchBooks(): Promise<Book[]> {
@@ -42,7 +90,7 @@ export async function fetchBooks(): Promise<Book[]> {
     .select("*")
     .order("created_at", { ascending: false });
   if (error) throw error;
-  return ((data ?? []) as LegacyBookRow[]).map(normalizeBook);
+  return ((data ?? []) as LegacyAuthorBookRow[]).map(normalizeBook);
 }
 
 export type BookInsert = Omit<Book, "created_at">;
@@ -53,7 +101,17 @@ export async function createBook(payload: BookInsert): Promise<Book> {
     .insert(payload)
     .select()
     .single();
-  if (!error) return normalizeBook(data as LegacyBookRow);
+  if (!error) return normalizeBook(data as LegacyAuthorBookRow);
+
+  if (isMissingAuthorsColumnError(error)) {
+    const { data: legacyData, error: legacyError } = await supabase
+      .from("books")
+      .insert(toLegacyAuthorPayload(payload))
+      .select()
+      .single();
+    if (legacyError) throw legacyError;
+    return normalizeBook(legacyData as LegacyAuthorBookRow);
+  }
 
   if (!isMissingGenresColumnError(error)) throw error;
 
@@ -63,7 +121,7 @@ export async function createBook(payload: BookInsert): Promise<Book> {
     .select()
     .single();
   if (legacyError) throw legacyError;
-  return normalizeBook(legacyData as LegacyBookRow);
+  return normalizeBook(legacyData as LegacyAuthorBookRow);
 }
 
 export async function updateBook(
@@ -76,7 +134,18 @@ export async function updateBook(
     .eq("id", id)
     .select()
     .single();
-  if (!error) return normalizeBook(data as LegacyBookRow);
+  if (!error) return normalizeBook(data as LegacyAuthorBookRow);
+
+  if (isMissingAuthorsColumnError(error)) {
+    const { data: legacyData, error: legacyError } = await supabase
+      .from("books")
+      .update(toLegacyAuthorPayload(payload))
+      .eq("id", id)
+      .select()
+      .single();
+    if (legacyError) throw legacyError;
+    return normalizeBook(legacyData as LegacyAuthorBookRow);
+  }
 
   if (!isMissingGenresColumnError(error)) throw error;
 
@@ -87,7 +156,7 @@ export async function updateBook(
     .select()
     .single();
   if (legacyError) throw legacyError;
-  return normalizeBook(legacyData as LegacyBookRow);
+  return normalizeBook(legacyData as LegacyAuthorBookRow);
 }
 
 export async function deleteBook(id: string): Promise<void> {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -29,3 +29,18 @@ export function parseGenresInput(input: string): string[] {
 export function formatGenresInput(genres?: string[]): string {
   return genres?.join(", ") ?? ""
 }
+
+export function parseAuthorsInput(input: string): string[] {
+  return Array.from(
+    new Set(
+      input
+        .split(/[\n,]/)
+        .map((author) => author.trim())
+        .filter(Boolean)
+    )
+  )
+}
+
+export function formatAuthorsInput(authors?: string[]): string {
+  return authors?.join(", ") ?? ""
+}

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -26,7 +26,13 @@ import {
 } from "@/components/ui/select";
 import { useBooksContext } from "@/context/BooksContext";
 import { useSeries } from "@/hooks/useSeries";
-import { formatGenresInput, parseGenresInput, statusVariant } from "@/lib/utils";
+import {
+  formatAuthorsInput,
+  formatGenresInput,
+  parseAuthorsInput,
+  parseGenresInput,
+  statusVariant,
+} from "@/lib/utils";
 import ReadingProgressDialog from "@/components/ReadingProgressDialog";
 import BookAnalyticsPanel from "@/components/BookAnalyticsPanel";
 import GenreTags from "@/components/GenreTags";
@@ -40,7 +46,7 @@ import type {
 
 interface FormValues {
   title: string;
-  author: string;
+  authorsInput: string;
   status: BookStatus;
   genresInput: string;
   isbn: string;
@@ -66,7 +72,7 @@ const STATUS_OPTIONS: BookStatus[] = [
 function bookToFormValues(book: Book): FormValues {
   return {
     title: book.title,
-    author: book.author,
+    authorsInput: formatAuthorsInput(book.authors),
     status: book.status,
     genresInput: formatGenresInput(book.genres),
     isbn: book.isbn ?? "",
@@ -108,7 +114,7 @@ export default function BookDetails() {
     handleSubmit,
     watch,
     reset,
-    formState: { isDirty, dirtyFields },
+    formState: { isDirty, dirtyFields, errors },
   } = useForm<FormValues>();
 
   useEffect(() => {
@@ -182,7 +188,14 @@ export default function BookDetails() {
     const payload: Partial<Book> = {};
 
     if (dirtyFields.title) payload.title = values.title;
-    if (dirtyFields.author) payload.author = values.author;
+    if (dirtyFields.authorsInput) {
+      const authors = parseAuthorsInput(values.authorsInput);
+      if (authors.length === 0) {
+        setErrorMsg("At least one author is required");
+        return;
+      }
+      payload.authors = authors;
+    }
     if (dirtyFields.status) payload.status = values.status;
     if (dirtyFields.genresInput) {
       const genres = parseGenresInput(values.genresInput);
@@ -329,7 +342,7 @@ export default function BookDetails() {
             )}
 
             <h1 className="text-3xl font-semibold leading-tight">{book.title}</h1>
-            <p className="text-base text-muted-foreground">{book.author}</p>
+            <p className="text-base text-muted-foreground">{book.authors.join(", ")}</p>
 
             {book.isbn && (
               <a
@@ -446,12 +459,18 @@ export default function BookDetails() {
                   </div>
 
                   <div className="space-y-1.5 md:col-span-2">
-                    <Label htmlFor="detail-author">Author</Label>
+                    <Label htmlFor="detail-authors">Authors</Label>
                     <Input
-                      id="detail-author"
+                      id="detail-authors"
                       readOnly={!isEditMode}
-                      {...register("author", { required: true })}
+                      {...register("authorsInput", {
+                        validate: (value) =>
+                          parseAuthorsInput(value).length > 0 || "At least one author is required",
+                      })}
                     />
+                    {errors.authorsInput && (
+                      <p className="text-xs text-destructive">{errors.authorsInput.message}</p>
+                    )}
                   </div>
 
                   <div className="space-y-1.5">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,7 +23,7 @@ export interface Series {
 export interface Book {
   id: string;
   title: string;
-  author: string;
+  authors: string[];
   genres?: string[];
   status: BookStatus;
   cover_url?: string;

--- a/supabase/migrations/20260421_books_authors_array.sql
+++ b/supabase/migrations/20260421_books_authors_array.sql
@@ -1,0 +1,35 @@
+ALTER TABLE public.books
+ADD COLUMN IF NOT EXISTS authors text[];
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'books'
+      AND column_name = 'author'
+  ) THEN
+    UPDATE public.books
+    SET authors = ARRAY[btrim(author)]
+    WHERE (authors IS NULL OR cardinality(authors) = 0)
+      AND author IS NOT NULL
+      AND btrim(author) <> '';
+  END IF;
+END $$;
+
+UPDATE public.books
+SET authors = ARRAY['Unknown']
+WHERE authors IS NULL OR cardinality(authors) = 0;
+
+ALTER TABLE public.books
+ALTER COLUMN authors SET NOT NULL;
+
+ALTER TABLE public.books
+DROP CONSTRAINT IF EXISTS books_authors_non_empty;
+
+ALTER TABLE public.books
+ADD CONSTRAINT books_authors_non_empty CHECK (cardinality(authors) > 0);
+
+ALTER TABLE public.books
+DROP COLUMN IF EXISTS author;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS books (
   id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   title           text NOT NULL,
-  author          text NOT NULL,
+  authors         text[] NOT NULL CHECK (cardinality(authors) > 0),
   genres          text[],
   status          text NOT NULL DEFAULT 'Wishlist'
                     CHECK (status IN ('Wishlist','Not Started','Up Next','Reading','Finished','DNF')),


### PR DESCRIPTION
## Summary
- migrate the `books` model from single `author` text to `authors` arrays, including a Supabase migration that backfills existing rows and enforces non-empty author lists
- update create/edit/detail/card flows to read and write multiple authors while keeping the UX as a single comma/newline-separated input
- map all ISBN lookup authors, add shared parse/format helpers, and keep legacy fallback handling so save flows still work before migration rollout

## Testing
- npm run typecheck
- npm test