### PR TITLE
Fix add-book flow when cover upload fails

### DIFF
--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -198,7 +198,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
         return;
       }
       const genres = parseGenresInput(values.genresInput);
-      await addBook(
+      const result = await addBook(
         {
           title: values.title,
           authors,
@@ -218,6 +218,24 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
         },
         coverFile ?? undefined
       );
+
+      if (result.warning) {
+        reset({ status: "Not Started", authorsInput: "" });
+        setCoverFile(null);
+        setCoverPreview(null);
+        setShowScanner(false);
+        setManualIsbn("");
+        setIsbnStatus("idle");
+        setIsbnError(null);
+        setScannedIsbn(null);
+        setAddingNewSeries(false);
+        setNewSeriesName("");
+        setIsCreatingSeries(false);
+        setPendingSeriesSelectionId(null);
+        setError("root", { message: result.warning });
+        return;
+      }
+
       reset();
       setCoverFile(null);
       setCoverPreview(null);

--- a/src/context/BooksContext.tsx
+++ b/src/context/BooksContext.tsx
@@ -1,12 +1,12 @@
 import { createContext, useContext, type ReactNode } from "react";
-import { useBooks, type AddBookPayload } from "@/hooks/useBooks";
+import { useBooks, type AddBookPayload, type AddBookResult } from "@/hooks/useBooks";
 import type { Book } from "@/types";
 
 interface BooksContextValue {
   books: Book[];
   loading: boolean;
   error: string | null;
-  addBook: (payload: AddBookPayload, coverFile?: File) => Promise<void>;
+  addBook: (payload: AddBookPayload, coverFile?: File) => Promise<AddBookResult>;
   updateBook: (id: string, payload: Partial<Book>) => Promise<void>;
   updateCover: (id: string, file: File) => Promise<void>;
   deleteBook: (id: string) => Promise<void>;

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -14,6 +14,18 @@ import type { Book } from "@/types";
 export interface AddBookPayload
   extends Omit<BookInsert, "id" | "cover_url" | "user_id"> {}
 
+export interface AddBookResult {
+  warning?: string;
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "object" && error !== null && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return fallback;
+}
+
 export function useBooks() {
   const { user } = useAuth();
   const [books, setBooks] = useState<Book[]>([]);
@@ -39,15 +51,26 @@ export function useBooks() {
   }, [load]);
 
   const addBook = useCallback(
-    async (payload: AddBookPayload, coverFile?: File): Promise<void> => {
+    async (payload: AddBookPayload, coverFile?: File): Promise<AddBookResult> => {
       if (!user) throw new Error("Not authenticated");
       const bookId = crypto.randomUUID();
-      let cover_url: string | undefined;
-      if (coverFile) {
-        cover_url = await uploadCover(user.id, bookId, coverFile);
-      }
-      const book = await createBook({ ...payload, id: bookId, cover_url, user_id: user.id });
+
+      const book = await createBook({ ...payload, id: bookId, user_id: user.id });
       setBooks((prev) => [book, ...prev]);
+
+      if (!coverFile) return {};
+
+      try {
+        const cover_url = await uploadCover(user.id, bookId, coverFile);
+        const updated = await updateBookDb(bookId, { cover_url });
+        setBooks((prev) => prev.map((b) => (b.id === bookId ? updated : b)));
+        return {};
+      } catch (error) {
+        const detail = getErrorMessage(error, "Upload request failed.");
+        return {
+          warning: `Book saved, but cover upload failed: ${detail} You can add the cover later from book details.`,
+        };
+      }
     },
     [user]
   );


### PR DESCRIPTION
## Summary
- change the add-book flow to create the `books` row first, then upload the cover and patch `cover_url`, matching the existing successful "add cover later" path
- keep book creation resilient when storage upload fails: the book is still saved and users now see a clear warning that the cover can be added later
- update `BooksContext` and dialog submit handling so `addBook` can return a warning state and show it as a root form error

## How it works now
- submitting with no cover behaves as before
- submitting with a cover now performs DB insert first, then storage upload, then row update
- if upload fails, the modal stays open with a message (`Book saved, but cover upload failed...`) instead of blocking book creation