### PR TITLE
Add estimated finish book analytic

### DIFF
--- a/src/components/BookAnalyticsPanel.tsx
+++ b/src/components/BookAnalyticsPanel.tsx
@@ -6,7 +6,9 @@ import { fetchReadingLogsForBook } from "@/lib/books";
 import {
   formatCalendarSpan,
   formatTotalReadingTime,
+  getEstimatedFinish,
   getReadingDuration,
+  MIN_READING_LOGS_FOR_ESTIMATED_FINISH,
   sumReadingMinutes,
 } from "@/lib/bookAnalytics";
 import type { Book, ReadingLog } from "@/types";
@@ -63,6 +65,21 @@ function formatReadingTime(minutes?: number): string | null {
   if (hours > 0 && mins > 0) return `${hours}h ${mins}m`;
   if (hours > 0) return `${hours}h`;
   return `${mins}m`;
+}
+
+function formatFinishDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatEstimateConfidence(confidence: "low" | "medium" | "high" | null): string {
+  if (confidence === "high") return "High confidence";
+  if (confidence === "medium") return "Medium confidence";
+  if (confidence === "low") return "Low confidence";
+  return "Confidence unavailable";
 }
 
 export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
@@ -170,6 +187,17 @@ export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
     [totalReadingMinutes]
   );
 
+  const estimatedFinish = useMemo(
+    () =>
+      getEstimatedFinish({
+        status: book.status,
+        currentPage: book.current_page,
+        totalPages: book.total_pages,
+        logs,
+      }),
+    [book.current_page, book.status, book.total_pages, logs]
+  );
+
   const readingDuration = useMemo(
     () =>
       getReadingDuration({
@@ -245,12 +273,14 @@ export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
 
   if (logsWithDelta.length === 0) {
     return (
-      <div className="flex h-48 flex-col items-center justify-center gap-2 text-center">
-        <BarChart3 className="h-8 w-8 text-muted-foreground/50" />
-        <p className="text-sm font-medium">No reading progress entries yet.</p>
-        <p className="text-xs text-muted-foreground">
-          Log progress in the Properties tab to see analytics.
-        </p>
+      <div className="space-y-3 py-2">
+        <div className="flex h-48 flex-col items-center justify-center gap-2 text-center">
+          <BarChart3 className="h-8 w-8 text-muted-foreground/50" />
+          <p className="text-sm font-medium">No reading progress entries yet.</p>
+          <p className="text-xs text-muted-foreground">
+            Log progress in the Properties tab to see analytics.
+          </p>
+        </div>
       </div>
     );
   }
@@ -258,6 +288,50 @@ export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
   return (
     <ScrollArea className="flex-1 min-h-0 pr-2">
       <div className="space-y-3 py-2">
+        {estimatedFinish.shouldShow && (
+          <section className="rounded-lg border bg-muted/20 p-3">
+            <p className="text-sm font-medium">Estimated finish</p>
+            {estimatedFinish.isAvailable && estimatedFinish.finishDate ? (
+              <>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <div className="rounded-md border bg-background/80 px-2 py-2">
+                    <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                      Finish date
+                    </p>
+                    <p className="mt-1 text-sm font-medium">
+                      {formatFinishDate(estimatedFinish.finishDate)}
+                    </p>
+                  </div>
+                  <div className="rounded-md border bg-background/80 px-2 py-2">
+                    <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                      Reading time left
+                    </p>
+                    <p className="mt-1 text-sm font-medium">
+                      {estimatedFinish.remainingMinutes
+                        ? formatReadingTime(estimatedFinish.remainingMinutes)
+                        : "Not enough timed sessions"}
+                    </p>
+                  </div>
+                </div>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {formatEstimateConfidence(estimatedFinish.confidence)} · Based on{" "}
+                  {estimatedFinish.readingSessionCount} reading session
+                  {estimatedFinish.readingSessionCount === 1 ? "" : "s"} and your average pace for
+                  this book.
+                </p>
+              </>
+            ) : (
+              <div className="mt-3 rounded-md border bg-background/80 px-2 py-2">
+                <p className="text-sm font-medium">Not enough data yet</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Log at least {MIN_READING_LOGS_FOR_ESTIMATED_FINISH} progress updates to
+                  estimate this.
+                </p>
+              </div>
+            )}
+          </section>
+        )}
+
       <section className="rounded-lg border bg-muted/20 p-3">
         <p className="text-sm font-medium">Time-based stats</p>
         <div className="mt-3 grid gap-2 sm:grid-cols-2">

--- a/src/lib/bookAnalytics.ts
+++ b/src/lib/bookAnalytics.ts
@@ -1,4 +1,4 @@
-import type { ReadingLog } from "@/types";
+import type { BookStatus, ReadingLog } from "@/types";
 
 export interface CalendarSpan {
   months: number;
@@ -12,12 +12,36 @@ export interface ReadingDurationResult {
   span: CalendarSpan | null;
 }
 
+export interface EstimatedFinishResult {
+  shouldShow: boolean;
+  isAvailable: boolean;
+  finishDate: Date | null;
+  remainingMinutes: number | null;
+  confidence: "low" | "medium" | "high" | null;
+  readingSessionCount: number;
+}
+
+export const MIN_READING_LOGS_FOR_ESTIMATED_FINISH = 3;
+
+function getEstimateConfidence(readingSessionCount: number): EstimatedFinishResult["confidence"] {
+  if (readingSessionCount >= 10) return "high";
+  if (readingSessionCount >= 6) return "medium";
+  if (readingSessionCount >= MIN_READING_LOGS_FOR_ESTIMATED_FINISH) return "low";
+  return null;
+}
+
 function isValidDate(date: Date): boolean {
   return !Number.isNaN(date.getTime());
 }
 
 function startOfLocalDay(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function wholeDaysBetween(startDate: Date, endDate: Date): number {
+  const start = startOfLocalDay(startDate);
+  const end = startOfLocalDay(endDate);
+  return Math.floor((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000));
 }
 
 function addMonthsClamped(date: Date, months: number): Date {
@@ -145,5 +169,99 @@ export function getReadingDuration(params: {
     isAvailable: true,
     isInProgress,
     span: calculateCalendarSpan(started, endDate),
+  };
+}
+
+export function getEstimatedFinish(params: {
+  status: BookStatus;
+  currentPage?: number;
+  totalPages?: number;
+  logs: ReadingLog[];
+  now?: Date;
+}): EstimatedFinishResult {
+  if (params.status !== "Reading") {
+    return {
+      shouldShow: false,
+      isAvailable: false,
+      finishDate: null,
+      remainingMinutes: null,
+      confidence: null,
+      readingSessionCount: 0,
+    };
+  }
+
+  const currentPage = params.currentPage ?? 0;
+  const totalPages = params.totalPages ?? 0;
+  const remainingPages = totalPages - currentPage;
+  const sortedLogs = [...params.logs].sort(
+    (a, b) => new Date(a.logged_at).getTime() - new Date(b.logged_at).getTime()
+  );
+
+  if (
+    sortedLogs.length < MIN_READING_LOGS_FOR_ESTIMATED_FINISH ||
+    totalPages <= 0 ||
+    currentPage < 0 ||
+    remainingPages <= 0
+  ) {
+    return {
+      shouldShow: true,
+      isAvailable: false,
+      finishDate: null,
+      remainingMinutes: null,
+      confidence: null,
+      readingSessionCount: sortedLogs.length,
+    };
+  }
+
+  const firstLog = sortedLogs[0];
+  const lastLog = sortedLogs[sortedLogs.length - 1];
+  const firstLogDate = new Date(firstLog.logged_at);
+  const lastLogDate = new Date(lastLog.logged_at);
+  const loggedDays = wholeDaysBetween(firstLogDate, lastLogDate);
+  const loggedProgress = lastLog.current_page - firstLog.current_page;
+
+  if (!isValidDate(firstLogDate) || !isValidDate(lastLogDate) || loggedDays <= 0 || loggedProgress <= 0) {
+    return {
+      shouldShow: true,
+      isAvailable: false,
+      finishDate: null,
+      remainingMinutes: null,
+      confidence: null,
+      readingSessionCount: sortedLogs.length,
+    };
+  }
+
+  const pagesPerDay = loggedProgress / loggedDays;
+  const daysRemaining = Math.ceil(remainingPages / pagesPerDay);
+  const now = startOfLocalDay(params.now ?? new Date());
+  const finishDate = new Date(now);
+  finishDate.setDate(finishDate.getDate() + daysRemaining);
+
+  let previousPage = 0;
+  let pagesWithTime = 0;
+  let minutesWithProgress = 0;
+
+  for (const log of sortedLogs) {
+    const pagesRead = Math.max(0, log.current_page - previousPage);
+    const minutes = log.reading_time_minutes ?? 0;
+    if (pagesRead > 0 && minutes > 0) {
+      pagesWithTime += pagesRead;
+      minutesWithProgress += minutes;
+    }
+    previousPage = log.current_page;
+  }
+
+  const remainingMinutes =
+    pagesWithTime > 0 && minutesWithProgress > 0
+      ? Math.ceil(remainingPages / (pagesWithTime / minutesWithProgress))
+      : null;
+
+  return {
+    shouldShow: true,
+    isAvailable: true,
+    finishDate,
+    remainingMinutes,
+    confidence: getEstimateConfidence(sortedLogs.length),
+    readingSessionCount: sortedLogs.length,
   };
 }

--- a/tests/bookAnalytics.test.ts
+++ b/tests/bookAnalytics.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   formatCalendarSpan,
   formatTotalReadingTime,
+  getEstimatedFinish,
   getReadingDuration,
   sumReadingMinutes,
 } from "../src/lib/bookAnalytics";
@@ -16,6 +17,22 @@ function makeLog(id: string, minutes?: number): ReadingLog {
     current_page: 10,
     reading_time_minutes: minutes,
     logged_at: "2026-04-01T12:00:00",
+  };
+}
+
+function makeProgressLog(
+  id: string,
+  currentPage: number,
+  loggedAt: string,
+  minutes?: number
+): ReadingLog {
+  return {
+    id,
+    book_id: "book-1",
+    user_id: "user-1",
+    current_page: currentPage,
+    reading_time_minutes: minutes,
+    logged_at: loggedAt,
   };
 }
 
@@ -71,4 +88,110 @@ test("returns unavailable when start date is missing or invalid range", () => {
 
   assert.equal(reversed.isAvailable, false);
   assert.equal(reversed.span, null);
+});
+
+test("estimates finish date and remaining reading time for reading books", () => {
+  const estimate = getEstimatedFinish({
+    status: "Reading",
+    currentPage: 80,
+    totalPages: 200,
+    now: new Date("2026-04-10T12:00:00"),
+    logs: [
+      makeProgressLog("a", 20, "2026-04-01T12:00:00", 30),
+      makeProgressLog("b", 50, "2026-04-02T12:00:00", 50),
+      makeProgressLog("c", 80, "2026-04-03T12:00:00", 40),
+    ],
+  });
+
+  assert.equal(estimate.shouldShow, true);
+  assert.equal(estimate.isAvailable, true);
+  assert.equal(estimate.finishDate?.getFullYear(), 2026);
+  assert.equal(estimate.finishDate?.getMonth(), 3);
+  assert.equal(estimate.finishDate?.getDate(), 14);
+  assert.equal(estimate.remainingMinutes, 180);
+  assert.equal(estimate.confidence, "low");
+  assert.equal(estimate.readingSessionCount, 3);
+});
+
+test("does not show estimated finish for books that are not currently reading", () => {
+  const estimate = getEstimatedFinish({
+    status: "Finished",
+    currentPage: 200,
+    totalPages: 200,
+    logs: [
+      makeProgressLog("a", 20, "2026-04-01T12:00:00", 30),
+      makeProgressLog("b", 50, "2026-04-02T12:00:00", 50),
+      makeProgressLog("c", 80, "2026-04-03T12:00:00", 40),
+    ],
+  });
+
+  assert.equal(estimate.shouldShow, false);
+  assert.equal(estimate.isAvailable, false);
+  assert.equal(estimate.confidence, null);
+  assert.equal(estimate.readingSessionCount, 0);
+});
+
+test("requires enough progress data before estimating finish", () => {
+  const estimate = getEstimatedFinish({
+    status: "Reading",
+    currentPage: 50,
+    totalPages: 200,
+    logs: [
+      makeProgressLog("a", 20, "2026-04-01T12:00:00", 30),
+      makeProgressLog("b", 50, "2026-04-02T12:00:00", 50),
+    ],
+  });
+
+  assert.equal(estimate.shouldShow, true);
+  assert.equal(estimate.isAvailable, false);
+  assert.equal(estimate.finishDate, null);
+  assert.equal(estimate.remainingMinutes, null);
+  assert.equal(estimate.confidence, null);
+  assert.equal(estimate.readingSessionCount, 2);
+});
+
+test("assigns medium confidence for 6 to 9 reading logs", () => {
+  const estimate = getEstimatedFinish({
+    status: "Reading",
+    currentPage: 100,
+    totalPages: 200,
+    now: new Date("2026-04-10T12:00:00"),
+    logs: [
+      makeProgressLog("a", 10, "2026-04-01T12:00:00", 10),
+      makeProgressLog("b", 25, "2026-04-02T12:00:00", 15),
+      makeProgressLog("c", 40, "2026-04-03T12:00:00", 15),
+      makeProgressLog("d", 60, "2026-04-04T12:00:00", 20),
+      makeProgressLog("e", 80, "2026-04-05T12:00:00", 20),
+      makeProgressLog("f", 100, "2026-04-06T12:00:00", 20),
+    ],
+  });
+
+  assert.equal(estimate.isAvailable, true);
+  assert.equal(estimate.confidence, "medium");
+  assert.equal(estimate.readingSessionCount, 6);
+});
+
+test("assigns high confidence for 10 or more reading logs", () => {
+  const estimate = getEstimatedFinish({
+    status: "Reading",
+    currentPage: 110,
+    totalPages: 200,
+    now: new Date("2026-04-12T12:00:00"),
+    logs: [
+      makeProgressLog("a", 10, "2026-04-01T12:00:00", 10),
+      makeProgressLog("b", 20, "2026-04-02T12:00:00", 10),
+      makeProgressLog("c", 30, "2026-04-03T12:00:00", 10),
+      makeProgressLog("d", 40, "2026-04-04T12:00:00", 10),
+      makeProgressLog("e", 50, "2026-04-05T12:00:00", 10),
+      makeProgressLog("f", 60, "2026-04-06T12:00:00", 10),
+      makeProgressLog("g", 70, "2026-04-07T12:00:00", 10),
+      makeProgressLog("h", 80, "2026-04-08T12:00:00", 10),
+      makeProgressLog("i", 95, "2026-04-09T12:00:00", 15),
+      makeProgressLog("j", 110, "2026-04-10T12:00:00", 15),
+    ],
+  });
+
+  assert.equal(estimate.isAvailable, true);
+  assert.equal(estimate.confidence, "high");
+  assert.equal(estimate.readingSessionCount, 10);
 });


### PR DESCRIPTION
## Summary
  Adds a new estimated finish analytic to the book analytics tab for books with status `Reading`.

  ## What changed
  - Added an estimated finish card near the top of the book analytics tab.
  - Estimates a finish date from the book's average page progress across reading logs.
  - Estimates remaining reading time from sessions that include both page progress and `reading_time_minutes`.
  - Shows `Not enough data yet` when the estimate would be too weak.
  - Hides the estimate card entirely when there are no reading logs yet.
  - Adds confidence labels based on reading session count:
    - Low confidence: 3-5 logs
    - Medium confidence: 6-9 logs
    - High confidence: 10+ logs
  - Adds explanation text showing how many reading sessions the estimate is based on.

  ## Notes
  This keeps the calculation intentionally simple and readable. Audiobooks still use the existing page-based progress fields because the current data model does not yet store audiobook duration or percent progress separately.

  Closes #126

  ## Validation
  - `npm test -- tests/bookAnalytics.test.ts`
  - `npm run typecheck`
  - `npm run build`