### PR TITLE
[codex] Improve weekday patterns chart

### DIFF
--- a/src/components/WeekdayPatternsChart.tsx
+++ b/src/components/WeekdayPatternsChart.tsx
@@ -1,35 +1,46 @@
-import type { ReadingHabitsMetrics, WeekdayStats } from "@/lib/readingHabits";
+import { ChartScatter } from "lucide-react";
+import { useState } from "react";
+
+import { formatMinutesCompact, type ReadingHabitsMetrics, type WeekdayStats } from "@/lib/readingHabits";
 
 interface WeekdayPatternsChartProps {
   weekdays: ReadingHabitsMetrics["weekdays"];
 }
 
-const MINUTES_COLOR = "#111111";
-const SESSIONS_COLOR = "#EEBC72";
+const DOT_COLOR = "#EEBC72";
 
-function getBarPercent(value: number, maxValue: number): number {
+function getColumnPercent(value: number, maxValue: number): number {
   if (value <= 0 || maxValue <= 0) return 0;
-  return Math.max((value / maxValue) * 100, 4);
+  return Math.max((value / maxValue) * 100, 6);
 }
 
 function getActivityLabel(day: WeekdayStats, highest: WeekdayStats, lowest: WeekdayStats): string | null {
   const isMost = day.weekdayLabel === highest.weekdayLabel;
   const isLeast = day.weekdayLabel === lowest.weekdayLabel;
 
-  if (isMost && isLeast) return "Most & least";
+  if (isMost && isLeast) return "Most and least active";
   if (isMost) return "Most active";
   if (isLeast) return "Least active";
   return null;
 }
 
 function getActivityMarker(label: string | null): string | null {
-  if (label === "Most & least") return "↕";
+  if (label === "Most and least active") return "↕";
   if (label === "Most active") return "↑";
   if (label === "Least active") return "↓";
   return null;
 }
 
+function formatWeekStart(weekStartIso: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(weekStartIso));
+}
+
 export default function WeekdayPatternsChart({ weekdays }: WeekdayPatternsChartProps) {
+  const [showWeeklyDots, setShowWeeklyDots] = useState(true);
+
   const highest = weekdays.highest;
   const lowest = weekdays.lowest;
 
@@ -41,84 +52,121 @@ export default function WeekdayPatternsChart({ weekdays }: WeekdayPatternsChartP
     );
   }
 
-  const maxMinutes = Math.max(...weekdays.all.map((day) => day.avgMinutesPerWeek), 0);
-  const maxSessions = Math.max(...weekdays.all.map((day) => day.avgSessionsPerWeek), 0);
+  const maxMedianMinutes = Math.max(...weekdays.all.map((day) => day.medianMinutesPerWeek), 0);
+  const maxWeeklyMinutes = Math.max(
+    ...weekdays.all.flatMap((day) => day.weeklyValues.map((week) => week.minutes)),
+    0
+  );
+  const chartMaxMinutes = Math.max(maxMedianMinutes, showWeeklyDots ? maxWeeklyMinutes : 0);
 
   return (
-    <section className="mt-3 space-y-2" aria-label="Weekday patterns chart">
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-muted-foreground" aria-label="Chart legend">
-        <span className="inline-flex items-center gap-1.5">
-          <span className="h-2 w-2 rounded-sm" style={{ backgroundColor: MINUTES_COLOR }} aria-hidden="true" />
-          Minutes/week
-        </span>
-        <span className="inline-flex items-center gap-1.5">
-          <span className="h-2 w-2 rounded-sm" style={{ backgroundColor: SESSIONS_COLOR }} aria-hidden="true" />
-          Sessions/week
-        </span>
-        <span className="inline-flex items-center gap-1.5" aria-hidden="true">
-          <span>↑</span>
-          Most active
-        </span>
-        <span className="inline-flex items-center gap-1.5" aria-hidden="true">
-          <span>↓</span>
-          Least active
-        </span>
+    <section className="mt-3 space-y-3" aria-label="Weekday patterns chart">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-muted-foreground" aria-label="Chart legend">
+          <span className="inline-flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-sm bg-primary/85" aria-hidden="true" />
+            Median minutes/week
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full" style={{ backgroundColor: DOT_COLOR }} aria-hidden="true" />
+            Individual weeks
+          </span>
+          <span className="inline-flex items-center gap-1.5" aria-hidden="true">
+            <span>↑</span>
+            Most typical
+          </span>
+          <span className="inline-flex items-center gap-1.5" aria-hidden="true">
+            <span>↓</span>
+            Least typical
+          </span>
+        </div>
+
+        <button
+          type="button"
+          className="inline-flex h-6 items-center gap-1.5 rounded-sm px-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+          onClick={() => setShowWeeklyDots((current) => !current)}
+          aria-pressed={showWeeklyDots}
+        >
+          <span
+            className="flex h-3.5 w-3.5 items-center justify-center rounded-[2px] border border-muted-foreground/70 text-[10px] leading-none"
+            aria-hidden="true"
+          >
+            {showWeeklyDots ? "✓" : ""}
+          </span>
+          Individual weeks
+        </button>
       </div>
 
-      <ul className="overflow-hidden rounded-md border" aria-label="Weekday rows from Monday to Sunday">
-        {weekdays.all.map((day) => {
-          const activityLabel = getActivityLabel(day, highest, lowest);
-          const activityMarker = getActivityMarker(activityLabel);
-          const minutesPerWeek = day.avgMinutesPerWeek.toFixed(1);
-          const sessionsPerWeek = day.avgSessionsPerWeek.toFixed(1);
+      <div className="rounded-md border px-3 py-3">
+        <div className="grid h-56 grid-cols-7 items-end gap-2" aria-label="Median reading minutes by weekday">
+          {weekdays.all.map((day) => {
+            const activityLabel = getActivityLabel(day, highest, lowest);
+            const activityMarker = getActivityMarker(activityLabel);
+            const medianMinutes = day.medianMinutesPerWeek;
+            const medianLabel = formatMinutesCompact(medianMinutes);
+            const columnHeight = getColumnPercent(medianMinutes, chartMaxMinutes);
 
-          return (
-            <li
-              key={day.weekdayLabel}
-              tabIndex={0}
-              className="grid grid-cols-[4.75rem_minmax(0,1fr)] items-stretch border-b bg-background last:border-b-0 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
-              aria-label={`${day.weekdayLabel}: ${minutesPerWeek} minutes per week, ${sessionsPerWeek} sessions per week${activityLabel ? `, ${activityLabel.toLowerCase()}` : ""}`}
-            >
-              <div className="flex items-center gap-1.5 border-r bg-muted/15 px-2 py-2">
-                <span className="text-sm font-medium">{day.weekdayLabel.slice(0, 3)}</span>
-                {activityMarker ? (
-                  <span className="text-[11px] leading-none text-muted-foreground" title={activityLabel ?? undefined} aria-hidden="true">
-                    {activityMarker}
+            return (
+              <div
+                key={day.weekdayLabel}
+                tabIndex={0}
+                className="group flex h-full min-w-0 flex-col justify-end rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                aria-label={`${day.weekdayLabel}: median ${medianLabel} per week, ${day.totalSessions} total sessions${activityLabel ? `, ${activityLabel.toLowerCase()}` : ""}`}
+              >
+                <div className="mb-2 text-center text-xs font-medium tabular-nums">{medianLabel}</div>
+
+                <div className="relative mx-auto flex h-36 w-full max-w-12 items-end justify-center border-b border-muted">
+                  {showWeeklyDots
+                    ? day.weeklyValues.map((week, index) => {
+                        if (week.minutes <= 0) return null;
+
+                        const dotBottom = getColumnPercent(week.minutes, chartMaxMinutes);
+                        const dotOffset = day.weeklyValues.length <= 1 ? 50 : (index / (day.weeklyValues.length - 1)) * 70 + 15;
+
+                        return (
+                          <span
+                            key={`${week.weekStartIso}-${index}`}
+                            className="absolute h-1.5 w-1.5 rounded-full opacity-75 shadow-sm"
+                            style={{
+                              bottom: `${dotBottom}%`,
+                              left: `${dotOffset}%`,
+                              backgroundColor: DOT_COLOR,
+                            }}
+                            title={`${formatWeekStart(week.weekStartIso)}: ${formatMinutesCompact(week.minutes)}`}
+                            aria-hidden="true"
+                          />
+                        );
+                      })
+                    : null}
+
+                  <div
+                    className="w-7 rounded-t-sm bg-primary/85 transition-colors group-hover:bg-primary"
+                    style={{
+                      height: `${columnHeight}%`,
+                    }}
+                    aria-hidden="true"
+                  />
+                </div>
+
+                <div className="mt-2 flex min-h-8 flex-col items-center justify-start text-center">
+                  <span className="text-sm font-medium leading-tight">{day.weekdayLabel.slice(0, 3)}</span>
+                  <span className="text-[11px] leading-tight text-muted-foreground">
+                    {activityMarker ? `${activityMarker} ` : ""}
+                    {day.totalSessions} session{day.totalSessions === 1 ? "" : "s"}
                   </span>
-                ) : null}
-              </div>
-
-              <div className="grid gap-0.5">
-                <div className="grid grid-cols-[minmax(0,1fr)_3rem] items-center gap-2 px-2 py-1">
-                  <div className="h-2 overflow-hidden rounded-full bg-muted/50" role="img" aria-label={`${minutesPerWeek} minutes per week`}>
-                    <div
-                      className="h-full rounded-full"
-                      style={{
-                        width: `${getBarPercent(day.avgMinutesPerWeek, maxMinutes)}%`,
-                        backgroundColor: MINUTES_COLOR,
-                      }}
-                    />
-                  </div>
-                  <span className="text-right text-xs font-medium tabular-nums sm:text-sm">{minutesPerWeek}</span>
-                </div>
-
-                <div className="grid grid-cols-[minmax(0,1fr)_3rem] items-center gap-2 px-2 py-1">
-                  <div className="h-2 overflow-hidden rounded-full bg-muted/50" role="img" aria-label={`${sessionsPerWeek} sessions per week`}>
-                    <div
-                      className="h-full rounded-full"
-                      style={{
-                        width: `${getBarPercent(day.avgSessionsPerWeek, maxSessions)}%`,
-                        backgroundColor: SESSIONS_COLOR,
-                      }}
-                    />
-                  </div>
-                  <span className="text-right text-xs font-medium tabular-nums sm:text-sm">{sessionsPerWeek}</span>
                 </div>
               </div>
-            </li>
-          );
-        })}
-      </ul>
+            );
+          })}
+        </div>
+
+        {showWeeklyDots ? (
+          <p className="mt-3 flex items-start gap-1.5 text-xs text-muted-foreground">
+            <ChartScatter className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Dots show individual weeks, so one unusually long week does not get hidden by the median.
+          </p>
+        ) : null}
+      </div>
     </section>
   );
 }

--- a/src/lib/readingHabits.ts
+++ b/src/lib/readingHabits.ts
@@ -41,8 +41,15 @@ export interface WeekdayStats {
   weekdayLabel: (typeof WEEKDAY_LABELS)[number];
   avgMinutesPerWeek: number;
   avgSessionsPerWeek: number;
+  medianMinutesPerWeek: number;
+  medianSessionsPerWeek: number;
   totalMinutes: number;
   totalSessions: number;
+  weeklyValues: {
+    weekStartIso: string;
+    minutes: number;
+    sessions: number;
+  }[];
 }
 
 export interface ReadingHabitsMetrics {
@@ -83,6 +90,12 @@ function startOfLocalDay(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
+function startOfLocalWeek(date: Date): Date {
+  const start = startOfLocalDay(date);
+  start.setDate(start.getDate() - toMondayFirstWeekdayIndex(start.getDay()));
+  return start;
+}
+
 function getWeekSpan(startIso: string, endIso: string): number {
   const start = startOfLocalDay(new Date(startIso));
   const end = startOfLocalDay(new Date(endIso));
@@ -98,6 +111,44 @@ function getEffectiveWeekSpan(logs: ReadingLog[], startIso: string, endIso: stri
   const firstLogStart = startOfLocalDay(new Date(logs[0].logged_at));
   const effectiveStart = firstLogStart > rangeStart ? firstLogStart : rangeStart;
   return getWeekSpan(effectiveStart.toISOString(), endIso);
+}
+
+function getEffectiveStartDate(logs: ReadingLog[], startIso: string): Date {
+  if (logs.length === 0) return startOfLocalDay(new Date(startIso));
+
+  const rangeStart = startOfLocalDay(new Date(startIso));
+  const firstLogStart = startOfLocalDay(new Date(logs[0].logged_at));
+  return firstLogStart > rangeStart ? firstLogStart : rangeStart;
+}
+
+function getWeekStarts(start: Date, end: Date): Date[] {
+  const weekStarts: Date[] = [];
+  const cursor = startOfLocalWeek(start);
+  const finalWeekStart = startOfLocalWeek(end);
+
+  while (cursor <= finalWeekStart) {
+    weekStarts.push(new Date(cursor));
+    cursor.setDate(cursor.getDate() + 7);
+  }
+
+  return weekStarts;
+}
+
+function getWeekKey(date: Date): string {
+  return startOfLocalWeek(date).toISOString();
+}
+
+function getMedian(values: number[]): number {
+  if (values.length === 0) return 0;
+
+  const sortedValues = [...values].sort((left, right) => left - right);
+  const middleIndex = Math.floor(sortedValues.length / 2);
+
+  if (sortedValues.length % 2 === 1) {
+    return sortedValues[middleIndex];
+  }
+
+  return (sortedValues[middleIndex - 1] + sortedValues[middleIndex]) / 2;
 }
 
 function allocateMinutesByHour(
@@ -159,8 +210,11 @@ export function calculateReadingHabits(
           weekdayLabel,
           avgMinutesPerWeek: 0,
           avgSessionsPerWeek: 0,
+          medianMinutesPerWeek: 0,
+          medianSessionsPerWeek: 0,
           totalMinutes: 0,
           totalSessions: 0,
+          weeklyValues: [],
         })),
       },
     };
@@ -177,13 +231,21 @@ export function calculateReadingHabits(
 
   const weekdayMinutesTotal = new Array<number>(7).fill(0);
   const weekdaySessionsTotal = new Array<number>(7).fill(0);
+  const weekdayWeeklyMinutes = Array.from({ length: 7 }, () => new Map<string, number>());
+  const weekdayWeeklySessions = Array.from({ length: 7 }, () => new Map<string, number>());
 
   const logsByBook = new Map<string, ReadingLog[]>();
 
   for (const log of sortedLogs) {
     const loggedAt = new Date(log.logged_at);
     const weekdayIndex = toMondayFirstWeekdayIndex(loggedAt.getDay());
+    const loggedAtWeekKey = getWeekKey(loggedAt);
+
     weekdaySessionsTotal[weekdayIndex] += 1;
+    weekdayWeeklySessions[weekdayIndex].set(
+      loggedAtWeekKey,
+      (weekdayWeeklySessions[weekdayIndex].get(loggedAtWeekKey) ?? 0) + 1
+    );
 
     const readingMinutes = log.reading_time_minutes ?? 0;
     if (readingMinutes > 0) {
@@ -194,10 +256,15 @@ export function calculateReadingHabits(
         const chunkHour = chunkStart.getHours();
         const chunkDayPart = getDayPartLabel(chunkHour);
         const chunkWeekdayIndex = toMondayFirstWeekdayIndex(chunkStart.getDay());
+        const chunkWeekKey = getWeekKey(chunkStart);
 
         dayPartMinutes.set(chunkDayPart, (dayPartMinutes.get(chunkDayPart) ?? 0) + chunkMinutes);
         hourMinutes[chunkHour] += chunkMinutes;
         weekdayMinutesTotal[chunkWeekdayIndex] += chunkMinutes;
+        weekdayWeeklyMinutes[chunkWeekdayIndex].set(
+          chunkWeekKey,
+          (weekdayWeeklyMinutes[chunkWeekdayIndex].get(chunkWeekKey) ?? 0) + chunkMinutes
+        );
       });
     }
 
@@ -251,23 +318,43 @@ export function calculateReadingHabits(
     maxHourCount > 0 ? hourMinutes.findIndex((count) => count === maxHourCount) : null;
 
   const weekSpan = getEffectiveWeekSpan(sortedLogs, startIso, endIso);
-  const weekdayStats: WeekdayStats[] = WEEKDAY_LABELS.map((weekdayLabel, index) => ({
-    weekdayLabel,
-    avgMinutesPerWeek: weekdayMinutesTotal[index] / weekSpan,
-    avgSessionsPerWeek: weekdaySessionsTotal[index] / weekSpan,
-    totalMinutes: weekdayMinutesTotal[index],
-    totalSessions: weekdaySessionsTotal[index],
-  }));
+  const effectiveStartDate = getEffectiveStartDate(sortedLogs, startIso);
+  const weekStarts = getWeekStarts(effectiveStartDate, startOfLocalDay(new Date(endIso)));
+  const weekKeys = weekStarts.map((weekStart) => weekStart.toISOString());
+  const weekdayStats: WeekdayStats[] = WEEKDAY_LABELS.map((weekdayLabel, index) => {
+    const weeklyValues = weekKeys.map((weekStartIso) => ({
+      weekStartIso,
+      minutes: weekdayWeeklyMinutes[index].get(weekStartIso) ?? 0,
+      sessions: weekdayWeeklySessions[index].get(weekStartIso) ?? 0,
+    }));
+
+    return {
+      weekdayLabel,
+      avgMinutesPerWeek: weekdayMinutesTotal[index] / weekSpan,
+      avgSessionsPerWeek: weekdaySessionsTotal[index] / weekSpan,
+      medianMinutesPerWeek: getMedian(weeklyValues.map((week) => week.minutes)),
+      medianSessionsPerWeek: getMedian(weeklyValues.map((week) => week.sessions)),
+      totalMinutes: weekdayMinutesTotal[index],
+      totalSessions: weekdaySessionsTotal[index],
+      weeklyValues,
+    };
+  });
 
   const hasWeekdayActivity = weekdayStats.some((weekday) => weekday.totalSessions > 0);
 
   const highest = hasWeekdayActivity
     ? [...weekdayStats].sort((left, right) => {
-        if (right.avgMinutesPerWeek !== left.avgMinutesPerWeek) {
-          return right.avgMinutesPerWeek - left.avgMinutesPerWeek;
+        if (right.medianMinutesPerWeek !== left.medianMinutesPerWeek) {
+          return right.medianMinutesPerWeek - left.medianMinutesPerWeek;
         }
-        if (right.avgSessionsPerWeek !== left.avgSessionsPerWeek) {
-          return right.avgSessionsPerWeek - left.avgSessionsPerWeek;
+        if (right.medianSessionsPerWeek !== left.medianSessionsPerWeek) {
+          return right.medianSessionsPerWeek - left.medianSessionsPerWeek;
+        }
+        if (right.totalMinutes !== left.totalMinutes) {
+          return right.totalMinutes - left.totalMinutes;
+        }
+        if (right.totalSessions !== left.totalSessions) {
+          return right.totalSessions - left.totalSessions;
         }
         return WEEKDAY_LABELS.indexOf(left.weekdayLabel) - WEEKDAY_LABELS.indexOf(right.weekdayLabel);
       })[0]
@@ -275,11 +362,17 @@ export function calculateReadingHabits(
 
   const lowest = hasWeekdayActivity
     ? [...weekdayStats].sort((left, right) => {
-        if (left.avgMinutesPerWeek !== right.avgMinutesPerWeek) {
-          return left.avgMinutesPerWeek - right.avgMinutesPerWeek;
+        if (left.medianMinutesPerWeek !== right.medianMinutesPerWeek) {
+          return left.medianMinutesPerWeek - right.medianMinutesPerWeek;
         }
-        if (left.avgSessionsPerWeek !== right.avgSessionsPerWeek) {
-          return left.avgSessionsPerWeek - right.avgSessionsPerWeek;
+        if (left.medianSessionsPerWeek !== right.medianSessionsPerWeek) {
+          return left.medianSessionsPerWeek - right.medianSessionsPerWeek;
+        }
+        if (left.totalMinutes !== right.totalMinutes) {
+          return left.totalMinutes - right.totalMinutes;
+        }
+        if (left.totalSessions !== right.totalSessions) {
+          return left.totalSessions - right.totalSessions;
         }
         return WEEKDAY_LABELS.indexOf(left.weekdayLabel) - WEEKDAY_LABELS.indexOf(right.weekdayLabel);
       })[0]

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -205,7 +205,7 @@ export default function Analytics() {
               </div>
 
               <div className="rounded-lg border p-4 sm:col-span-2">
-                <p className="text-xs text-muted-foreground">Weekday patterns (average per week)</p>
+                <p className="text-xs text-muted-foreground">Weekday patterns (median per week)</p>
                 <WeekdayPatternsChart weekdays={habits.weekdays} />
               </div>
             </div>

--- a/tests/readingHabits.test.ts
+++ b/tests/readingHabits.test.ts
@@ -113,3 +113,30 @@ test("normalizes weekday metrics per week and uses sessions as tie-breaker", () 
   assert.equal(metrics.weekdays.lowest?.weekdayLabel, "Thursday");
   assert.equal(metrics.weekdays.weekSpan.toFixed(2), "3.86");
 });
+
+test("computes weekday medians from individual week buckets", () => {
+  const logs: ReadingLog[] = [
+    makeLog("m1", "book-a", "2026-01-05T09:00:00", 10, 20),
+    makeLog("m2", "book-a", "2026-01-12T09:00:00", 20, 60),
+    makeLog("m3", "book-a", "2026-01-19T09:00:00", 30, 100),
+    makeLog("t1", "book-a", "2026-01-06T09:00:00", 40, 300),
+  ];
+
+  const metrics = calculateReadingHabits(logs, "2026-01-01T00:00:00", "2026-01-25T23:59:59");
+  const monday = metrics.weekdays.all.find((weekday) => weekday.weekdayLabel === "Monday");
+  const tuesday = metrics.weekdays.all.find((weekday) => weekday.weekdayLabel === "Tuesday");
+
+  assert.equal(monday?.medianMinutesPerWeek, 60);
+  assert.deepEqual(
+    monday?.weeklyValues.map((week) => week.minutes),
+    [20, 60, 100]
+  );
+
+  assert.equal(tuesday?.avgMinutesPerWeek.toFixed(1), "100.0");
+  assert.equal(tuesday?.medianMinutesPerWeek, 0);
+  assert.deepEqual(
+    tuesday?.weeklyValues.map((week) => week.minutes),
+    [300, 0, 0]
+  );
+  assert.equal(metrics.weekdays.highest?.weekdayLabel, "Monday");
+});


### PR DESCRIPTION
## What changed

- Reworked the weekday patterns chart from horizontal average bars into vertical median columns.
- Added weekly reading buckets so the chart can show median minutes per weekday and optional individual-week dots.
- Added a compact checkbox-style toggle for showing/hiding individual weeks.
- Reused the same bg-primary/85 bar color pattern as the book analytics chart so the bars adapt in dark mode.
- Added a focused regression test for weekday medians.

## Why

The previous visualization mixed average minutes and sessions in a way that made weekday patterns harder to understand. Median minutes gives a clearer typical weekday view, while the optional dots preserve the real weekly variation without making the default chart too noisy.

## Validation

- npm run typecheck
- npm test