### PR TITLE
Add light/dark/system theme switcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,31 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <title>Reading Journal</title>
+    <script>
+      (function () {
+        var storageKey = "reading-journal-theme";
+        var root = document.documentElement;
+        var storedTheme;
+
+        try {
+          storedTheme = localStorage.getItem(storageKey);
+        } catch {
+          storedTheme = null;
+        }
+
+        var theme =
+          storedTheme === "light" || storedTheme === "dark" || storedTheme === "system"
+            ? storedTheme
+            : "system";
+        var prefersDark =
+          typeof window.matchMedia === "function" &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var resolvedTheme = theme === "system" ? (prefersDark ? "dark" : "light") : theme;
+
+        root.classList.toggle("dark", resolvedTheme === "dark");
+        root.style.colorScheme = resolvedTheme;
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
 import { RouterProvider } from "react-router-dom";
-import { AuthProvider } from "@/context";
+import { AuthProvider, ThemeProvider } from "@/context";
 import { router } from "@/lib/router";
 
 export default function App() {
   return (
-    <AuthProvider>
-      <RouterProvider router={router} />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <RouterProvider router={router} />
+      </AuthProvider>
+    </ThemeProvider>
   );
 }

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -7,10 +7,13 @@ import {
   Library,
   KeyRound,
   BarChart3,
+  Monitor,
+  Sun,
+  Moon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { BooksProvider } from "@/context/BooksContext";
-import { useAuth } from "@/context";
+import { useAuth, useTheme } from "@/context";
 import AddBookDialog from "./AddBookDialog";
 import SetPasswordDialog from "./SetPasswordDialog";
 import { cn } from "@/lib/utils";
@@ -22,11 +25,25 @@ const navLinks = [
   { to: "/analytics", label: "Analytics", icon: BarChart3 },
 ];
 
+const themeCycle = ["system", "light", "dark"] as const;
+
 export default function AppLayout() {
   const { signOut } = useAuth();
+  const { theme, setTheme } = useTheme();
   const location = useLocation();
   const [addBookOpen, setAddBookOpen] = useState(false);
   const [passwordOpen, setPasswordOpen] = useState(false);
+
+  const currentThemeIndex = themeCycle.indexOf(theme);
+  const nextTheme = themeCycle[(currentThemeIndex + 1) % themeCycle.length];
+
+  const ThemeIcon =
+    theme === "light" ? Sun : theme === "dark" ? Moon : Monitor;
+
+  const currentThemeLabel =
+    theme === "system" ? "System" : theme === "light" ? "Light" : "Dark";
+  const nextThemeLabel =
+    nextTheme === "system" ? "System" : nextTheme === "light" ? "Light" : "Dark";
 
   return (
     <BooksProvider>
@@ -42,7 +59,7 @@ export default function AppLayout() {
               <img
                 src={readingJournalLogo}
                 alt="Reading Journal logo"
-                className="h-6 w-6 rounded-sm object-cover"
+                className="h-6 w-6 rounded-sm object-cover dark:brightness-0 dark:invert"
               />
               <span className="hidden sm:inline">Reading Journal</span>
             </Link>
@@ -87,6 +104,15 @@ export default function AppLayout() {
                 aria-label="Set password"
               >
                 <KeyRound className="h-5 w-5" />
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={() => setTheme(nextTheme)}
+                aria-label={`Theme: ${currentThemeLabel}. Switch to ${nextThemeLabel}.`}
+                title={`Theme: ${currentThemeLabel} (click to switch to ${nextThemeLabel})`}
+              >
+                <ThemeIcon className="h-5 w-5" />
               </Button>
               <Button
                 size="icon"

--- a/src/components/GenreTags.tsx
+++ b/src/components/GenreTags.tsx
@@ -24,8 +24,8 @@ export default function GenreTags({
         <span
           key={genre}
           className={cn(
-            "inline-flex pb-0.5 text-sm font-semibold leading-none text-black transition-shadow duration-150",
-            "shadow-[inset_0_-1px_0_0_rgb(0_0_0)] hover:shadow-[inset_0_-2px_0_0_rgb(0_0_0)]",
+            "inline-flex pb-0.5 text-sm font-semibold leading-none text-foreground transition-shadow duration-150",
+            "shadow-[inset_0_-1px_0_0_currentColor] hover:shadow-[inset_0_-2px_0_0_currentColor]",
             tagClassName
           )}
         >

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,104 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type Theme = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
+
+const THEME_STORAGE_KEY = "reading-journal-theme";
+const SYSTEM_THEME_QUERY = "(prefers-color-scheme: dark)";
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function isTheme(value: string | null): value is Theme {
+  return value === "light" || value === "dark" || value === "system";
+}
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === "undefined") return "light";
+  return window.matchMedia(SYSTEM_THEME_QUERY).matches ? "dark" : "light";
+}
+
+function getStoredTheme(): Theme {
+  if (typeof window === "undefined") return "system";
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return isTheme(stored) ? stored : "system";
+  } catch {
+    return "system";
+  }
+}
+
+function applyThemeToDocument(theme: ResolvedTheme) {
+  const root = document.documentElement;
+  root.classList.toggle("dark", theme === "dark");
+  root.style.colorScheme = theme;
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => getStoredTheme());
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() => getSystemTheme());
+
+  const resolvedTheme = theme === "system" ? systemTheme : theme;
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(SYSTEM_THEME_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(event.matches ? "dark" : "light");
+    };
+
+    setSystemTheme(mediaQuery.matches ? "dark" : "light");
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    applyThemeToDocument(resolvedTheme);
+  }, [resolvedTheme]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      return;
+    }
+  }, [theme]);
+
+  const setThemeValue = useCallback((nextTheme: Theme) => {
+    setTheme(nextTheme);
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      resolvedTheme,
+      setTheme: setThemeValue,
+    }),
+    [theme, resolvedTheme, setThemeValue]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within <ThemeProvider>");
+  }
+  return context;
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,3 +1,4 @@
 export { AuthProvider, useAuth } from "./AuthContext";
 export { BooksProvider, useBooksContext } from "./BooksContext";
-
+export { ThemeProvider, useTheme } from "./ThemeContext";
+export type { Theme } from "./ThemeContext";


### PR DESCRIPTION
## Summary
- add a global `ThemeProvider` with `light`, `dark`, and `system` modes persisted in local storage
- add an icon-only header theme toggle that cycles modes and updates the app-wide appearance immediately
- apply theme on first paint via an `index.html` bootstrap script to prevent flicker, and fix genre tag contrast in dark mode

## Testing
- npm run typecheck
- npm run build

Closes #79