### PR TITLE
[codex] Fix clearing book ratings

### DIFF
--- a/src/context/BooksContext.tsx
+++ b/src/context/BooksContext.tsx
@@ -1,13 +1,13 @@
 import { createContext, useContext, type ReactNode } from "react";
 import { useBooks, type AddBookPayload, type AddBookResult } from "@/hooks/useBooks";
-import type { Book } from "@/types";
+import type { Book, BookUpdate } from "@/types";
 
 interface BooksContextValue {
   books: Book[];
   loading: boolean;
   error: string | null;
   addBook: (payload: AddBookPayload, coverFile?: File) => Promise<AddBookResult>;
-  updateBook: (id: string, payload: Partial<Book>) => Promise<void>;
+  updateBook: (id: string, payload: BookUpdate) => Promise<void>;
   updateCover: (id: string, file: File) => Promise<void>;
   deleteBook: (id: string) => Promise<void>;
   reload: () => Promise<void>;

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -9,7 +9,7 @@ import {
   deleteCover,
   type BookInsert,
 } from "@/lib/books";
-import type { Book } from "@/types";
+import type { Book, BookUpdate } from "@/types";
 
 export interface AddBookPayload
   extends Omit<BookInsert, "id" | "cover_url" | "user_id"> {}
@@ -76,7 +76,7 @@ export function useBooks() {
   );
 
   const updateBook = useCallback(
-    async (id: string, payload: Partial<Book>): Promise<void> => {
+    async (id: string, payload: BookUpdate): Promise<void> => {
       const updated = await updateBookDb(id, payload);
       setBooks((prev) => prev.map((b) => (b.id === id ? updated : b)));
     },

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -1,5 +1,5 @@
 import { supabase } from "./supabase";
-import type { Book, Series, ReadingLog } from "@/types";
+import type { Book, BookUpdate, Series, ReadingLog } from "@/types";
 
 type LegacyAuthorBookRow = Omit<Book, "authors"> & {
   authors?: string[] | null;
@@ -152,7 +152,7 @@ export async function createBook(payload: BookInsert): Promise<Book> {
 
 export async function updateBook(
   id: string,
-  payload: Partial<Omit<Book, "id" | "user_id" | "created_at">>
+  payload: BookUpdate,
 ): Promise<Book> {
   try {
     return await updateBookPayload(id, payload);
@@ -160,14 +160,14 @@ export async function updateBook(
     if (!isMissingMetadataSourceColumnError(error)) throw error;
     return updateBookPayload(
       id,
-      withoutMetadataSourcePayload(payload) as Partial<Omit<Book, "id" | "user_id" | "created_at">>,
+      withoutMetadataSourcePayload(payload) as BookUpdate,
     );
   }
 }
 
 async function updateBookPayload(
   id: string,
-  payload: Partial<Omit<Book, "id" | "user_id" | "created_at">>,
+  payload: BookUpdate,
 ): Promise<Book> {
   const { data, error } = await supabase
     .from("books")

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -199,7 +199,7 @@ export default function BookDetails() {
     if (!book) return;
     const next = localRating === rating ? null : rating;
     setLocalRating(next);
-    await updateBook(book.id, { rating: next ?? undefined });
+    await updateBook(book.id, { rating: next });
   }
 
   async function handleCoverChange(event: ChangeEvent<HTMLInputElement>) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,7 +29,7 @@ export interface Book {
   genres?: string[];
   status: BookStatus;
   cover_url?: string;
-  rating?: number; // 1–5
+  rating?: number | null; // 1-5, or null when unrated
   is_favorite: boolean;
   current_page?: number;
   total_pages?: number;
@@ -46,6 +46,8 @@ export interface Book {
   user_id: string;
   created_at: string;
 }
+
+export type BookUpdate = Partial<Omit<Book, "id" | "user_id" | "created_at">>;
 
 export interface ReadingLog {
   id: string;


### PR DESCRIPTION
## Summary
- Persist cleared book ratings as NULL instead of omitting the rating field.
- Add a shared BookUpdate type so nullable rating updates are type-safe.

## Validation
- npm run typecheck
- npm test

Closes #120