### PR TITLE
[codex] Add searchable library page

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -5,6 +5,7 @@ import {
   LogOut,
   LayoutDashboard,
   Library,
+  Search,
   KeyRound,
   BarChart3,
   UserRound,
@@ -99,6 +100,11 @@ export default function AppLayout() {
                 aria-label="Add book"
               >
                 <Plus className="h-5 w-5" />
+              </Button>
+              <Button size="icon" variant="ghost" asChild>
+                <Link to="/search" aria-label="Search">
+                  <Search className="h-5 w-5" />
+                </Link>
               </Button>
               <Button
                 size="icon"

--- a/src/lib/bookSearch.ts
+++ b/src/lib/bookSearch.ts
@@ -50,7 +50,10 @@ export interface BookSearchSection {
   matches: BookSearchMatch[];
 }
 
-export const BOOK_SEARCH_PROPERTIES: BookSearchProperty[] = [
+export const BOOK_SEARCH_PROPERTIES: Array<{
+  key: BookSearchPropertyKey;
+  label: string;
+}> = [
   { key: "title", label: "Title" },
   { key: "authors", label: "Authors" },
   { key: "genres", label: "Genres" },

--- a/src/lib/bookSearch.ts
+++ b/src/lib/bookSearch.ts
@@ -1,0 +1,296 @@
+import type { Book, Series } from "@/types";
+
+export type BookSearchPropertyKey =
+  | "title"
+  | "authors"
+  | "genres"
+  | "status"
+  | "rating"
+  | "favorite"
+  | "pagesProgress"
+  | "dates"
+  | "language"
+  | "belongsTo"
+  | "format"
+  | "isbn"
+  | "series"
+  | "volume";
+
+export type BookSearchSourceKey = BookSearchPropertyKey | (string & {});
+
+export interface BookSearchProperty {
+  key: BookSearchSourceKey;
+  label: string;
+}
+
+export interface BookSearchSource {
+  key: BookSearchSourceKey;
+  label: string;
+  getValues: (book: Book, context: BookSearchContext) => string[];
+}
+
+export interface BookSearchContext {
+  seriesById: Map<string, Series>;
+}
+
+export interface BookSearchOptions {
+  series?: Series[];
+  selectedProperties?: BookSearchSourceKey[];
+  additionalSources?: BookSearchSource[];
+}
+
+export interface BookSearchMatch {
+  book: Book;
+  property: BookSearchProperty;
+  values: string[];
+}
+
+export interface BookSearchSection {
+  property: BookSearchProperty;
+  matches: BookSearchMatch[];
+}
+
+export const BOOK_SEARCH_PROPERTIES: BookSearchProperty[] = [
+  { key: "title", label: "Title" },
+  { key: "authors", label: "Authors" },
+  { key: "genres", label: "Genres" },
+  { key: "status", label: "Status" },
+  { key: "series", label: "Series" },
+  { key: "volume", label: "Volume" },
+  { key: "language", label: "Language" },
+  { key: "format", label: "Format" },
+  { key: "belongsTo", label: "Belongs To" },
+  { key: "rating", label: "Rating" },
+  { key: "favorite", label: "Favorite" },
+  { key: "dates", label: "Dates" },
+  { key: "pagesProgress", label: "Pages / Progress" },
+  { key: "isbn", label: "ISBN" },
+];
+
+const BASE_SOURCES: BookSearchSource[] = [
+  {
+    key: "title",
+    label: "Title",
+    getValues: (book) => [book.title],
+  },
+  {
+    key: "authors",
+    label: "Authors",
+    getValues: (book) => book.authors,
+  },
+  {
+    key: "genres",
+    label: "Genres",
+    getValues: (book) => book.genres ?? [],
+  },
+  {
+    key: "status",
+    label: "Status",
+    getValues: (book) => [book.status],
+  },
+  {
+    key: "series",
+    label: "Series",
+    getValues: (book, context) => {
+      if (!book.series_id) return [];
+      const series = context.seriesById.get(book.series_id);
+      return series ? [series.name] : [];
+    },
+  },
+  {
+    key: "volume",
+    label: "Volume",
+    getValues: (book) =>
+      typeof book.volume_number === "number"
+        ? [`${book.volume_number}`, `Volume ${book.volume_number}`]
+        : [],
+  },
+  {
+    key: "language",
+    label: "Language",
+    getValues: (book) => (book.language ? [book.language] : []),
+  },
+  {
+    key: "format",
+    label: "Format",
+    getValues: (book) => (book.format ? [book.format] : []),
+  },
+  {
+    key: "belongsTo",
+    label: "Belongs To",
+    getValues: (book) => (book.belongs_to ? [book.belongs_to] : []),
+  },
+  {
+    key: "rating",
+    label: "Rating",
+    getValues: (book) =>
+      typeof book.rating === "number"
+        ? [`${book.rating}`, `${book.rating} stars`, `${book.rating}/5`]
+        : [],
+  },
+  {
+    key: "favorite",
+    label: "Favorite",
+    getValues: (book) => (book.is_favorite ? ["Is favorite", "Favorite"] : []),
+  },
+  {
+    key: "dates",
+    label: "Dates",
+    getValues: (book) => formatDateValues(book),
+  },
+  {
+    key: "pagesProgress",
+    label: "Pages / Progress",
+    getValues: (book) => formatProgressValues(book),
+  },
+  {
+    key: "isbn",
+    label: "ISBN",
+    getValues: (book) => (book.isbn ? [book.isbn] : []),
+  },
+];
+
+export function searchBooks(
+  books: Book[],
+  query: string,
+  options: BookSearchOptions = {}
+): BookSearchSection[] {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) return [];
+
+  const selected = new Set(
+    options.selectedProperties ?? BOOK_SEARCH_PROPERTIES.map((property) => property.key)
+  );
+  if (selected.size === 0) return [];
+
+  const context: BookSearchContext = {
+    seriesById: new Map((options.series ?? []).map((series) => [series.id, series])),
+  };
+
+  const sources = [...BASE_SOURCES, ...(options.additionalSources ?? [])].filter((source) =>
+    selected.has(source.key)
+  );
+
+  return sources
+    .map((source) => {
+      const matches = books
+        .map((book): BookSearchMatch | null => {
+          const values = unique(source.getValues(book, context).filter(Boolean));
+          const matchedValues = values.filter((value) => matchesQuery(value, normalizedQuery));
+          if (matchedValues.length === 0) return null;
+
+          return {
+            book,
+            property: { key: source.key, label: source.label },
+            values: matchedValues,
+          };
+        })
+        .filter((match): match is BookSearchMatch => match !== null);
+
+      return {
+        property: { key: source.key, label: source.label },
+        matches,
+      };
+    })
+    .filter((section) => section.matches.length > 0);
+}
+
+export function normalize(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .trim();
+}
+
+function matchesQuery(value: string, normalizedQuery: string): boolean {
+  const normalizedValue = normalize(value);
+  if (!normalizedValue) return false;
+  if (normalizedValue.includes(normalizedQuery)) return true;
+
+  const queryTokens = tokenize(normalizedQuery);
+  const valueTokens = tokenize(normalizedValue);
+
+  return queryTokens.every((queryToken) =>
+    valueTokens.some(
+      (valueToken) =>
+        valueToken.includes(queryToken) ||
+        isFuzzyTokenMatch(valueToken, queryToken)
+    )
+  );
+}
+
+function tokenize(value: string): string[] {
+  return value.split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+function isFuzzyTokenMatch(valueToken: string, queryToken: string): boolean {
+  if (queryToken.length < 4 || valueToken.length < 4) return false;
+  const maxDistance = queryToken.length >= 7 ? 2 : 1;
+  return levenshteinDistance(valueToken, queryToken) <= maxDistance;
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  const previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+
+  for (let i = 1; i <= a.length; i += 1) {
+    const current = [i];
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        current[j - 1] + 1,
+        previous[j] + 1,
+        previous[j - 1] + cost
+      );
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+
+  return previous[b.length];
+}
+
+function formatProgressValues(book: Book): string[] {
+  const values: string[] = [];
+  const currentPage = book.current_page;
+  const totalPages = book.total_pages;
+
+  if (typeof currentPage === "number") {
+    values.push(`${currentPage}`, `Page ${currentPage}`);
+  }
+
+  if (typeof totalPages === "number") {
+    values.push(`${totalPages}`, `${totalPages} pages`);
+  }
+
+  if (
+    typeof currentPage === "number" &&
+    typeof totalPages === "number" &&
+    totalPages > 0
+  ) {
+    const percent = Math.round((currentPage / totalPages) * 100);
+    values.push(`${currentPage} / ${totalPages}`, `${percent}%`);
+  }
+
+  return values;
+}
+
+function formatDateValues(book: Book): string[] {
+  const values: string[] = [];
+  if (book.date_started) {
+    values.push(book.date_started, `Started ${formatDateForDisplay(book.date_started)}`);
+  }
+  if (book.date_finished) {
+    values.push(book.date_finished, `Finished ${formatDateForDisplay(book.date_finished)}`);
+  }
+  return values;
+}
+
+function formatDateForDisplay(value: string): string {
+  const [year, month, day] = value.split("-");
+  if (!year || !month || !day) return value;
+  return `${day}.${month}.${year}`;
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values));
+}

--- a/src/lib/router.tsx
+++ b/src/lib/router.tsx
@@ -6,6 +6,7 @@ import AppLayout from "@/components/AppLayout";
 const Login = lazy(() => import("@/pages/Login"));
 const Dashboard = lazy(() => import("@/pages/Dashboard"));
 const Library = lazy(() => import("@/pages/Library"));
+const Search = lazy(() => import("@/pages/Search"));
 const Analytics = lazy(() => import("@/pages/Analytics"));
 const BookDetails = lazy(() => import("@/pages/BookDetails"));
 const Account = lazy(() => import("@/pages/Account"));
@@ -38,6 +39,7 @@ export const router = createBrowserRouter([
         children: [
           { path: "/", element: lazyRoute(<Dashboard />) },
           { path: "/library", element: lazyRoute(<Library />) },
+          { path: "/search", element: lazyRoute(<Search />) },
           { path: "/books/:bookId", element: lazyRoute(<BookDetails />) },
           { path: "/analytics", element: lazyRoute(<Analytics />) },
           { path: "/account", element: lazyRoute(<Account />) },

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { BookOpen, Check, SlidersHorizontal } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { useBooksContext } from "@/context/BooksContext";
+import { useSeries } from "@/hooks/useSeries";
+import {
+  BOOK_SEARCH_PROPERTIES,
+  searchBooks,
+  type BookSearchPropertyKey,
+} from "@/lib/bookSearch";
+import { cn, statusVariant } from "@/lib/utils";
+import type { Book } from "@/types";
+
+const allPropertyKeys = BOOK_SEARCH_PROPERTIES.map((property) => property.key);
+
+export default function Search() {
+  const navigate = useNavigate();
+  const { books, loading, error } = useBooksContext();
+  const { series } = useSeries();
+  const [query, setQuery] = useState("");
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [selectedProperties, setSelectedProperties] =
+    useState<BookSearchPropertyKey[]>(allPropertyKeys);
+  const filterRef = useRef<HTMLDivElement>(null);
+
+  const sections = useMemo(
+    () =>
+      searchBooks(books, query, {
+        series,
+        selectedProperties,
+      }),
+    [books, query, selectedProperties, series]
+  );
+
+  const hasQuery = query.trim().length > 0;
+  const allPropertiesSelected = selectedProperties.length === allPropertyKeys.length;
+
+  useEffect(() => {
+    if (!filtersOpen) return;
+
+    function handlePointerDown(event: PointerEvent) {
+      if (!filterRef.current?.contains(event.target as Node)) {
+        setFiltersOpen(false);
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [filtersOpen]);
+
+  function openBook(book: Book) {
+    navigate(`/books/${book.id}`);
+  }
+
+  function toggleProperty(property: BookSearchPropertyKey) {
+    setSelectedProperties((current) => {
+      if (current.length === allPropertyKeys.length) {
+        return [property];
+      }
+
+      if (current.includes(property)) {
+        return current.length === 1
+          ? allPropertyKeys
+          : current.filter((item) => item !== property);
+      }
+
+      return [...current, property];
+    });
+  }
+
+  function selectAllProperties() {
+    setSelectedProperties(allPropertyKeys);
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="text-2xl font-heading leading-snug font-medium">Search</h1>
+        <span className="text-sm text-muted-foreground">
+          {loading ? "…" : `${books.length} book${books.length !== 1 ? "s" : ""}`}
+        </span>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex gap-2">
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search books"
+            aria-label="Search books"
+            autoComplete="off"
+            className="h-10"
+          />
+          <div ref={filterRef} className="relative">
+            <Button
+              type="button"
+              size="icon-lg"
+              variant={filtersOpen ? "secondary" : "outline"}
+              aria-label="Search filters"
+              aria-expanded={filtersOpen}
+              aria-haspopup="menu"
+              onClick={() => setFiltersOpen((open) => !open)}
+            >
+              <SlidersHorizontal className="h-5 w-5" />
+            </Button>
+
+            {filtersOpen && (
+              <div className="absolute right-0 top-11 z-20 w-64 rounded-lg border bg-popover p-2 text-popover-foreground shadow-lg">
+                <div className="flex items-center justify-between gap-2 border-b pb-2">
+                  <p className="px-1 text-xs font-medium text-muted-foreground">
+                    Search properties
+                  </p>
+                  {!allPropertiesSelected && (
+                    <Button
+                      type="button"
+                      size="xs"
+                      variant="ghost"
+                      onClick={selectAllProperties}
+                    >
+                      All
+                    </Button>
+                  )}
+                </div>
+                <div className="mt-2 max-h-80 overflow-y-auto">
+                  {BOOK_SEARCH_PROPERTIES.map((property) => {
+                    const selected = selectedProperties.includes(property.key);
+                    return (
+                      <button
+                        key={property.key}
+                        type="button"
+                        role="menuitemcheckbox"
+                        aria-checked={selected}
+                        className="flex w-full items-center justify-between gap-3 rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+                        onClick={() => toggleProperty(property.key)}
+                      >
+                        <span>{property.label}</span>
+                        <span
+                          className={cn(
+                            "flex h-4 w-4 items-center justify-center rounded-sm border",
+                            selected
+                              ? "border-primary bg-primary text-primary-foreground"
+                              : "border-input"
+                          )}
+                          aria-hidden="true"
+                        >
+                          {selected && <Check className="h-3 w-3" />}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {!allPropertiesSelected && (
+          <p className="text-xs text-muted-foreground">
+            Searching {selectedProperties.length} of {allPropertyKeys.length} properties
+          </p>
+        )}
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {!loading && !error && !hasQuery && (
+        <EmptyState message="Enter a search term to search your library." />
+      )}
+
+      {!loading && !error && hasQuery && sections.length === 0 && (
+        <EmptyState message="No matching books found." />
+      )}
+
+      {sections.map((section) => (
+        <section key={section.property.key} className="space-y-3">
+          <div>
+            <h2 className="font-heading leading-snug font-medium">
+              {section.property.label}
+            </h2>
+            <p className="text-xs text-muted-foreground">
+              {section.matches.length} match{section.matches.length !== 1 ? "es" : ""}
+            </p>
+          </div>
+          <Separator />
+          <div className="space-y-2">
+            {section.matches.map((match) => (
+              <button
+                key={`${section.property.key}-${match.book.id}`}
+                type="button"
+                className="flex w-full items-center gap-3 rounded-lg border bg-card p-2 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+                onClick={() => openBook(match.book)}
+              >
+                <BookCover book={match.book} />
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex min-w-0 items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">{match.book.title}</p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {match.book.authors.join(", ")}
+                      </p>
+                    </div>
+                    <Badge
+                      variant={statusVariant(match.book.status)}
+                      className="hidden sm:inline-flex"
+                    >
+                      {match.book.status}
+                    </Badge>
+                  </div>
+                  {!["title", "authors", "status"].includes(section.property.key) && (
+                    <div className="flex flex-wrap gap-1.5">
+                      {match.values.map((value) => (
+                        <Badge
+                          key={value}
+                          variant="outline"
+                          className="max-w-full truncate"
+                        >
+                          {value}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function BookCover({ book }: { book: Book }) {
+  return (
+    <div
+      className={cn(
+        "flex h-16 w-11 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted"
+      )}
+    >
+      {book.cover_url ? (
+        <img src={book.cover_url} alt="" className="h-full w-full object-cover" />
+      ) : (
+        <BookOpen className="h-5 w-5 text-muted-foreground/50" />
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-16 text-center">
+      <BookOpen className="h-10 w-10 text-muted-foreground/40" />
+      <p className="text-sm text-muted-foreground">{message}</p>
+    </div>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,5 +1,6 @@
 export { default as Login } from "./Login";
 export { default as Dashboard } from "./Dashboard";
 export { default as Library } from "./Library";
+export { default as Search } from "./Search";
 export { default as Analytics } from "./Analytics";
 export { default as BookDetails } from "./BookDetails";

--- a/tests/bookSearch.test.ts
+++ b/tests/bookSearch.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { searchBooks, type BookSearchPropertyKey } from "../src/lib/bookSearch";
+import type { Book, Series } from "../src/types";
+
+const series: Series[] = [
+  {
+    id: "series-1",
+    name: "The Broken Earth",
+    user_id: "user-1",
+    created_at: "2026-04-01T10:00:00Z",
+  },
+];
+
+function makeBook(overrides: Partial<Book>): Book {
+  return {
+    id: "book-1",
+    title: "The Fifth Season",
+    authors: ["N. K. Jemisin"],
+    genres: ["Fantasy", "Science Fiction"],
+    status: "Reading",
+    rating: 5,
+    is_favorite: true,
+    current_page: 120,
+    total_pages: 512,
+    date_started: "2026-04-10",
+    language: "English",
+    belongs_to: "Me",
+    format: "Paperback",
+    isbn: "9780316229296",
+    series_id: "series-1",
+    volume_number: 1,
+    user_id: "user-1",
+    created_at: "2026-04-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function sectionKeys(query: string, selectedProperties?: BookSearchPropertyKey[]) {
+  return searchBooks([makeBook({})], query, { series, selectedProperties }).map(
+    (section) => section.property.key
+  );
+}
+
+test("matches case-insensitive partial title queries", () => {
+  const sections = searchBooks([makeBook({})], "fif", { series });
+
+  assert.deepEqual(
+    sections.map((section) => section.property.key),
+    ["title"]
+  );
+  assert.equal(sections[0].matches[0].book.title, "The Fifth Season");
+  assert.deepEqual(sections[0].matches[0].values, ["The Fifth Season"]);
+});
+
+test("matches array fields like authors and genres", () => {
+  assert.deepEqual(sectionKeys("jem"), ["authors"]);
+  assert.deepEqual(sectionKeys("fant"), ["genres"]);
+});
+
+test("resolves series names from series_id", () => {
+  const sections = searchBooks([makeBook({})], "broken", { series });
+
+  assert.deepEqual(
+    sections.map((section) => section.property.key),
+    ["series"]
+  );
+  assert.deepEqual(sections[0].matches[0].values, ["The Broken Earth"]);
+});
+
+test("groups results by every matched property", () => {
+  const sections = searchBooks([makeBook({})], "paper", { series });
+
+  assert.deepEqual(
+    sections.map((section) => section.property.key),
+    ["format"]
+  );
+  assert.deepEqual(sections[0].matches.map((match) => match.book.id), ["book-1"]);
+});
+
+test("repeats a book across multiple matched property sections", () => {
+  const book = makeBook({
+    title: "English Lessons",
+    genres: ["English history"],
+    language: "English",
+  });
+
+  const sections = searchBooks([book], "english", { series });
+
+  assert.deepEqual(
+    sections.map((section) => section.property.key),
+    ["title", "genres", "language"]
+  );
+  assert.deepEqual(
+    sections.flatMap((section) => section.matches.map((match) => match.book.id)),
+    ["book-1", "book-1", "book-1"]
+  );
+});
+
+test("limits results to selected property filters", () => {
+  const book = makeBook({
+    title: "English Lessons",
+    genres: ["English history"],
+    language: "English",
+  });
+
+  const sections = searchBooks([book], "english", {
+    series,
+    selectedProperties: ["language"],
+  });
+
+  assert.deepEqual(
+    sections.map((section) => section.property.key),
+    ["language"]
+  );
+});
+
+test("returns no sections for an empty query", () => {
+  assert.deepEqual(searchBooks([makeBook({})], "   ", { series }), []);
+});
+
+test("matches favorite searches only for books marked as favorite", () => {
+  const favorite = makeBook({ id: "favorite-book", is_favorite: true });
+  const notFavorite = makeBook({ id: "regular-book", is_favorite: false });
+
+  const sections = searchBooks([favorite, notFavorite], "is favorite", { series });
+
+  assert.deepEqual(
+    sections.map((section) => section.property.key),
+    ["favorite"]
+  );
+  assert.deepEqual(
+    sections[0].matches.map((match) => match.book.id),
+    ["favorite-book"]
+  );
+  assert.deepEqual(sections[0].matches[0].values, ["Is favorite"]);
+});
+
+test("searches user-visible property values but not internal fields", () => {
+  const book = makeBook({
+    id: "hidden-id-match",
+    user_id: "hidden-user-match",
+    created_at: "hidden-created-match",
+    cover_url: "https://example.com/hidden-cover-match.jpg",
+    metadata_source_url: "https://example.com/hidden-source-match",
+  });
+
+  assert.deepEqual(searchBooks([book], "hidden", { series }), []);
+});


### PR DESCRIPTION
## Summary

Adds a protected Search page for the book library with client-side fuzzy/partial matching across user-visible book properties.

## What changed

- Added a lazy /search route and exposed it through a magnifying-glass header button between Add book and Set password.
- Added src/lib/bookSearch.ts, a pure search helper that normalizes case/diacritics, supports partial/token/fuzzy matching, and groups results by matched property.
- Searches visible book properties including title, authors, genres, status, series, volume, language, format, belongs to, rating, favorite, dates, pages/progress, and ISBN.
- Excludes internal/system fields such as IDs, user IDs, created timestamps, cover URLs, and metadata source URLs.
- Added a filter dropdown beside the search input for selecting one or more searchable properties.
- Added compact clickable grouped result rows that open the book details page.
- Avoided duplicate matched-value badges for title, authors, and status because those values are already visible in each row.
- Added an extension hook for future search sources, so Notes content can be wired later without changing the core search flow.

## User impact

Users can quickly find books by title, author, metadata, status, series, favorite state, progress, and other visible properties without leaving the app or relying on an external search service.

## Validation

- npm test passes, 28/28
- npm run typecheck passes
