### PR TITLE
feat: automatic status transitions in book details

### DIFF
--- a/src/components/ReadingProgressDialog.tsx
+++ b/src/components/ReadingProgressDialog.tsx
@@ -13,17 +13,28 @@ interface ReadingProgressDialogProps {
   book: Book;
   trigger: ReactNode;
   onProgressSaved: (newCurrentPage: number) => Promise<void> | void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export default function ReadingProgressDialog({
   book,
   trigger,
   onProgressSaved,
+  open,
+  onOpenChange,
 }: ReadingProgressDialogProps) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = typeof open === "boolean";
+  const resolvedOpen = isControlled ? open : internalOpen;
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!isControlled) setInternalOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={resolvedOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent
         className="sm:max-w-md"
@@ -36,10 +47,10 @@ export default function ReadingProgressDialog({
           book={book}
           defaultExpanded
           hideTrigger
-          onCancel={() => setOpen(false)}
+          onCancel={() => handleOpenChange(false)}
           onProgressSaved={async (newPage) => {
             await onProgressSaved(newPage);
-            setOpen(false);
+            handleOpenChange(false);
           }}
         />
       </DialogContent>

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -107,6 +107,7 @@ export default function BookDetails() {
   const [isFavorite, setIsFavorite] = useState(false);
   const [localRating, setLocalRating] = useState<number | null>(null);
   const [isEditMode, setIsEditMode] = useState(false);
+  const [isProgressDialogOpen, setIsProgressDialogOpen] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -125,6 +126,7 @@ export default function BookDetails() {
 
   useEffect(() => {
     window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+    setIsProgressDialogOpen(false);
   }, [bookId]);
 
   useEffect(() => {
@@ -433,11 +435,39 @@ export default function BookDetails() {
               </PropertyBox>
             </div>
             <Progress value={progressPercent} className="h-1.5" />
+            {status === "Up Next" && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={async () => {
+                  try {
+                    setErrorMsg(null);
+                    await updateBook(book.id, { status: "Reading" });
+                    setIsProgressDialogOpen(true);
+                  } catch (err) {
+                    setErrorMsg(err instanceof Error ? err.message : "Failed to start reading");
+                  }
+                }}
+              >
+                Start Reading
+              </Button>
+            )}
             {status === "Reading" && (
               <ReadingProgressDialog
                 book={book}
+                open={isProgressDialogOpen}
+                onOpenChange={setIsProgressDialogOpen}
                 onProgressSaved={async (newPage) => {
-                  await updateBook(book.id, { current_page: newPage });
+                  const shouldFinish =
+                    typeof book.total_pages === "number" &&
+                    book.total_pages > 0 &&
+                    newPage >= book.total_pages;
+
+                  await updateBook(book.id, {
+                    current_page: newPage,
+                    ...(shouldFinish ? { status: "Finished" } : {}),
+                  });
                 }}
                 trigger={
                   <Button type="button" variant="outline" size="sm">


### PR DESCRIPTION
## Summary
- add a contextual `Start Reading` action in the book details reading progress section when a book is `Up Next`
- transition `Up Next -> Reading` immediately and open the `Update progress` dialog in the same action slot
- auto-transition to `Finished` when saved progress reaches or exceeds `total_pages` while still updating `current_page` for every save
- make `ReadingProgressDialog` support controlled open state so book details can programmatically open it without changing existing callers

## Testing
- npm run typecheck
- npm run build