### PR TITLE
feat: add time-based stats to book analytics tab

### DIFF
--- a/src/components/BookAnalyticsPanel.tsx
+++ b/src/components/BookAnalyticsPanel.tsx
@@ -3,6 +3,12 @@ import { BarChart3 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { fetchReadingLogsForBook } from "@/lib/books";
+import {
+  formatCalendarSpan,
+  formatTotalReadingTime,
+  getReadingDuration,
+  sumReadingMinutes,
+} from "@/lib/bookAnalytics";
 import type { Book, ReadingLog } from "@/types";
 
 interface BookAnalyticsPanelProps {
@@ -153,6 +159,27 @@ export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
     [chartPoints]
   );
 
+  const totalReadingMinutes = useMemo(() => sumReadingMinutes(logs), [logs]);
+
+  const totalReadingTimeLabel = useMemo(
+    () => formatTotalReadingTime(totalReadingMinutes),
+    [totalReadingMinutes]
+  );
+
+  const readingDuration = useMemo(
+    () =>
+      getReadingDuration({
+        dateStarted: book.date_started,
+        dateFinished: book.date_finished,
+      }),
+    [book.date_finished, book.date_started]
+  );
+
+  const readingDurationLabel = useMemo(() => {
+    if (!readingDuration.isAvailable || !readingDuration.span) return "Not available";
+    return formatCalendarSpan(readingDuration.span);
+  }, [readingDuration.isAvailable, readingDuration.span]);
+
   const activeDays = useMemo(
     () => chartPoints.filter((point) => point.pagesRead > 0).length,
     [chartPoints]
@@ -227,6 +254,25 @@ export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
   return (
     <ScrollArea className="flex-1 min-h-0 pr-2">
       <div className="space-y-3 py-2">
+      <section className="rounded-lg border bg-muted/20 p-3">
+        <p className="text-sm font-medium">Time-based stats</p>
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          <div className="rounded-md border bg-background/80 px-2 py-2">
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              Total time spent reading
+            </p>
+            <p className="mt-1 text-sm font-medium">{totalReadingTimeLabel}</p>
+          </div>
+          <div className="rounded-md border bg-background/80 px-2 py-2">
+            <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Reading duration</p>
+            <p className="mt-1 text-sm font-medium">{readingDurationLabel}</p>
+            {readingDuration.isAvailable && readingDuration.isInProgress && (
+              <p className="mt-0.5 text-xs text-muted-foreground">In progress (to today)</p>
+            )}
+          </div>
+        </div>
+      </section>
+
       <section className="rounded-lg border bg-muted/20 p-3 space-y-3">
         <div>
           <p className="text-sm font-medium">Pages read per day</p>

--- a/src/lib/bookAnalytics.ts
+++ b/src/lib/bookAnalytics.ts
@@ -1,0 +1,149 @@
+import type { ReadingLog } from "@/types";
+
+export interface CalendarSpan {
+  months: number;
+  weeks: number;
+  days: number;
+}
+
+export interface ReadingDurationResult {
+  isAvailable: boolean;
+  isInProgress: boolean;
+  span: CalendarSpan | null;
+}
+
+function isValidDate(date: Date): boolean {
+  return !Number.isNaN(date.getTime());
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function addMonthsClamped(date: Date, months: number): Date {
+  const targetYear = date.getFullYear();
+  const targetMonthIndex = date.getMonth() + months;
+
+  const firstOfTargetMonth = new Date(targetYear, targetMonthIndex, 1);
+  const lastDayOfTargetMonth = new Date(
+    firstOfTargetMonth.getFullYear(),
+    firstOfTargetMonth.getMonth() + 1,
+    0
+  ).getDate();
+
+  const day = Math.min(date.getDate(), lastDayOfTargetMonth);
+  return new Date(firstOfTargetMonth.getFullYear(), firstOfTargetMonth.getMonth(), day);
+}
+
+export function parseLocalDateOnly(value?: string): Date | null {
+  if (!value) return null;
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  const parsed = new Date(year, monthIndex, day);
+  if (!isValidDate(parsed)) return null;
+  if (parsed.getFullYear() !== year || parsed.getMonth() !== monthIndex || parsed.getDate() !== day) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function sumReadingMinutes(logs: ReadingLog[]): number {
+  return logs.reduce((sum, log) => {
+    const minutes = log.reading_time_minutes;
+    if (typeof minutes !== "number" || !Number.isFinite(minutes) || minutes <= 0) return sum;
+    return sum + Math.round(minutes);
+  }, 0);
+}
+
+export function formatTotalReadingTime(totalMinutes: number): string {
+  if (totalMinutes <= 0) return "No sessions logged";
+
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+
+  return parts.join(" ");
+}
+
+export function calculateCalendarSpan(startDate: Date, endDate: Date): CalendarSpan {
+  const start = startOfLocalDay(startDate);
+  const end = startOfLocalDay(endDate);
+
+  if (!isValidDate(start) || !isValidDate(end) || end < start) {
+    return { months: 0, weeks: 0, days: 0 };
+  }
+
+  let months = 0;
+  let cursor = start;
+
+  while (true) {
+    const nextMonth = addMonthsClamped(cursor, 1);
+    if (nextMonth <= end) {
+      months += 1;
+      cursor = nextMonth;
+      continue;
+    }
+    break;
+  }
+
+  const remainingMs = end.getTime() - cursor.getTime();
+  const remainingDays = Math.floor(remainingMs / (24 * 60 * 60 * 1000));
+  const weeks = Math.floor(remainingDays / 7);
+  const days = remainingDays % 7;
+
+  return { months, weeks, days };
+}
+
+export function formatCalendarSpan(span: CalendarSpan): string {
+  const parts: string[] = [];
+
+  if (span.months > 0) parts.push(`${span.months} month${span.months === 1 ? "" : "s"}`);
+  if (span.weeks > 0) parts.push(`${span.weeks} week${span.weeks === 1 ? "" : "s"}`);
+  if (span.days > 0) parts.push(`${span.days} day${span.days === 1 ? "" : "s"}`);
+
+  return parts.length > 0 ? parts.join(" ") : "0 days";
+}
+
+export function getReadingDuration(params: {
+  dateStarted?: string;
+  dateFinished?: string;
+  now?: Date;
+}): ReadingDurationResult {
+  const started = parseLocalDateOnly(params.dateStarted);
+  if (!started) {
+    return {
+      isAvailable: false,
+      isInProgress: false,
+      span: null,
+    };
+  }
+
+  const finished = parseLocalDateOnly(params.dateFinished);
+  const isInProgress = !finished;
+  const fallbackNow = params.now ?? new Date();
+  const endDate = finished ?? startOfLocalDay(fallbackNow);
+
+  if (!isValidDate(endDate) || endDate < started) {
+    return {
+      isAvailable: false,
+      isInProgress,
+      span: null,
+    };
+  }
+
+  return {
+    isAvailable: true,
+    isInProgress,
+    span: calculateCalendarSpan(started, endDate),
+  };
+}

--- a/tests/bookAnalytics.test.ts
+++ b/tests/bookAnalytics.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatCalendarSpan,
+  formatTotalReadingTime,
+  getReadingDuration,
+  sumReadingMinutes,
+} from "../src/lib/bookAnalytics";
+import type { ReadingLog } from "../src/types";
+
+function makeLog(id: string, minutes?: number): ReadingLog {
+  return {
+    id,
+    book_id: "book-1",
+    user_id: "user-1",
+    current_page: 10,
+    reading_time_minutes: minutes,
+    logged_at: "2026-04-01T12:00:00",
+  };
+}
+
+test("sums reading minutes and formats with days, hours, and minutes", () => {
+  const logs: ReadingLog[] = [makeLog("a", 60), makeLog("b", 24 * 60), makeLog("c", 15)];
+  const total = sumReadingMinutes(logs);
+
+  assert.equal(total, 1515);
+  assert.equal(formatTotalReadingTime(total), "1d 1h 15m");
+});
+
+test("handles missing or zero reading minutes as no sessions logged", () => {
+  const logs: ReadingLog[] = [makeLog("a"), makeLog("b", 0), makeLog("c", -10)];
+  const total = sumReadingMinutes(logs);
+
+  assert.equal(total, 0);
+  assert.equal(formatTotalReadingTime(total), "No sessions logged");
+});
+
+test("computes reading duration for a finished book", () => {
+  const duration = getReadingDuration({
+    dateStarted: "2026-01-15",
+    dateFinished: "2026-03-05",
+  });
+
+  assert.equal(duration.isAvailable, true);
+  assert.equal(duration.isInProgress, false);
+  assert.deepEqual(duration.span, { months: 1, weeks: 2, days: 4 });
+  assert.equal(formatCalendarSpan(duration.span!), "1 month 2 weeks 4 days");
+});
+
+test("computes in-progress reading duration to provided current date", () => {
+  const duration = getReadingDuration({
+    dateStarted: "2026-04-01",
+    now: new Date("2026-04-20T09:30:00"),
+  });
+
+  assert.equal(duration.isAvailable, true);
+  assert.equal(duration.isInProgress, true);
+  assert.deepEqual(duration.span, { months: 0, weeks: 2, days: 5 });
+  assert.equal(formatCalendarSpan(duration.span!), "2 weeks 5 days");
+});
+
+test("returns unavailable when start date is missing or invalid range", () => {
+  const missingStart = getReadingDuration({ dateFinished: "2026-04-20" });
+  const reversed = getReadingDuration({
+    dateStarted: "2026-04-20",
+    dateFinished: "2026-04-10",
+  });
+
+  assert.equal(missingStart.isAvailable, false);
+  assert.equal(missingStart.span, null);
+
+  assert.equal(reversed.isAvailable, false);
+  assert.equal(reversed.span, null);
+});


### PR DESCRIPTION
## Summary
- add book-level analytics helpers for total reading time aggregation and calendar-span duration formatting, including safe local date parsing
- surface new Time-based stats in the Book Analytics panel for total time spent reading and reading duration, with clear in-progress and missing-data states
- add unit tests covering total-time formatting, finished/in-progress duration spans, and invalid or missing date edge cases

## Testing
- npm run test
- npm run typecheck

Closes #80