### PR TITLE
[codex] Improve library shelf navigation

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -12,12 +12,14 @@ interface BookCardProps {
   book: Book;
   onClick: (book: Book) => void;
   showQuickProgress?: boolean;
+  textSize?: "default" | "compact";
 }
 
 export default function BookCard({
   book,
   onClick,
   showQuickProgress = false,
+  textSize = "default",
 }: BookCardProps) {
   const { updateBook } = useBooksContext();
 
@@ -62,9 +64,13 @@ export default function BookCard({
       </div>
 
       <CardContent className="p-2 space-y-1">
-        <p className="text-sm font-medium leading-tight line-clamp-2">{book.title}</p>
-        <p className="text-xs text-muted-foreground line-clamp-1">{book.authors.join(", ")}</p>
-        <Badge variant={statusVariant(book.status)} className="text-xs">
+        <p className={textSize === "compact" ? "text-xs font-medium leading-tight line-clamp-2" : "text-sm font-medium leading-tight line-clamp-2"}>
+          {book.title}
+        </p>
+        <p className={textSize === "compact" ? "text-[11px] text-muted-foreground line-clamp-1" : "text-xs text-muted-foreground line-clamp-1"}>
+          {book.authors.join(", ")}
+        </p>
+        <Badge variant={statusVariant(book.status)} className={textSize === "compact" ? "text-[10px]" : "text-xs"}>
           {book.status}
         </Badge>
         {!showDashboardQuickProgress && progress !== null && (

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -1,14 +1,204 @@
-import { useNavigate } from "react-router-dom";
-import { BookOpen, RefreshCw } from "lucide-react";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { useEffect, useMemo } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { BookOpen, ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { useBooksContext } from "@/context/BooksContext";
 import { useSeries } from "@/hooks/useSeries";
+import { cn } from "@/lib/utils";
 import BookCard from "@/components/BookCard";
-import type { Book } from "@/types";
+import type { Book, Series } from "@/types";
 
-function EmptyTab({ message }: { message: string }) {
+type LibraryView =
+  | "all"
+  | "tbr"
+  | "reading"
+  | "finished"
+  | "wishlist"
+  | "dnf"
+  | "series"
+  | "authors"
+  | "genres"
+  | "languages"
+  | "format"
+  | "belongs-to";
+
+type PrimaryShelf = {
+  value: LibraryView;
+  label: string;
+  matches: (book: Book) => boolean;
+  emptyMessage: string;
+};
+
+type CategoryShelf = {
+  value: LibraryView;
+  label: string;
+};
+
+type BookGroup = {
+  name: string;
+  books: Book[];
+};
+
+const UNCATEGORIZED = "Uncategorized";
+
+const primaryShelves: PrimaryShelf[] = [
+  {
+    value: "all",
+    label: "All Books",
+    matches: () => true,
+    emptyMessage: "No books yet. Tap + to add one.",
+  },
+  {
+    value: "tbr",
+    label: "To Be Read",
+    matches: (book) => ["Wishlist", "Not Started", "Up Next"].includes(book.status),
+    emptyMessage: "No books in your reading list.",
+  },
+  {
+    value: "reading",
+    label: "Currently Reading",
+    matches: (book) => book.status === "Reading",
+    emptyMessage: "No books are currently in progress.",
+  },
+  {
+    value: "finished",
+    label: "Finished",
+    matches: (book) => book.status === "Finished",
+    emptyMessage: "No finished books yet.",
+  },
+  {
+    value: "wishlist",
+    label: "Wishlist",
+    matches: (book) => book.status === "Wishlist",
+    emptyMessage: "No wishlist books yet.",
+  },
+  {
+    value: "dnf",
+    label: "DNF",
+    matches: (book) => book.status === "DNF",
+    emptyMessage: "No DNF books yet.",
+  },
+];
+
+const categoryShelves: CategoryShelf[] = [
+  { value: "series", label: "Series" },
+  { value: "authors", label: "Authors" },
+  { value: "genres", label: "Genres" },
+  { value: "languages", label: "Languages" },
+  { value: "format", label: "Format" },
+  { value: "belongs-to", label: "Belongs to" },
+];
+
+const validViews = new Set<LibraryView>([
+  ...primaryShelves.map((shelf) => shelf.value),
+  ...categoryShelves.map((shelf) => shelf.value),
+]);
+
+function isLibraryView(value: string | null): value is LibraryView {
+  return value !== null && validViews.has(value as LibraryView);
+}
+
+function viewPath(view: LibraryView) {
+  return `/library?view=${view}`;
+}
+
+function sortBooksByTitle(books: Book[]) {
+  return [...books].sort((a, b) =>
+    a.title.localeCompare(b.title, undefined, { sensitivity: "base", numeric: true })
+  );
+}
+
+function sortBooksByVolume(books: Book[]) {
+  return [...books].sort((a, b) => {
+    const volumeA = a.volume_number ?? Number.MAX_SAFE_INTEGER;
+    const volumeB = b.volume_number ?? Number.MAX_SAFE_INTEGER;
+
+    if (volumeA !== volumeB) return volumeA - volumeB;
+    return a.title.localeCompare(b.title, undefined, { sensitivity: "base", numeric: true });
+  });
+}
+
+function sortGroups(groups: BookGroup[]) {
+  return [...groups].sort((a, b) => {
+    if (a.name === UNCATEGORIZED) return 1;
+    if (b.name === UNCATEGORIZED) return -1;
+    return a.name.localeCompare(b.name, undefined, { sensitivity: "base", numeric: true });
+  });
+}
+
+function addBookToGroup(groups: Map<string, Book[]>, groupName: string, book: Book) {
+  const existingBooks = groups.get(groupName) ?? [];
+  existingBooks.push(book);
+  groups.set(groupName, existingBooks);
+}
+
+function uniqueCleanValues(values: string[] | undefined) {
+  return Array.from(new Set(values?.map((value) => value.trim()).filter(Boolean)));
+}
+
+function buildMultiValueGroups(
+  books: Book[],
+  getValues: (book: Book) => string[] | undefined
+) {
+  const groups = new Map<string, Book[]>();
+
+  books.forEach((book) => {
+    const values = uniqueCleanValues(getValues(book));
+
+    if (values.length === 0) {
+      addBookToGroup(groups, UNCATEGORIZED, book);
+      return;
+    }
+
+    values.forEach((value) => addBookToGroup(groups, value, book));
+  });
+
+  return sortGroups(
+    Array.from(groups, ([name, groupBooks]) => ({
+      name,
+      books: sortBooksByTitle(groupBooks),
+    }))
+  );
+}
+
+function buildSingleValueGroups(books: Book[], getValue: (book: Book) => string | undefined) {
+  const groups = new Map<string, Book[]>();
+
+  books.forEach((book) => {
+    addBookToGroup(groups, getValue(book) ?? UNCATEGORIZED, book);
+  });
+
+  return sortGroups(
+    Array.from(groups, ([name, groupBooks]) => ({
+      name,
+      books: sortBooksByTitle(groupBooks),
+    }))
+  );
+}
+
+function buildSeriesGroups(books: Book[], series: Series[]) {
+  const seriesById = new Map(series.map((item) => [item.id, item.name]));
+  const groups = new Map<string, Book[]>();
+
+  books.forEach((book) => {
+    if (!book.series_id) return;
+
+    const seriesName = seriesById.get(book.series_id);
+    if (!seriesName) return;
+
+    addBookToGroup(groups, seriesName, book);
+  });
+
+  return sortGroups(
+    Array.from(groups, ([name, groupBooks]) => ({
+      name,
+      books: sortBooksByVolume(groupBooks),
+    }))
+  );
+}
+
+function EmptyLibraryView({ message }: { message: string }) {
   return (
     <div className="flex flex-col items-center gap-3 py-16 text-center">
       <BookOpen className="h-10 w-10 text-muted-foreground/40" />
@@ -20,49 +210,205 @@ function EmptyTab({ message }: { message: string }) {
 function BooksGrid({ books, onBook }: { books: Book[]; onBook: (b: Book) => void }) {
   if (books.length === 0) return null;
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+    <div className="grid grid-cols-3 gap-2.5 md:grid-cols-4 lg:gap-3">
       {books.map((book) => (
-        <BookCard key={book.id} book={book} onClick={onBook} />
+        <BookCard key={book.id} book={book} onClick={onBook} textSize="compact" />
       ))}
     </div>
   );
 }
 
+function LoadingGrid() {
+  return (
+    <div className="grid grid-cols-3 gap-2.5 md:grid-cols-4 lg:gap-3">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="aspect-[2/3] animate-pulse rounded-xl bg-muted" />
+      ))}
+    </div>
+  );
+}
+
+function groupCountLabel(count: number) {
+  return `${count} book${count !== 1 ? "s" : ""}`;
+}
+
+function LibraryShelfList({
+  activeView,
+  counts,
+  mobile = false,
+}: {
+  activeView?: LibraryView;
+  counts: Partial<Record<LibraryView, number>>;
+  mobile?: boolean;
+}) {
+  return (
+    <nav className="space-y-4" aria-label="Library views">
+      <div className="space-y-1">
+        {primaryShelves.map((shelf) => {
+          const active = activeView === shelf.value;
+
+          return (
+            <Link
+              key={shelf.value}
+              to={viewPath(shelf.value)}
+              className={cn(
+                "flex items-center rounded-lg transition-colors",
+                mobile ? "gap-2 px-3 py-2 text-sm" : "gap-3 px-3 py-2 text-sm",
+                active
+                  ? "bg-muted font-medium text-foreground"
+                  : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              )}
+            >
+              <span className="min-w-0">{shelf.label}</span>
+              <span
+                className={cn(
+                  "text-muted-foreground",
+                  mobile ? "text-sm" : "ml-auto text-xs"
+                )}
+              >
+                {counts[shelf.value] ?? 0}
+              </span>
+              {mobile && (
+                <ChevronRight className="ml-auto h-5 w-5 text-muted-foreground" aria-hidden="true" />
+              )}
+            </Link>
+          );
+        })}
+      </div>
+
+      <div className="space-y-1 pt-3">
+        <p
+          className={cn(
+            "px-3 font-medium uppercase tracking-wide text-foreground",
+            mobile ? "pb-1 pt-2 text-xs" : "text-xs"
+          )}
+        >
+          Categories
+        </p>
+        {categoryShelves.map((shelf) => {
+          const active = activeView === shelf.value;
+
+          return (
+            <Link
+              key={shelf.value}
+              to={viewPath(shelf.value)}
+              className={cn(
+                "flex items-center rounded-lg transition-colors",
+                mobile ? "px-3 py-2 text-sm" : "px-3 py-2 text-sm",
+                active
+                  ? "bg-muted font-medium text-foreground"
+                  : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              )}
+            >
+              <span>{shelf.label}</span>
+              {mobile && (
+                <ChevronRight className="ml-auto h-5 w-5 text-muted-foreground" aria-hidden="true" />
+              )}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}
+
+function GroupedBooksView({
+  groups,
+  onBook,
+}: {
+  groups: BookGroup[];
+  onBook: (book: Book) => void;
+}) {
+  if (groups.length === 0) {
+    return <EmptyLibraryView message="No books yet." />;
+  }
+
+  return (
+    <div className="space-y-6">
+      {groups.map((group) => (
+        <section key={group.name} className="space-y-3">
+          <div>
+            <h3 className="font-heading leading-snug font-medium">{group.name}</h3>
+            <p className="text-xs text-muted-foreground">{groupCountLabel(group.books.length)}</p>
+          </div>
+          <Separator />
+          <BooksGrid books={group.books} onBook={onBook} />
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function getViewLabel(view: LibraryView) {
+  return (
+    primaryShelves.find((shelf) => shelf.value === view)?.label ??
+    categoryShelves.find((shelf) => shelf.value === view)?.label ??
+    "Library"
+  );
+}
+
 export default function Library() {
-  const { books, loading, error, reload } = useBooksContext();
-  const { series } = useSeries();
+  const { books, loading: booksLoading, error, reload } = useBooksContext();
+  const { series, loading: seriesLoading } = useSeries();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const viewParam = searchParams.get("view");
+  const hasExplicitView = isLibraryView(viewParam);
+  const activeView = hasExplicitView ? viewParam : undefined;
+  const contentView = activeView ?? "all";
+  const loading = booksLoading || seriesLoading;
+  const mobileHeading = activeView ? getViewLabel(activeView) : "Library";
+
+  useEffect(() => {
+    if (viewParam && !isLibraryView(viewParam)) {
+      navigate("/library", { replace: true });
+    }
+  }, [navigate, viewParam]);
 
   function openBook(book: Book) {
     navigate(`/books/${book.id}`);
   }
 
-  const allBooks = [...books].sort((a, b) =>
-    a.title.localeCompare(b.title, undefined, { sensitivity: "base", numeric: true })
+  const primaryCounts = useMemo(
+    () =>
+      primaryShelves.reduce(
+        (counts, shelf) => ({
+          ...counts,
+          [shelf.value]: books.filter(shelf.matches).length,
+        }),
+        {} as Partial<Record<LibraryView, number>>
+      ),
+    [books]
   );
 
-  const tbrBooks = books.filter((b) =>
-    ["Wishlist", "Not Started", "Up Next"].includes(b.status)
-  );
+  const activePrimaryShelf = primaryShelves.find((shelf) => shelf.value === contentView);
+  const visibleBooks = useMemo(() => {
+    if (!activePrimaryShelf) return [];
+    return sortBooksByTitle(books.filter(activePrimaryShelf.matches));
+  }, [activePrimaryShelf, books]);
 
-  // Group books by series
-  const seriesWithBooks = series
-    .map((s) => ({
-      ...s,
-      books: books
-        .filter((b) => b.series_id === s.id)
-        .sort((a, b) => (a.volume_number ?? 0) - (b.volume_number ?? 0)),
-    }))
-    .filter((s) => s.books.length > 0);
-
-  const standaloneBooks = books.filter((b) => !b.series_id);
+  const groupedBooks = useMemo(() => {
+    if (contentView === "series") return buildSeriesGroups(books, series);
+    if (contentView === "authors") return buildMultiValueGroups(books, (book) => book.authors);
+    if (contentView === "genres") return buildMultiValueGroups(books, (book) => book.genres);
+    if (contentView === "languages") return buildSingleValueGroups(books, (book) => book.language);
+    if (contentView === "format") return buildSingleValueGroups(books, (book) => book.format);
+    if (contentView === "belongs-to") {
+      return buildSingleValueGroups(books, (book) => book.belongs_to);
+    }
+    return [];
+  }, [contentView, books, series]);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 md:flex md:h-[calc(100svh-6.5rem)] md:min-h-0 md:flex-col">
       <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-heading leading-snug font-medium">Library</h1>
+        <h1 className="text-2xl font-heading leading-snug font-medium">
+          <span className="md:hidden">{mobileHeading}</span>
+          <span className="hidden md:inline">Library</span>
+        </h1>
         <span className="text-sm text-muted-foreground">
-          {loading ? "…" : `${books.length} book${books.length !== 1 ? "s" : ""}`}
+          {loading ? "..." : `${books.length} book${books.length !== 1 ? "s" : ""}`}
         </span>
       </div>
 
@@ -76,81 +422,47 @@ export default function Library() {
         </div>
       )}
 
-      <Tabs defaultValue="all">
-        <TabsList className="w-full">
-          <TabsTrigger value="all" className="flex-1">
-            All Books
-          </TabsTrigger>
-          <TabsTrigger value="tbr" className="flex-1">
-            TBR {!loading && tbrBooks.length > 0 && `(${tbrBooks.length})`}
-          </TabsTrigger>
-          <TabsTrigger value="series" className="flex-1">
-            Series
-          </TabsTrigger>
-        </TabsList>
+      <div className="md:hidden">
+        {!hasExplicitView ? (
+          <LibraryShelfList
+            activeView={activeView}
+            counts={primaryCounts}
+            mobile
+          />
+        ) : (
+          <Button variant="ghost" size="sm" asChild>
+            <Link to="/library">
+              <ChevronLeft className="mr-2 h-4 w-4" />
+              Library
+            </Link>
+          </Button>
+        )}
+      </div>
 
-        {/* All Books */}
-        <TabsContent value="all">
-          <div className="mt-3">
-            {loading ? (
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
-                {Array.from({ length: 8 }).map((_, i) => (
-                  <div key={i} className="animate-pulse rounded-xl bg-muted aspect-[2/3]" />
-                ))}
-              </div>
-            ) : books.length === 0 ? (
-              <EmptyTab message="No books yet. Tap + to add one." />
+      <div
+        className={cn(
+          "grid gap-4 md:min-h-0 md:flex-1 md:grid-cols-[12rem_minmax(0,1fr)] lg:grid-cols-[13rem_minmax(0,1fr)]",
+          !hasExplicitView && "hidden md:grid"
+        )}
+      >
+        <aside className="hidden md:block md:min-h-0 md:overflow-y-auto md:pr-1">
+          <LibraryShelfList activeView={activeView} counts={primaryCounts} />
+        </aside>
+
+        <section className="min-w-0 md:min-h-0 md:overflow-y-auto md:pr-1">
+          {loading ? (
+            <LoadingGrid />
+          ) : activePrimaryShelf ? (
+            visibleBooks.length === 0 ? (
+              <EmptyLibraryView message={activePrimaryShelf.emptyMessage} />
             ) : (
-              <BooksGrid books={allBooks} onBook={openBook} />
-            )}
-          </div>
-        </TabsContent>
-
-        {/* TBR */}
-        <TabsContent value="tbr">
-          <div className="mt-3">
-            {loading ? null : tbrBooks.length === 0 ? (
-              <EmptyTab message="No books in your reading list." />
-            ) : (
-              <BooksGrid books={tbrBooks} onBook={openBook} />
-            )}
-          </div>
-        </TabsContent>
-
-        {/* Series */}
-        <TabsContent value="series">
-          <div className="mt-3">
-            {loading ? null : seriesWithBooks.length === 0 && standaloneBooks.length === 0 ? (
-              <EmptyTab message="No books yet." />
-            ) : (
-              <div className="space-y-6">
-                {seriesWithBooks.map((s) => (
-                  <section key={s.id} className="space-y-3">
-                    <div>
-                      <h3 className="font-heading leading-snug font-medium">{s.name}</h3>
-                      <p className="text-xs text-muted-foreground">
-                        {s.books.length} book{s.books.length !== 1 ? "s" : ""}
-                      </p>
-                    </div>
-                    <Separator />
-                    <BooksGrid books={s.books} onBook={openBook} />
-                  </section>
-                ))}
-
-                {standaloneBooks.length > 0 && (
-                  <section className="space-y-3">
-                    <div>
-                      <h3 className="font-heading leading-snug font-medium text-muted-foreground">Standalone</h3>
-                    </div>
-                    <Separator />
-                    <BooksGrid books={standaloneBooks} onBook={openBook} />
-                  </section>
-                )}
-              </div>
-            )}
-          </div>
-        </TabsContent>
-      </Tabs>
+              <BooksGrid books={visibleBooks} onBook={openBook} />
+            )
+          ) : (
+            <GroupedBooksView groups={groupedBooks} onBook={openBook} />
+          )}
+        </section>
+      </div>
     </div>
   );
 }

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -137,6 +137,19 @@ function uniqueCleanValues(values: string[] | undefined) {
   return Array.from(new Set(values?.map((value) => value.trim()).filter(Boolean)));
 }
 
+function countUniqueBookValues(
+  books: Book[],
+  getValues: (book: Book) => string[] | undefined
+) {
+  const values = new Set<string>();
+
+  books.forEach((book) => {
+    uniqueCleanValues(getValues(book)).forEach((value) => values.add(value));
+  });
+
+  return values.size;
+}
+
 function buildMultiValueGroups(
   books: Book[],
   getValues: (book: Book) => string[] | undefined
@@ -235,10 +248,12 @@ function groupCountLabel(count: number) {
 function LibraryShelfList({
   activeView,
   counts,
+  categoryCounts,
   mobile = false,
 }: {
   activeView?: LibraryView;
   counts: Partial<Record<LibraryView, number>>;
+  categoryCounts: Partial<Record<LibraryView, number>>;
   mobile?: boolean;
 }) {
   return (
@@ -287,6 +302,7 @@ function LibraryShelfList({
         </p>
         {categoryShelves.map((shelf) => {
           const active = activeView === shelf.value;
+          const count = categoryCounts[shelf.value];
 
           return (
             <Link
@@ -300,9 +316,14 @@ function LibraryShelfList({
                   : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
               )}
             >
-              <span>{shelf.label}</span>
+              <span className="min-w-0 flex-1">{shelf.label}</span>
+              {count !== undefined && (
+                <span className={cn("text-muted-foreground", mobile ? "text-sm" : "text-xs")}>
+                  {count}
+                </span>
+              )}
               {mobile && (
-                <ChevronRight className="ml-auto h-5 w-5 text-muted-foreground" aria-hidden="true" />
+                <ChevronRight className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
               )}
             </Link>
           );
@@ -382,6 +403,15 @@ export default function Library() {
     [books]
   );
 
+  const categoryCounts = useMemo(
+    () => ({
+      series: series.filter((item) => books.some((book) => book.series_id === item.id)).length,
+      authors: countUniqueBookValues(books, (book) => book.authors),
+      genres: countUniqueBookValues(books, (book) => book.genres),
+    }),
+    [books, series]
+  );
+
   const activePrimaryShelf = primaryShelves.find((shelf) => shelf.value === contentView);
   const visibleBooks = useMemo(() => {
     if (!activePrimaryShelf) return [];
@@ -402,7 +432,7 @@ export default function Library() {
 
   const displayedBookCount = activePrimaryShelf
     ? visibleBooks.length
-    : groupedBooks.reduce((count, group) => count + group.books.length, 0);
+    : books.length;
 
   return (
     <div className="space-y-4 md:flex md:h-[calc(100svh-6.5rem)] md:min-h-0 md:flex-col">
@@ -431,6 +461,7 @@ export default function Library() {
           <LibraryShelfList
             activeView={activeView}
             counts={primaryCounts}
+            categoryCounts={categoryCounts}
             mobile
           />
         ) : (
@@ -450,7 +481,11 @@ export default function Library() {
         )}
       >
         <aside className="hidden md:block md:min-h-0 md:overflow-y-auto md:pr-1">
-          <LibraryShelfList activeView={activeView} counts={primaryCounts} />
+          <LibraryShelfList
+            activeView={activeView}
+            counts={primaryCounts}
+            categoryCounts={categoryCounts}
+          />
         </aside>
 
         <section className="min-w-0 md:min-h-0 md:overflow-y-auto md:pr-1">

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -245,6 +245,10 @@ function groupCountLabel(count: number) {
   return `${count} book${count !== 1 ? "s" : ""}`;
 }
 
+function itemCountLabel(count: number, singular: string, plural = `${singular}s`) {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
 function LibraryShelfList({
   activeView,
   counts,
@@ -430,9 +434,13 @@ export default function Library() {
     return [];
   }, [contentView, books, series]);
 
-  const displayedBookCount = activePrimaryShelf
-    ? visibleBooks.length
-    : books.length;
+  const displayedCountLabel = (() => {
+    if (activePrimaryShelf) return itemCountLabel(visibleBooks.length, "book");
+    if (contentView === "series") return itemCountLabel(categoryCounts.series ?? 0, "series", "series");
+    if (contentView === "authors") return itemCountLabel(categoryCounts.authors ?? 0, "author");
+    if (contentView === "genres") return itemCountLabel(categoryCounts.genres ?? 0, "genre");
+    return itemCountLabel(books.length, "book");
+  })();
 
   return (
     <div className="space-y-4 md:flex md:h-[calc(100svh-6.5rem)] md:min-h-0 md:flex-col">
@@ -442,7 +450,7 @@ export default function Library() {
           <span className="hidden md:inline">Library</span>
         </h1>
         <span className="text-sm text-muted-foreground">
-          {loading ? "..." : `${displayedBookCount} book${displayedBookCount !== 1 ? "s" : ""}`}
+          {loading ? "..." : displayedCountLabel}
         </span>
       </div>
 

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -320,14 +320,14 @@ function LibraryShelfList({
                   : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
               )}
             >
-              <span className="min-w-0 flex-1">{shelf.label}</span>
+              <span className={cn("min-w-0", !mobile && "flex-1")}>{shelf.label}</span>
               {count !== undefined && (
                 <span className={cn("text-muted-foreground", mobile ? "text-sm" : "text-xs")}>
                   {count}
                 </span>
               )}
               {mobile && (
-                <ChevronRight className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+                <ChevronRight className="ml-auto h-5 w-5 text-muted-foreground" aria-hidden="true" />
               )}
             </Link>
           );

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -314,7 +314,7 @@ function LibraryShelfList({
               to={viewPath(shelf.value)}
               className={cn(
                 "flex items-center rounded-lg transition-colors",
-                mobile ? "px-3 py-2 text-sm" : "px-3 py-2 text-sm",
+                mobile ? "gap-2 px-3 py-2 text-sm" : "px-3 py-2 text-sm",
                 active
                   ? "bg-muted font-medium text-foreground"
                   : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -400,6 +400,10 @@ export default function Library() {
     return [];
   }, [contentView, books, series]);
 
+  const displayedBookCount = activePrimaryShelf
+    ? visibleBooks.length
+    : groupedBooks.reduce((count, group) => count + group.books.length, 0);
+
   return (
     <div className="space-y-4 md:flex md:h-[calc(100svh-6.5rem)] md:min-h-0 md:flex-col">
       <div className="flex items-center justify-between">
@@ -408,7 +412,7 @@ export default function Library() {
           <span className="hidden md:inline">Library</span>
         </h1>
         <span className="text-sm text-muted-foreground">
-          {loading ? "..." : `${books.length} book${books.length !== 1 ? "s" : ""}`}
+          {loading ? "..." : `${displayedBookCount} book${displayedBookCount !== 1 ? "s" : ""}`}
         </span>
       </div>
 


### PR DESCRIPTION
## Summary

This PR replaces the Library page's simple tab layout with a fuller shelf-style navigation model and grouped browsing experience.

## What changed

### Library shelf navigation
- Replaced the old `Tabs` UI with a persistent shelf list on desktop and a stacked shelf list on mobile.
- Added primary shelf views for:
  - All Books
  - To Be Read
  - Currently Reading
  - Finished
  - Wishlist
  - DNF
- Added category views for:
  - Series
  - Authors
  - Genres
  - Languages
  - Format
  - Belongs to
- Shelf selections are URL-driven through `?view=...`, which makes views linkable and refresh-safe.
- Invalid `view` query params are redirected back to `/library`.

### Neutral mobile shelf state
- `/library` now acts as the neutral Library index state.
- When exiting a shelf view on mobile, the back button returns to `/library` and no shelf remains selected.
- Explicit shelf URLs like `/library?view=all` still select and display that shelf.

### Grouped category browsing
- Added grouping helpers for category shelves:
  - Series groups sort books by volume number, then title.
  - Authors and genres support multi-value grouping, so one book can appear under each relevant value.
  - Language, format, and belongs-to use single-value grouping.
  - Missing values are grouped under `Uncategorized` where appropriate.
- Group headings show book counts and preserve the existing book-card click behavior.

### Responsive behavior
- Desktop uses a two-column layout with a left shelf sidebar and scrollable content area.
- Mobile shows the shelf list first, then uses a small back control from a selected shelf back to the Library index.
- Mobile headings change based on the selected shelf so the current view is clear.

### Book card density
- Added an optional `textSize` prop to `BookCard`.
- Library grids use the new compact text mode so three-column mobile grids remain readable without taking too much vertical space.
- The default card styling remains unchanged for existing call sites.

## Why

The old Library page only exposed a few tabs, so users could not browse by important book dimensions like status, author, genre, language, format, or ownership. The new structure makes the Library page scale better as the book collection grows while keeping navigation understandable on mobile.

The neutral `/library` state fixes a smaller UX issue: after backing out of a shelf view, the shelf list should not imply that a shelf is still active.

## Validation

- Ran `npm run build` successfully.
- Ran `git diff --cached --check` before committing; no whitespace errors were reported.

## Notes

This PR focuses on the Library browsing enhancement only. It does not change book data storage, Supabase policies, or the add/edit book flows.
