### PR TITLE
Add profiles and groups

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -7,6 +7,7 @@ import {
   Library,
   KeyRound,
   BarChart3,
+  UserRound,
   Monitor,
   Sun,
   Moon,
@@ -24,6 +25,7 @@ const navLinks = [
   { to: "/", label: "Dashboard", icon: LayoutDashboard },
   { to: "/library", label: "Library", icon: Library },
   { to: "/analytics", label: "Analytics", icon: BarChart3 },
+  { to: "/account", label: "Account", icon: UserRound },
 ];
 
 const themeCycle = ["system", "light", "dark"] as const;

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -1,0 +1,211 @@
+import { supabase } from "./supabase";
+import type {
+  Group,
+  GroupMembership,
+  GroupMembershipRole,
+  Profile,
+} from "@/types";
+
+type NullableProfileRow = Omit<Profile, "first_name" | "last_name" | "avatar_url" | "bio" | "timezone" | "language"> & {
+  first_name: string | null;
+  last_name: string | null;
+  avatar_url: string | null;
+  bio: string | null;
+  timezone: string | null;
+  language: string | null;
+};
+
+type NullableGroupRow = Omit<Group, "description" | "avatar_url"> & {
+  description: string | null;
+  avatar_url: string | null;
+};
+
+export type ProfilePayload = Partial<
+  Pick<Profile, "first_name" | "last_name" | "avatar_url" | "bio" | "timezone" | "language">
+>;
+
+export type GroupPayload = Pick<Group, "name"> &
+  Partial<Pick<Group, "description" | "avatar_url">>;
+
+function normalizeProfile(row: NullableProfileRow): Profile {
+  return {
+    id: row.id,
+    first_name: row.first_name ?? undefined,
+    last_name: row.last_name ?? undefined,
+    avatar_url: row.avatar_url ?? undefined,
+    bio: row.bio ?? undefined,
+    timezone: row.timezone ?? undefined,
+    language: row.language ?? undefined,
+    created_at: row.created_at,
+  };
+}
+
+function normalizeGroup(row: NullableGroupRow): Group {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? undefined,
+    avatar_url: row.avatar_url ?? undefined,
+    created_by: row.created_by,
+    created_at: row.created_at,
+  };
+}
+
+async function getCurrentUserId(): Promise<string> {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error) throw error;
+  if (!user) throw new Error("You must be signed in.");
+  return user.id;
+}
+
+async function ensureMyProfile(): Promise<void> {
+  const userId = await getCurrentUserId();
+  const { error } = await supabase
+    .from("profiles")
+    .upsert({ id: userId }, { onConflict: "id" });
+
+  if (error) throw error;
+}
+
+export async function getMyProfile(): Promise<Profile | null> {
+  const userId = await getCurrentUserId();
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("*")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data ? normalizeProfile(data as NullableProfileRow) : null;
+}
+
+export async function createMyProfile(profile: ProfilePayload): Promise<Profile> {
+  const userId = await getCurrentUserId();
+  const { data, error } = await supabase
+    .from("profiles")
+    .insert({ id: userId, ...profile })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return normalizeProfile(data as NullableProfileRow);
+}
+
+export async function updateMyProfile(profile: ProfilePayload): Promise<Profile> {
+  const userId = await getCurrentUserId();
+  const { data, error } = await supabase
+    .from("profiles")
+    .update(profile)
+    .eq("id", userId)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return normalizeProfile(data as NullableProfileRow);
+}
+
+export async function getMyGroups(): Promise<Group[]> {
+  const { data, error } = await supabase
+    .from("groups")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+  return ((data ?? []) as NullableGroupRow[]).map(normalizeGroup);
+}
+
+export async function createGroup(payload: GroupPayload): Promise<{
+  group: Group;
+  ownerMembership: GroupMembership;
+}> {
+  await ensureMyProfile();
+  const userId = await getCurrentUserId();
+
+  const { data: groupData, error: groupError } = await supabase
+    .from("groups")
+    .insert({ ...payload, created_by: userId })
+    .select()
+    .single();
+
+  if (groupError) throw groupError;
+  const group = normalizeGroup(groupData as NullableGroupRow);
+
+  const { data: membershipData, error: membershipError } = await supabase
+    .from("group_memberships")
+    .insert({
+      group_id: group.id,
+      user_id: userId,
+      role: "owner",
+      status: "active",
+    })
+    .select()
+    .single();
+
+  if (membershipError) throw membershipError;
+
+  return {
+    group,
+    ownerMembership: membershipData as GroupMembership,
+  };
+}
+
+export async function getGroupMembers(groupId: string): Promise<GroupMembership[]> {
+  const { data, error } = await supabase
+    .from("group_memberships")
+    .select("*")
+    .eq("group_id", groupId)
+    .order("joined_at", { ascending: true });
+
+  if (error) throw error;
+  return (data ?? []) as GroupMembership[];
+}
+
+export async function addGroupMember(
+  groupId: string,
+  userId: string,
+): Promise<GroupMembership> {
+  const { data, error } = await supabase
+    .from("group_memberships")
+    .insert({
+      group_id: groupId,
+      user_id: userId,
+      role: "member",
+      status: "active",
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as GroupMembership;
+}
+
+export async function updateGroupMemberRole(
+  groupId: string,
+  userId: string,
+  role: GroupMembershipRole,
+): Promise<GroupMembership> {
+  const { data, error } = await supabase
+    .from("group_memberships")
+    .update({ role })
+    .eq("group_id", groupId)
+    .eq("user_id", userId)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as GroupMembership;
+}
+
+export async function removeGroupMember(groupId: string, userId: string): Promise<void> {
+  const { error } = await supabase
+    .from("group_memberships")
+    .delete()
+    .eq("group_id", groupId)
+    .eq("user_id", userId);
+
+  if (error) throw error;
+}

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -27,6 +27,14 @@ export type ProfilePayload = Partial<
 export type GroupPayload = Pick<Group, "name"> &
   Partial<Pick<Group, "description" | "avatar_url">>;
 
+export function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return fallback;
+}
+
 function normalizeProfile(row: NullableProfileRow): Profile {
   return {
     id: row.id,
@@ -122,27 +130,22 @@ export async function createGroup(payload: GroupPayload): Promise<{
   group: Group;
   ownerMembership: GroupMembership;
 }> {
-  await ensureMyProfile();
-  const userId = await getCurrentUserId();
-
   const { data: groupData, error: groupError } = await supabase
-    .from("groups")
-    .insert({ ...payload, created_by: userId })
-    .select()
+    .rpc("create_group_with_owner", {
+      group_name: payload.name,
+      group_description: payload.description ?? null,
+      group_avatar_url: payload.avatar_url ?? null,
+    })
     .single();
 
   if (groupError) throw groupError;
-  const group = normalizeGroup(groupData as NullableGroupRow);
 
+  const group = normalizeGroup(groupData as NullableGroupRow);
   const { data: membershipData, error: membershipError } = await supabase
     .from("group_memberships")
-    .insert({
-      group_id: group.id,
-      user_id: userId,
-      role: "owner",
-      status: "active",
-    })
-    .select()
+    .select("*")
+    .eq("group_id", group.id)
+    .eq("user_id", group.created_by)
     .single();
 
   if (membershipError) throw membershipError;

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -70,15 +70,6 @@ async function getCurrentUserId(): Promise<string> {
   return user.id;
 }
 
-async function ensureMyProfile(): Promise<void> {
-  const userId = await getCurrentUserId();
-  const { error } = await supabase
-    .from("profiles")
-    .upsert({ id: userId }, { onConflict: "id" });
-
-  if (error) throw error;
-}
-
 export async function getMyProfile(): Promise<Profile | null> {
   const userId = await getCurrentUserId();
   const { data, error } = await supabase

--- a/src/lib/router.tsx
+++ b/src/lib/router.tsx
@@ -8,6 +8,7 @@ const Dashboard = lazy(() => import("@/pages/Dashboard"));
 const Library = lazy(() => import("@/pages/Library"));
 const Analytics = lazy(() => import("@/pages/Analytics"));
 const BookDetails = lazy(() => import("@/pages/BookDetails"));
+const Account = lazy(() => import("@/pages/Account"));
 
 function lazyRoute(element: ReactNode) {
   return <Suspense fallback={null}>{element}</Suspense>;
@@ -39,6 +40,7 @@ export const router = createBrowserRouter([
           { path: "/library", element: lazyRoute(<Library />) },
           { path: "/books/:bookId", element: lazyRoute(<BookDetails />) },
           { path: "/analytics", element: lazyRoute(<Analytics />) },
+          { path: "/account", element: lazyRoute(<Account />) },
         ],
       },
     ],

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,0 +1,469 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { RefreshCw, Save, UserPlus, Users } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/context";
+import {
+  addGroupMember,
+  createGroup,
+  createMyProfile,
+  getGroupMembers,
+  getMyGroups,
+  getMyProfile,
+  removeGroupMember,
+  updateGroupMemberRole,
+  updateMyProfile,
+  type GroupPayload,
+  type ProfilePayload,
+} from "@/lib/profiles";
+import type { Group, GroupMembership, GroupMembershipRole, Profile } from "@/types";
+
+type ProfileForm = Required<ProfilePayload>;
+
+const emptyProfileForm: ProfileForm = {
+  first_name: "",
+  last_name: "",
+  avatar_url: "",
+  bio: "",
+  timezone: "",
+  language: "",
+};
+
+function profileToForm(profile: Profile | null): ProfileForm {
+  return {
+    first_name: profile?.first_name ?? "",
+    last_name: profile?.last_name ?? "",
+    avatar_url: profile?.avatar_url ?? "",
+    bio: profile?.bio ?? "",
+    timezone: profile?.timezone ?? "",
+    language: profile?.language ?? "",
+  };
+}
+
+function cleanProfilePayload(form: ProfileForm): ProfilePayload {
+  return Object.fromEntries(
+    Object.entries(form).map(([key, value]) => [key, value.trim() || undefined]),
+  ) as ProfilePayload;
+}
+
+export default function Account() {
+  const { user } = useAuth();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [profileForm, setProfileForm] = useState<ProfileForm>(emptyProfileForm);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [selectedGroupId, setSelectedGroupId] = useState<string>("");
+  const [members, setMembers] = useState<GroupMembership[]>([]);
+  const [groupForm, setGroupForm] = useState<GroupPayload>({ name: "", description: "" });
+  const [memberUserId, setMemberUserId] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [savingProfile, setSavingProfile] = useState(false);
+  const [creatingGroup, setCreatingGroup] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedGroup = useMemo(
+    () => groups.find((group) => group.id === selectedGroupId) ?? null,
+    [groups, selectedGroupId],
+  );
+
+  async function loadAccount() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [nextProfile, nextGroups] = await Promise.all([getMyProfile(), getMyGroups()]);
+      setProfile(nextProfile);
+      setProfileForm(profileToForm(nextProfile));
+      setGroups(nextGroups);
+      setSelectedGroupId((current) =>
+        nextGroups.some((group) => group.id === current) ? current : nextGroups[0]?.id || "",
+      );
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Could not load account data.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadAccount();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedGroupId) {
+      setMembers([]);
+      return;
+    }
+
+    let cancelled = false;
+    getGroupMembers(selectedGroupId)
+      .then((nextMembers) => {
+        if (!cancelled) setMembers(nextMembers);
+      })
+      .catch((memberError) => {
+        if (!cancelled) {
+          setError(memberError instanceof Error ? memberError.message : "Could not load group members.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedGroupId]);
+
+  async function saveProfile(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSavingProfile(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const payload = cleanProfilePayload(profileForm);
+      const savedProfile = profile
+        ? await updateMyProfile(payload)
+        : await createMyProfile(payload);
+      setProfile(savedProfile);
+      setProfileForm(profileToForm(savedProfile));
+      setMessage("Profile saved.");
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "Could not save profile.");
+    } finally {
+      setSavingProfile(false);
+    }
+  }
+
+  async function submitGroup(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const name = groupForm.name.trim();
+    if (!name) return;
+
+    setCreatingGroup(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const { group } = await createGroup({
+        name,
+        description: groupForm.description?.trim() || undefined,
+        avatar_url: groupForm.avatar_url?.trim() || undefined,
+      });
+      setGroups((current) => [group, ...current]);
+      setSelectedGroupId(group.id);
+      setGroupForm({ name: "", description: "" });
+      setMessage("Group created.");
+    } catch (groupError) {
+      setError(groupError instanceof Error ? groupError.message : "Could not create group.");
+    } finally {
+      setCreatingGroup(false);
+    }
+  }
+
+  async function submitMember(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const nextUserId = memberUserId.trim();
+    if (!selectedGroupId || !nextUserId) return;
+
+    setError(null);
+    setMessage(null);
+
+    try {
+      const member = await addGroupMember(selectedGroupId, nextUserId);
+      setMembers((current) => [...current.filter((item) => item.user_id !== member.user_id), member]);
+      setMemberUserId("");
+      setMessage("Member added.");
+    } catch (memberError) {
+      setError(memberError instanceof Error ? memberError.message : "Could not add member.");
+    }
+  }
+
+  async function changeRole(userId: string, role: GroupMembershipRole) {
+    if (!selectedGroupId) return;
+    setError(null);
+    setMessage(null);
+
+    try {
+      const member = await updateGroupMemberRole(selectedGroupId, userId, role);
+      setMembers((current) =>
+        current.map((item) => (item.user_id === userId ? member : item)),
+      );
+      setMessage("Member role updated.");
+    } catch (roleError) {
+      setError(roleError instanceof Error ? roleError.message : "Could not update member role.");
+    }
+  }
+
+  async function removeMember(userId: string) {
+    if (!selectedGroupId) return;
+    setError(null);
+    setMessage(null);
+
+    try {
+      await removeGroupMember(selectedGroupId, userId);
+      setMembers((current) => current.filter((member) => member.user_id !== userId));
+      setMessage(userId === user?.id ? "You left the group." : "Member removed.");
+      if (userId === user?.id) {
+        const nextGroups = await getMyGroups();
+        setGroups(nextGroups);
+        setSelectedGroupId(nextGroups[0]?.id || "");
+      }
+    } catch (removeError) {
+      setError(removeError instanceof Error ? removeError.message : "Could not remove member.");
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-heading leading-snug font-medium">Account</h1>
+          <p className="text-sm text-muted-foreground">{user?.email}</p>
+        </div>
+        <Button variant="outline" size="sm" onClick={() => loadAccount()} disabled={loading}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Refresh
+        </Button>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      {message && <p className="text-sm text-muted-foreground">{message}</p>}
+
+      <Tabs defaultValue="profile">
+        <TabsList className="w-full">
+          <TabsTrigger value="profile" className="flex-1">
+            Profile
+          </TabsTrigger>
+          <TabsTrigger value="groups" className="flex-1">
+            Groups
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="profile" className="mt-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>Profile</CardTitle>
+              <CardDescription>Personal details for this account.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form className="space-y-4" onSubmit={saveProfile}>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="first-name">First name</Label>
+                    <Input
+                      id="first-name"
+                      value={profileForm.first_name}
+                      onChange={(event) =>
+                        setProfileForm((current) => ({ ...current, first_name: event.target.value }))
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="last-name">Last name</Label>
+                    <Input
+                      id="last-name"
+                      value={profileForm.last_name}
+                      onChange={(event) =>
+                        setProfileForm((current) => ({ ...current, last_name: event.target.value }))
+                      }
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="avatar-url">Avatar URL</Label>
+                  <Input
+                    id="avatar-url"
+                    value={profileForm.avatar_url}
+                    onChange={(event) =>
+                      setProfileForm((current) => ({ ...current, avatar_url: event.target.value }))
+                    }
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="bio">Bio</Label>
+                  <Textarea
+                    id="bio"
+                    value={profileForm.bio}
+                    onChange={(event) =>
+                      setProfileForm((current) => ({ ...current, bio: event.target.value }))
+                    }
+                  />
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="timezone">Timezone</Label>
+                    <Input
+                      id="timezone"
+                      placeholder="Europe/Vienna"
+                      value={profileForm.timezone}
+                      onChange={(event) =>
+                        setProfileForm((current) => ({ ...current, timezone: event.target.value }))
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="language">Language</Label>
+                    <Input
+                      id="language"
+                      placeholder="English"
+                      value={profileForm.language}
+                      onChange={(event) =>
+                        setProfileForm((current) => ({ ...current, language: event.target.value }))
+                      }
+                    />
+                  </div>
+                </div>
+
+                <Button type="submit" disabled={savingProfile || loading}>
+                  <Save className="mr-2 h-4 w-4" />
+                  {savingProfile ? "Saving..." : "Save profile"}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="groups" className="mt-3">
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+            <Card>
+              <CardHeader>
+                <CardTitle>Create Group</CardTitle>
+                <CardDescription>Private reading groups.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <form className="space-y-3" onSubmit={submitGroup}>
+                  <div className="space-y-2">
+                    <Label htmlFor="group-name">Name</Label>
+                    <Input
+                      id="group-name"
+                      value={groupForm.name}
+                      onChange={(event) =>
+                        setGroupForm((current) => ({ ...current, name: event.target.value }))
+                      }
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="group-description">Description</Label>
+                    <Textarea
+                      id="group-description"
+                      value={groupForm.description ?? ""}
+                      onChange={(event) =>
+                        setGroupForm((current) => ({ ...current, description: event.target.value }))
+                      }
+                    />
+                  </div>
+                  <Button type="submit" disabled={creatingGroup || !groupForm.name.trim()}>
+                    <Users className="mr-2 h-4 w-4" />
+                    {creatingGroup ? "Creating..." : "Create group"}
+                  </Button>
+                </form>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>My Groups</CardTitle>
+                <CardDescription>
+                  {groups.length === 0
+                    ? "No groups yet."
+                    : `${groups.length} group${groups.length === 1 ? "" : "s"}`}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {groups.length > 0 && (
+                  <div className="space-y-2">
+                    <Label htmlFor="selected-group">Group</Label>
+                    <Select value={selectedGroupId} onValueChange={setSelectedGroupId}>
+                      <SelectTrigger id="selected-group" className="w-full">
+                        <SelectValue placeholder="Choose a group" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {groups.map((group) => (
+                          <SelectItem key={group.id} value={group.id}>
+                            {group.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+
+                {selectedGroup && (
+                  <div className="space-y-4">
+                    <div>
+                      <h2 className="font-heading leading-snug font-medium">{selectedGroup.name}</h2>
+                      {selectedGroup.description && (
+                        <p className="text-sm text-muted-foreground">{selectedGroup.description}</p>
+                      )}
+                    </div>
+
+                    <form className="flex flex-col gap-2 sm:flex-row" onSubmit={submitMember}>
+                      <Input
+                        aria-label="User ID"
+                        placeholder="User UUID"
+                        value={memberUserId}
+                        onChange={(event) => setMemberUserId(event.target.value)}
+                      />
+                      <Button type="submit" variant="outline" disabled={!memberUserId.trim()}>
+                        <UserPlus className="mr-2 h-4 w-4" />
+                        Add
+                      </Button>
+                    </form>
+
+                    <div className="space-y-2">
+                      {members.map((member) => (
+                        <div
+                          key={member.user_id}
+                          className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center"
+                        >
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-medium">{member.user_id}</p>
+                            <p className="text-xs text-muted-foreground">{member.status}</p>
+                          </div>
+                          <Select
+                            value={member.role}
+                            onValueChange={(value) =>
+                              changeRole(member.user_id, value as GroupMembershipRole)
+                            }
+                          >
+                            <SelectTrigger className="w-full sm:w-32">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="owner">Owner</SelectItem>
+                              <SelectItem value="admin">Admin</SelectItem>
+                              <SelectItem value="member">Member</SelectItem>
+                            </SelectContent>
+                          </Select>
+                          <Button
+                            type="button"
+                            variant="destructive"
+                            size="sm"
+                            onClick={() => removeMember(member.user_id)}
+                          >
+                            Remove
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -21,6 +21,7 @@ import {
   getGroupMembers,
   getMyGroups,
   getMyProfile,
+  getErrorMessage,
   removeGroupMember,
   updateGroupMemberRole,
   updateMyProfile,
@@ -89,7 +90,7 @@ export default function Account() {
         nextGroups.some((group) => group.id === current) ? current : nextGroups[0]?.id || "",
       );
     } catch (loadError) {
-      setError(loadError instanceof Error ? loadError.message : "Could not load account data.");
+      setError(getErrorMessage(loadError, "Could not load account data."));
     } finally {
       setLoading(false);
     }
@@ -112,7 +113,7 @@ export default function Account() {
       })
       .catch((memberError) => {
         if (!cancelled) {
-          setError(memberError instanceof Error ? memberError.message : "Could not load group members.");
+          setError(getErrorMessage(memberError, "Could not load group members."));
         }
       });
 
@@ -136,7 +137,7 @@ export default function Account() {
       setProfileForm(profileToForm(savedProfile));
       setMessage("Profile saved.");
     } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : "Could not save profile.");
+      setError(getErrorMessage(saveError, "Could not save profile."));
     } finally {
       setSavingProfile(false);
     }
@@ -162,7 +163,7 @@ export default function Account() {
       setGroupForm({ name: "", description: "" });
       setMessage("Group created.");
     } catch (groupError) {
-      setError(groupError instanceof Error ? groupError.message : "Could not create group.");
+      setError(getErrorMessage(groupError, "Could not create group."));
     } finally {
       setCreatingGroup(false);
     }
@@ -182,7 +183,7 @@ export default function Account() {
       setMemberUserId("");
       setMessage("Member added.");
     } catch (memberError) {
-      setError(memberError instanceof Error ? memberError.message : "Could not add member.");
+      setError(getErrorMessage(memberError, "Could not add member."));
     }
   }
 
@@ -198,7 +199,7 @@ export default function Account() {
       );
       setMessage("Member role updated.");
     } catch (roleError) {
-      setError(roleError instanceof Error ? roleError.message : "Could not update member role.");
+      setError(getErrorMessage(roleError, "Could not update member role."));
     }
   }
 
@@ -217,7 +218,7 @@ export default function Account() {
         setSelectedGroupId(nextGroups[0]?.id || "");
       }
     } catch (removeError) {
-      setError(removeError instanceof Error ? removeError.message : "Could not remove member.");
+      setError(getErrorMessage(removeError, "Could not remove member."));
     }
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,3 +55,35 @@ export interface ReadingLog {
   reading_time_minutes?: number;
   logged_at: string;
 }
+
+export interface Profile {
+  id: string;
+  first_name?: string;
+  last_name?: string;
+  avatar_url?: string;
+  bio?: string;
+  timezone?: string;
+  language?: string;
+  created_at: string;
+}
+
+export interface Group {
+  id: string;
+  name: string;
+  description?: string;
+  avatar_url?: string;
+  created_by: string;
+  created_at: string;
+}
+
+export type GroupMembershipRole = "owner" | "admin" | "member";
+
+export type GroupMembershipStatus = "active" | "invited";
+
+export interface GroupMembership {
+  group_id: string;
+  user_id: string;
+  role: GroupMembershipRole;
+  status: GroupMembershipStatus;
+  joined_at: string;
+}

--- a/supabase/migrations/20260426_profiles_groups.sql
+++ b/supabase/migrations/20260426_profiles_groups.sql
@@ -1,0 +1,147 @@
+-- Profiles and groups for app-specific user data and future sharing features.
+
+CREATE TABLE IF NOT EXISTS profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  first_name text,
+  last_name text,
+  avatar_url text,
+  bio text,
+  timezone text,
+  language text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS groups (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  description text,
+  avatar_url text,
+  created_by uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS group_memberships (
+  group_id uuid NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  role text NOT NULL DEFAULT 'member'
+    CHECK (role IN ('owner', 'admin', 'member')),
+  status text NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'invited')),
+  joined_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (group_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS profiles_created_at_idx ON profiles(created_at);
+CREATE INDEX IF NOT EXISTS groups_created_by_idx ON groups(created_by);
+CREATE INDEX IF NOT EXISTS group_memberships_user_id_idx ON group_memberships(user_id);
+CREATE INDEX IF NOT EXISTS group_memberships_group_id_idx ON group_memberships(group_id);
+
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE group_memberships ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION is_active_group_member(group_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM group_memberships
+    WHERE group_id = group_uuid
+      AND user_id = user_uuid
+      AND status = 'active'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION can_manage_group(group_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM group_memberships
+    WHERE group_id = group_uuid
+      AND user_id = user_uuid
+      AND role IN ('owner', 'admin')
+      AND status = 'active'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION is_group_owner(group_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM group_memberships
+    WHERE group_id = group_uuid
+      AND user_id = user_uuid
+      AND role = 'owner'
+      AND status = 'active'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION is_group_creator(group_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM groups
+    WHERE id = group_uuid
+      AND created_by = user_uuid
+  );
+$$;
+
+-- profiles
+CREATE POLICY "profiles: owner select" ON profiles FOR SELECT USING (auth.uid() = id);
+CREATE POLICY "profiles: owner insert" ON profiles FOR INSERT WITH CHECK (auth.uid() = id);
+CREATE POLICY "profiles: owner update" ON profiles FOR UPDATE USING (auth.uid() = id) WITH CHECK (auth.uid() = id);
+
+-- groups
+CREATE POLICY "groups: member select" ON groups FOR SELECT USING (is_active_group_member(id, auth.uid()));
+CREATE POLICY "groups: owner insert" ON groups FOR INSERT WITH CHECK (auth.uid() = created_by);
+CREATE POLICY "groups: manager update" ON groups FOR UPDATE USING (can_manage_group(id, auth.uid())) WITH CHECK (can_manage_group(id, auth.uid()));
+CREATE POLICY "groups: owner delete" ON groups FOR DELETE USING (is_group_owner(id, auth.uid()));
+
+-- group_memberships
+CREATE POLICY "group_memberships: member select" ON group_memberships
+  FOR SELECT
+  USING (is_active_group_member(group_id, auth.uid()));
+
+CREATE POLICY "group_memberships: manager insert" ON group_memberships
+  FOR INSERT
+  WITH CHECK (
+    can_manage_group(group_id, auth.uid())
+    OR (
+      auth.uid() = user_id
+      AND role = 'owner'
+      AND status = 'active'
+      AND is_group_creator(group_id, auth.uid())
+    )
+  );
+
+CREATE POLICY "group_memberships: manager update" ON group_memberships
+  FOR UPDATE
+  USING (can_manage_group(group_id, auth.uid()))
+  WITH CHECK (can_manage_group(group_id, auth.uid()));
+
+CREATE POLICY "group_memberships: self delete" ON group_memberships
+  FOR DELETE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "group_memberships: owner delete" ON group_memberships
+  FOR DELETE
+  USING (is_group_owner(group_id, auth.uid()));

--- a/supabase/migrations/20260428_create_group_with_owner_rpc.sql
+++ b/supabase/migrations/20260428_create_group_with_owner_rpc.sql
@@ -1,0 +1,50 @@
+-- Create a group and its owner membership in one trusted database operation.
+-- This avoids client-side bootstrap problems where the group is not readable
+-- until the first active membership exists.
+
+CREATE OR REPLACE FUNCTION create_group_with_owner(
+  group_name text,
+  group_description text DEFAULT NULL,
+  group_avatar_url text DEFAULT NULL
+)
+RETURNS SETOF groups
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  new_group_id uuid := gen_random_uuid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  IF NULLIF(btrim(group_name), '') IS NULL THEN
+    RAISE EXCEPTION 'Group name is required.';
+  END IF;
+
+  INSERT INTO profiles (id)
+  VALUES (current_user_id)
+  ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO groups (id, name, description, avatar_url, created_by)
+  VALUES (
+    new_group_id,
+    btrim(group_name),
+    NULLIF(btrim(group_description), ''),
+    NULLIF(btrim(group_avatar_url), ''),
+    current_user_id
+  );
+
+  INSERT INTO group_memberships (group_id, user_id, role, status)
+  VALUES (new_group_id, current_user_id, 'owner', 'active');
+
+  RETURN QUERY
+  SELECT g.*
+  FROM groups AS g
+  WHERE g.id = new_group_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_group_with_owner(text, text, text) TO authenticated;

--- a/supabase/migrations/20260428_fix_create_group_rpc_ambiguity.sql
+++ b/supabase/migrations/20260428_fix_create_group_rpc_ambiguity.sql
@@ -1,0 +1,52 @@
+-- Replace the group creation RPC with a version that does not declare output
+-- parameters named like table columns. PL/pgSQL treats RETURNS TABLE columns
+-- as variables, which can make references such as id ambiguous.
+
+DROP FUNCTION IF EXISTS create_group_with_owner(text, text, text);
+
+CREATE FUNCTION create_group_with_owner(
+  group_name text,
+  group_description text DEFAULT NULL,
+  group_avatar_url text DEFAULT NULL
+)
+RETURNS SETOF groups
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  new_group_id uuid := gen_random_uuid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  IF NULLIF(btrim(group_name), '') IS NULL THEN
+    RAISE EXCEPTION 'Group name is required.';
+  END IF;
+
+  INSERT INTO profiles (id)
+  VALUES (current_user_id)
+  ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO groups (id, name, description, avatar_url, created_by)
+  VALUES (
+    new_group_id,
+    btrim(group_name),
+    NULLIF(btrim(group_description), ''),
+    NULLIF(btrim(group_avatar_url), ''),
+    current_user_id
+  );
+
+  INSERT INTO group_memberships (group_id, user_id, role, status)
+  VALUES (new_group_id, current_user_id, 'owner', 'active');
+
+  RETURN QUERY
+  SELECT g.*
+  FROM groups AS g
+  WHERE g.id = new_group_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_group_with_owner(text, text, text) TO authenticated;

--- a/supabase/migrations/20260428_fix_group_owner_membership_policy.sql
+++ b/supabase/migrations/20260428_fix_group_owner_membership_policy.sql
@@ -1,0 +1,32 @@
+-- Allow the first owner membership to be inserted after a user creates a group.
+-- Existing projects may still have the older insert policy that queried groups
+-- through RLS, which blocks the bootstrap membership row.
+
+CREATE OR REPLACE FUNCTION is_group_creator(group_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM groups
+    WHERE id = group_uuid
+      AND created_by = user_uuid
+  );
+$$;
+
+DROP POLICY IF EXISTS "group_memberships: manager insert" ON group_memberships;
+
+CREATE POLICY "group_memberships: manager insert" ON group_memberships
+  FOR INSERT
+  WITH CHECK (
+    can_manage_group(group_id, auth.uid())
+    OR (
+      auth.uid() = user_id
+      AND role = 'owner'
+      AND status = 'active'
+      AND is_group_creator(group_id, auth.uid())
+    )
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -51,6 +51,39 @@ CREATE TABLE IF NOT EXISTS reading_logs (
   logged_at            timestamptz NOT NULL DEFAULT now()
 );
 
+-- ── PROFILES ──────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS profiles (
+  id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  first_name text,
+  last_name text,
+  avatar_url text,
+  bio text,
+  timezone text,
+  language text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- ── GROUPS ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS groups (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  description text,
+  avatar_url text,
+  created_by uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS group_memberships (
+  group_id uuid NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  role text NOT NULL DEFAULT 'member'
+    CHECK (role IN ('owner', 'admin', 'member')),
+  status text NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'invited')),
+  joined_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (group_id, user_id)
+);
+
 -- ── INDEXES ───────────────────────────────────────────────
 -- All queries are scoped by user_id; compound index on status
 -- supports the "currently reading" dashboard card query.
@@ -59,11 +92,83 @@ CREATE INDEX IF NOT EXISTS books_status_idx         ON books(user_id, status);
 CREATE INDEX IF NOT EXISTS series_user_id_idx       ON series(user_id);
 CREATE INDEX IF NOT EXISTS reading_logs_user_id_idx ON reading_logs(user_id);
 CREATE INDEX IF NOT EXISTS reading_logs_book_id_idx ON reading_logs(book_id);
+CREATE INDEX IF NOT EXISTS profiles_created_at_idx ON profiles(created_at);
+CREATE INDEX IF NOT EXISTS groups_created_by_idx ON groups(created_by);
+CREATE INDEX IF NOT EXISTS group_memberships_user_id_idx ON group_memberships(user_id);
+CREATE INDEX IF NOT EXISTS group_memberships_group_id_idx ON group_memberships(group_id);
 
 -- ── ROW LEVEL SECURITY ────────────────────────────────────
 ALTER TABLE series       ENABLE ROW LEVEL SECURITY;
 ALTER TABLE books        ENABLE ROW LEVEL SECURITY;
 ALTER TABLE reading_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE group_memberships ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION is_active_group_member(group_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM group_memberships
+    WHERE group_id = group_uuid
+      AND user_id = user_uuid
+      AND status = 'active'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION can_manage_group(group_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM group_memberships
+    WHERE group_id = group_uuid
+      AND user_id = user_uuid
+      AND role IN ('owner', 'admin')
+      AND status = 'active'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION is_group_owner(group_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM group_memberships
+    WHERE group_id = group_uuid
+      AND user_id = user_uuid
+      AND role = 'owner'
+      AND status = 'active'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION is_group_creator(group_uuid uuid, user_uuid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM groups
+    WHERE id = group_uuid
+      AND created_by = user_uuid
+  );
+$$;
 
 -- series
 CREATE POLICY "series: owner select" ON series FOR SELECT USING (auth.uid() = user_id);
@@ -82,3 +187,44 @@ CREATE POLICY "reading_logs: owner select" ON reading_logs FOR SELECT USING (aut
 CREATE POLICY "reading_logs: owner insert" ON reading_logs FOR INSERT WITH CHECK (auth.uid() = user_id);
 CREATE POLICY "reading_logs: owner update" ON reading_logs FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
 CREATE POLICY "reading_logs: owner delete" ON reading_logs FOR DELETE USING (auth.uid() = user_id);
+
+-- profiles
+CREATE POLICY "profiles: owner select" ON profiles FOR SELECT USING (auth.uid() = id);
+CREATE POLICY "profiles: owner insert" ON profiles FOR INSERT WITH CHECK (auth.uid() = id);
+CREATE POLICY "profiles: owner update" ON profiles FOR UPDATE USING (auth.uid() = id) WITH CHECK (auth.uid() = id);
+
+-- groups
+CREATE POLICY "groups: member select" ON groups FOR SELECT USING (is_active_group_member(id, auth.uid()));
+CREATE POLICY "groups: owner insert" ON groups FOR INSERT WITH CHECK (auth.uid() = created_by);
+CREATE POLICY "groups: manager update" ON groups FOR UPDATE USING (can_manage_group(id, auth.uid())) WITH CHECK (can_manage_group(id, auth.uid()));
+CREATE POLICY "groups: owner delete" ON groups FOR DELETE USING (is_group_owner(id, auth.uid()));
+
+-- group_memberships
+CREATE POLICY "group_memberships: member select" ON group_memberships
+  FOR SELECT
+  USING (is_active_group_member(group_id, auth.uid()));
+
+CREATE POLICY "group_memberships: manager insert" ON group_memberships
+  FOR INSERT
+  WITH CHECK (
+    can_manage_group(group_id, auth.uid())
+    OR (
+      auth.uid() = user_id
+      AND role = 'owner'
+      AND status = 'active'
+      AND is_group_creator(group_id, auth.uid())
+    )
+  );
+
+CREATE POLICY "group_memberships: manager update" ON group_memberships
+  FOR UPDATE
+  USING (can_manage_group(group_id, auth.uid()))
+  WITH CHECK (can_manage_group(group_id, auth.uid()));
+
+CREATE POLICY "group_memberships: self delete" ON group_memberships
+  FOR DELETE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "group_memberships: owner delete" ON group_memberships
+  FOR DELETE
+  USING (is_group_owner(group_id, auth.uid()));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -170,6 +170,53 @@ AS $$
   );
 $$;
 
+CREATE OR REPLACE FUNCTION create_group_with_owner(
+  group_name text,
+  group_description text DEFAULT NULL,
+  group_avatar_url text DEFAULT NULL
+)
+RETURNS SETOF groups
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  new_group_id uuid := gen_random_uuid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  IF NULLIF(btrim(group_name), '') IS NULL THEN
+    RAISE EXCEPTION 'Group name is required.';
+  END IF;
+
+  INSERT INTO profiles (id)
+  VALUES (current_user_id)
+  ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO groups (id, name, description, avatar_url, created_by)
+  VALUES (
+    new_group_id,
+    btrim(group_name),
+    NULLIF(btrim(group_description), ''),
+    NULLIF(btrim(group_avatar_url), ''),
+    current_user_id
+  );
+
+  INSERT INTO group_memberships (group_id, user_id, role, status)
+  VALUES (new_group_id, current_user_id, 'owner', 'active');
+
+  RETURN QUERY
+  SELECT g.*
+  FROM groups AS g
+  WHERE g.id = new_group_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_group_with_owner(text, text, text) TO authenticated;
+
 -- series
 CREATE POLICY "series: owner select" ON series FOR SELECT USING (auth.uid() = user_id);
 CREATE POLICY "series: owner insert" ON series FOR INSERT WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add Supabase profiles, groups, and group_memberships tables with conservative RLS
- add typed Supabase helpers for profile and group operations
- add an Account page for profile editing and basic group management
- route group creation through a `create_group_with_owner` RPC to avoid the first-owner-membership RLS bootstrap problem
- add repair migrations for existing databases that already applied the earlier group policies/RPC

## Database Notes
Apply the migrations in order. Existing databases that already ran the first migration should also apply:
- `20260428_fix_group_owner_membership_policy.sql`
- `20260428_create_group_with_owner_rpc.sql`
- `20260428_fix_create_group_rpc_ambiguity.sql`

## Verification
- `npm run typecheck` passed locally after the latest RPC fix.
- Manual local group creation should be retried after applying the latest RPC repair migration.