### PR TITLE
feat: improve reading activity heatmap history navigation

### DIFF
--- a/src/components/ReadingHeatmap.tsx
+++ b/src/components/ReadingHeatmap.tsx
@@ -1,4 +1,6 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import type { ReadingLog } from "@/types";
 import { cn } from "@/lib/utils";
 
@@ -16,6 +18,9 @@ interface HeatmapCell {
   inRange: boolean;
 }
 
+const WINDOW_MONTHS = 12;
+const PAGE_MONTHS = 12;
+
 function toLocalDayKey(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -27,10 +32,22 @@ function startOfLocalDay(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
+function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+function endOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+}
+
 function addDays(date: Date, days: number): Date {
   const next = new Date(date);
   next.setDate(next.getDate() + days);
   return next;
+}
+
+function addMonths(date: Date, months: number): Date {
+  return new Date(date.getFullYear(), date.getMonth() + months, 1);
 }
 
 function getIntensityLevel(minutes: number): 0 | 1 | 2 | 3 | 4 {
@@ -49,36 +66,59 @@ function formatDate(date: Date): string {
   });
 }
 
-function buildRange() {
-  const today = startOfLocalDay(new Date());
-  const start = new Date(today);
-  start.setFullYear(start.getFullYear() - 1);
-  start.setDate(start.getDate() + 1);
-  return { start, end: today };
+function clampMonthStart(date: Date, min: Date, max: Date): Date {
+  if (date.getTime() < min.getTime()) return min;
+  if (date.getTime() > max.getTime()) return max;
+  return startOfMonth(date);
+}
+
+function getOldestLogMonth(logs: ReadingLog[], fallback: Date): Date {
+  if (logs.length === 0) return fallback;
+  let oldest = new Date(logs[0].logged_at);
+  for (const log of logs) {
+    const loggedAt = new Date(log.logged_at);
+    if (loggedAt.getTime() < oldest.getTime()) {
+      oldest = loggedAt;
+    }
+  }
+  return startOfMonth(oldest);
 }
 
 export default function ReadingHeatmap({ logs }: ReadingHeatmapProps) {
   const columnWidthPx = 16;
-  const { weeks, monthLabels, hasAnyReading } = useMemo(() => {
-    const { start, end } = buildRange();
+  const currentMonthStart = useMemo(() => startOfMonth(new Date()), []);
+  const latestWindowStart = useMemo(
+    () => addMonths(currentMonthStart, -(WINDOW_MONTHS - 1)),
+    [currentMonthStart]
+  );
+  const oldestLogMonthStart = useMemo(
+    () => getOldestLogMonth(logs, currentMonthStart),
+    [currentMonthStart, logs]
+  );
+
+  const [windowStartMonth, setWindowStartMonth] = useState<Date>(latestWindowStart);
+  const activeWindowStart = useMemo(
+    () => clampMonthStart(windowStartMonth, oldestLogMonthStart, latestWindowStart),
+    [latestWindowStart, oldestLogMonthStart, windowStartMonth]
+  );
+
+  const canPageOlder = activeWindowStart.getTime() > oldestLogMonthStart.getTime();
+  const canPageNewer = activeWindowStart.getTime() < latestWindowStart.getTime();
+
+  const { weeks, monthLabels, hasAnyReading, windowEnd } = useMemo(() => {
+    const start = activeWindowStart;
+    const end = endOfMonth(addMonths(start, WINDOW_MONTHS - 1));
 
     const dayTotals = new Map<string, number>();
     const dayLogCounts = new Map<string, number>();
     for (const log of logs) {
       const minutes = log.reading_time_minutes ?? 0;
-      const key = toLocalDayKey(new Date(log.logged_at));
+      const key = toLocalDayKey(startOfLocalDay(new Date(log.logged_at)));
       dayLogCounts.set(key, (dayLogCounts.get(key) ?? 0) + 1);
       if (minutes > 0) {
         dayTotals.set(key, (dayTotals.get(key) ?? 0) + minutes);
       }
     }
-
-    const hasAnyReadingInRange = Array.from(dayLogCounts.entries()).some(([key, count]) => {
-      if (count <= 0) return false;
-      const [year, month, day] = key.split("-").map(Number);
-      const date = new Date(year, month - 1, day);
-      return date >= start && date <= end;
-    });
 
     const gridStart = addDays(start, -start.getDay());
     const daysToSaturday = 6 - end.getDay();
@@ -125,9 +165,10 @@ export default function ReadingHeatmap({ logs }: ReadingHeatmapProps) {
     return {
       weeks: weekColumns,
       monthLabels: labels,
-      hasAnyReading: hasAnyReadingInRange,
+      hasAnyReading: dayLogCounts.size > 0,
+      windowEnd: end,
     };
-  }, [logs]);
+  }, [activeWindowStart, logs]);
 
   const intensityClassByLevel: Record<HeatmapCell["level"], string> = {
     0: "bg-muted border-border/70",
@@ -137,11 +178,19 @@ export default function ReadingHeatmap({ logs }: ReadingHeatmapProps) {
     4: "bg-emerald-600 border-emerald-700",
   };
 
+  const windowRangeLabel = `${activeWindowStart.toLocaleDateString(undefined, {
+    month: "short",
+    year: "numeric",
+  })} - ${windowEnd.toLocaleDateString(undefined, {
+    month: "short",
+    year: "numeric",
+  })}`;
+
   return (
     <section className="space-y-4">
       <div>
         <h2 className="text-base font-semibold">Reading activity</h2>
-        <p className="text-sm text-muted-foreground">Last 12 months by day (minutes read)</p>
+        <p className="text-sm text-muted-foreground">12-month view by day (minutes read)</p>
       </div>
 
       {hasAnyReading ? (
@@ -214,7 +263,60 @@ export default function ReadingHeatmap({ logs }: ReadingHeatmapProps) {
           </div>
 
           <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
-            <p>Hover a day to see details.</p>
+            <div className="flex items-center gap-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "h-7 w-7",
+                  canPageOlder
+                    ? "text-foreground hover:bg-muted/80"
+                    : "text-muted-foreground/40 hover:bg-transparent"
+                )}
+                onClick={() =>
+                  setWindowStartMonth((current) => {
+                    const bounded = clampMonthStart(current, oldestLogMonthStart, latestWindowStart);
+                    return clampMonthStart(
+                      addMonths(bounded, -PAGE_MONTHS),
+                      oldestLogMonthStart,
+                      latestWindowStart
+                    );
+                  })
+                }
+                disabled={!canPageOlder}
+                aria-label="Show previous 12 months"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "h-7 w-7",
+                  canPageNewer
+                    ? "text-foreground hover:bg-muted/80"
+                    : "text-muted-foreground/40 hover:bg-transparent"
+                )}
+                onClick={() =>
+                  setWindowStartMonth((current) => {
+                    const bounded = clampMonthStart(current, oldestLogMonthStart, latestWindowStart);
+                    return clampMonthStart(
+                      addMonths(bounded, PAGE_MONTHS),
+                      oldestLogMonthStart,
+                      latestWindowStart
+                    );
+                  })
+                }
+                disabled={!canPageNewer}
+                aria-label="Show next 12 months"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+              <span className="text-[11px]">{windowRangeLabel}</span>
+            </div>
+
             <div className="flex items-center gap-1.5">
               <span>Less</span>
               <span className={cn("h-3 w-3 rounded-[3px] border", intensityClassByLevel[0])} />

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -273,6 +273,16 @@ export async function fetchReadingLogsForBook(
   return (data ?? []) as ReadingLog[];
 }
 
+export async function fetchReadingLogs(): Promise<ReadingLog[]> {
+  const { data, error } = await supabase
+    .from("reading_logs")
+    .select("*")
+    .order("logged_at", { ascending: true });
+
+  if (error) throw error;
+  return (data ?? []) as ReadingLog[];
+}
+
 export async function fetchReadingLogsInRange(
   startIso: string,
   endIso: string

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import ReadingHeatmap from "@/components/ReadingHeatmap";
 import GenreDistributionChart from "@/components/GenreDistributionChart";
 import { useBooksContext } from "@/context/BooksContext";
-import { fetchReadingLogsInRange } from "@/lib/books";
+import { fetchReadingLogs } from "@/lib/books";
 import {
   calculateReadingHabits,
   formatDurationMinutes,
@@ -22,7 +22,7 @@ const DAY_PART_HOUR_RANGES: Record<string, string> = {
   Night: "23:00-05:59",
 };
 
-function getHeatmapRangeIso(): { startIso: string; endIso: string } {
+function getHabitsRangeIso(): { startIso: string; endIso: string } {
   const now = new Date();
   const endDate = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
   const startDate = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate() + 1, 0, 0, 0, 0);
@@ -40,17 +40,27 @@ export default function Analytics() {
   const [loading, setLoading] = useState(true);
   const [heatmapError, setHeatmapError] = useState<string | null>(null);
 
-  const range = useMemo(() => getHeatmapRangeIso(), []);
+  const habitsRange = useMemo(() => getHabitsRangeIso(), []);
+  const habitsStartMs = useMemo(() => new Date(habitsRange.startIso).getTime(), [habitsRange.startIso]);
+  const habitsEndMs = useMemo(() => new Date(habitsRange.endIso).getTime(), [habitsRange.endIso]);
+  const habitsLogs = useMemo(
+    () =>
+      logs.filter((log) => {
+        const loggedAt = new Date(log.logged_at).getTime();
+        return loggedAt >= habitsStartMs && loggedAt <= habitsEndMs;
+      }),
+    [habitsEndMs, habitsStartMs, logs]
+  );
   const habits = useMemo(
-    () => calculateReadingHabits(logs, range.startIso, range.endIso),
-    [logs, range.endIso, range.startIso]
+    () => calculateReadingHabits(habitsLogs, habitsRange.startIso, habitsRange.endIso),
+    [habitsLogs, habitsRange.endIso, habitsRange.startIso]
   );
 
   async function loadHeatmapLogs() {
     try {
       setLoading(true);
       setHeatmapError(null);
-      const data = await fetchReadingLogsInRange(range.startIso, range.endIso);
+      const data = await fetchReadingLogs();
       setLogs(data);
     } catch (err) {
       setHeatmapError(err instanceof Error ? err.message : "Failed to load reading activity");


### PR DESCRIPTION
## Summary
- switch Reading activity heatmap to a paged 12-month window that opens on the latest period, keeps horizontal scrolling, and adds footer arrow controls with clear enabled/disabled states
- allow browsing the full reading-log history by clamping month-window navigation to oldest/newest available ranges
- fetch full reading-log history for the heatmap while keeping Reading habits scoped to the last 12 months

## Testing
- npm run typecheck
- npm run test

Closes #83