### PR TITLE
[codex] Add controlled genre dropdown

### DIFF
--- a/src/components/AddBookDialog.tsx
+++ b/src/components/AddBookDialog.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useEffect } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { ImagePlus, ScanBarcode, Loader2 } from "lucide-react";
 import BarcodeScanner from "@/components/BarcodeScanner";
+import GenreMultiSelect from "@/components/GenreMultiSelect";
 import { fetchBookByISBN } from "@/lib/bookLookup";
 import {
   Dialog,
@@ -25,17 +26,16 @@ import { useBooksContext } from "@/context/BooksContext";
 import { useSeries } from "@/hooks/useSeries";
 import {
   formatAuthorsInput,
-  formatGenresInput,
   parseAuthorsInput,
-  parseGenresInput,
 } from "@/lib/utils";
+import { getAllowedGenres } from "@/lib/bookGenres";
 import type { BookStatus, BookLanguage, BookBelongsTo, BookFormat, BookMetadataSource } from "@/types";
 
 interface FormValues {
   title: string;
   authorsInput: string;
   status: BookStatus;
-  genresInput: string;
+  genres: string[];
   language: BookLanguage | "";
   format: BookFormat | "";
   belongs_to: BookBelongsTo | "";
@@ -92,7 +92,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
     clearErrors,
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
-    defaultValues: { status: "Not Started", authorsInput: "" },
+    defaultValues: { status: "Not Started", authorsInput: "", genres: [] },
   });
 
   const status = watch("status");
@@ -147,7 +147,13 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
       setValue("title", bookData.title);
       setValue("authorsInput", formatAuthorsInput(bookData.authors), { shouldValidate: true });
       if (bookData.totalPages) setValue("total_pages", String(bookData.totalPages));
-      if (bookData.genres) setValue("genresInput", formatGenresInput(bookData.genres));
+      if (bookData.genres) {
+        setValue("genres", getAllowedGenres(bookData.genres), {
+          shouldDirty: true,
+          shouldTouch: true,
+          shouldValidate: true,
+        });
+      }
       if (bookData.language) setValue("language", bookData.language as BookLanguage);
       if (bookData.format) setValue("format", bookData.format as BookFormat);
 
@@ -203,7 +209,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
         setError("authorsInput", { message: "At least one author is required" });
         return;
       }
-      const genres = parseGenresInput(values.genresInput);
+      const genres = getAllowedGenres(values.genres);
       const result = await addBook(
         {
           title: values.title,
@@ -228,7 +234,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
       );
 
       if (result.warning) {
-        reset({ status: "Not Started", authorsInput: "" });
+        reset({ status: "Not Started", authorsInput: "", genres: [] });
         setCoverFile(null);
         setCoverPreview(null);
         setShowScanner(false);
@@ -246,7 +252,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
         return;
       }
 
-      reset();
+      reset({ status: "Not Started", authorsInput: "", genres: [] });
       setCoverFile(null);
       setCoverPreview(null);
       setShowScanner(false);
@@ -273,7 +279,7 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
 
   function handleOpenChange(nextOpen: boolean) {
     if (!nextOpen) {
-      reset();
+      reset({ status: "Not Started", authorsInput: "", genres: [] });
       setCoverFile(null);
       setCoverPreview(null);
       setShowScanner(false);
@@ -440,10 +446,13 @@ export default function AddBookDialog({ open, onOpenChange }: AddBookDialogProps
 
               {/* Genres */}
               <div className="space-y-1.5">
-                <Label htmlFor="genresInput">Genres</Label>
-                <Input
-                  id="genresInput"
-                  {...register("genresInput")}
+                <Label>Genres</Label>
+                <Controller
+                  name="genres"
+                  control={control}
+                  render={({ field }) => (
+                    <GenreMultiSelect value={field.value ?? []} onChange={field.onChange} />
+                  )}
                 />
               </div>
 

--- a/src/components/GenreMultiSelect.tsx
+++ b/src/components/GenreMultiSelect.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useId, useRef, useState } from "react";
+import { Check, ChevronDown, X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { BOOK_GENRES, isAllowedGenre } from "@/lib/bookGenres";
+import { cn } from "@/lib/utils";
+
+interface GenreMultiSelectProps {
+  value: string[];
+  onChange: (genres: string[]) => void;
+  disabled?: boolean;
+}
+
+export default function GenreMultiSelect({
+  value,
+  onChange,
+  disabled = false,
+}: GenreMultiSelectProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listId = useId();
+  const selectedGenres = value ?? [];
+  const legacyGenres = selectedGenres.filter((genre) => !isAllowedGenre(genre));
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handlePointerDown(event: PointerEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [open]);
+
+  function toggleGenre(genre: string) {
+    if (selectedGenres.includes(genre)) {
+      onChange(selectedGenres.filter((item) => item !== genre));
+      return;
+    }
+
+    onChange([...selectedGenres, genre]);
+  }
+
+  function removeGenre(genre: string) {
+    onChange(selectedGenres.filter((item) => item !== genre));
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <Button
+        type="button"
+        variant="outline"
+        className="h-auto min-h-9 w-full justify-between gap-2 px-3 py-2 text-left font-normal"
+        onClick={() => setOpen((current) => !current)}
+        disabled={disabled}
+        aria-expanded={open}
+        aria-controls={listId}
+      >
+        <span className="flex min-w-0 flex-1 flex-wrap gap-1.5">
+          {selectedGenres.length > 0 ? (
+            selectedGenres.map((genre) => (
+              <Badge key={genre} variant="secondary" className="max-w-full">
+                <span className="truncate">{genre}</span>
+              </Badge>
+            ))
+          ) : (
+            <span className="text-sm text-muted-foreground">No genres selected</span>
+          )}
+        </span>
+        <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+      </Button>
+
+      {open && (
+        <div
+          id={listId}
+          className="absolute z-50 mt-1 max-h-72 w-full overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10"
+        >
+          {BOOK_GENRES.map((genre) => {
+            const selected = selectedGenres.includes(genre);
+
+            return (
+              <button
+                key={genre}
+                type="button"
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
+                  selected && "font-medium"
+                )}
+                onClick={() => toggleGenre(genre)}
+              >
+                <span className="flex h-4 w-4 items-center justify-center rounded-sm border border-input">
+                  {selected && <Check className="h-3 w-3" />}
+                </span>
+                <span>{genre}</span>
+              </button>
+            );
+          })}
+
+          {legacyGenres.length > 0 && (
+            <div className="mt-1 border-t border-border pt-1">
+              {legacyGenres.map((genre) => (
+                <div
+                  key={genre}
+                  className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm text-muted-foreground"
+                >
+                  <span className="truncate">{genre}</span>
+                  <button
+                    type="button"
+                    className="rounded-sm p-0.5 hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                    onClick={() => removeGenre(genre)}
+                    aria-label={`Remove ${genre}`}
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/bookGenres.ts
+++ b/src/lib/bookGenres.ts
@@ -1,0 +1,58 @@
+export const BOOK_GENRES = [
+  "Fantasy",
+  "Science Fiction",
+  "Romance",
+  "Mystery",
+  "Thriller",
+  "Horror",
+  "Historical Fiction",
+  "Literary Fiction",
+  "Contemporary Fiction",
+  "Classics",
+  "Adventure",
+  "Young Adult",
+  "Children's",
+  "Graphic Novel/Comics",
+  "Short Stories",
+  "Poetry",
+  "Biography",
+  "Memoir",
+  "History",
+  "Science",
+  "Psychology",
+  "Philosophy",
+  "Religion/Spirituality",
+  "Self-Help",
+  "Business",
+  "Politics",
+  "Travel",
+  "True Crime",
+  "Cooking/Food",
+  "Art/Design",
+] as const;
+
+export type BookGenre = (typeof BOOK_GENRES)[number];
+
+const GENRE_BY_NORMALIZED_LABEL = new Map(
+  BOOK_GENRES.map((genre) => [normalizeGenreLabel(genre), genre])
+);
+
+function normalizeGenreLabel(genre: string): string {
+  return genre.trim().toLowerCase();
+}
+
+export function getAllowedGenres(genres?: string[]): string[] {
+  if (!genres) return [];
+
+  return Array.from(
+    new Set(
+      genres
+        .map((genre) => GENRE_BY_NORMALIZED_LABEL.get(normalizeGenreLabel(genre)))
+        .filter((genre): genre is BookGenre => Boolean(genre))
+    )
+  );
+}
+
+export function isAllowedGenre(genre: string): boolean {
+  return GENRE_BY_NORMALIZED_LABEL.has(normalizeGenreLabel(genre));
+}

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -28,10 +28,10 @@ import { useBooksContext } from "@/context/BooksContext";
 import { useSeries } from "@/hooks/useSeries";
 import {
   formatAuthorsInput,
-  formatGenresInput,
   parseAuthorsInput,
-  parseGenresInput,
 } from "@/lib/utils";
+import { getAllowedGenres } from "@/lib/bookGenres";
+import GenreMultiSelect from "@/components/GenreMultiSelect";
 import ReadingProgressDialog from "@/components/ReadingProgressDialog";
 import BookAnalyticsPanel from "@/components/BookAnalyticsPanel";
 import PropertyBox from "@/components/PropertyBox";
@@ -47,7 +47,7 @@ interface FormValues {
   title: string;
   authorsInput: string;
   status: BookStatus;
-  genresInput: string;
+  genres: string[];
   isbn: string;
   language: BookLanguage | "";
   format: BookFormat | "";
@@ -84,7 +84,7 @@ function bookToFormValues(book: Book): FormValues {
     title: book.title,
     authorsInput: formatAuthorsInput(book.authors),
     status: book.status,
-    genresInput: formatGenresInput(book.genres),
+    genres: book.genres ?? [],
     isbn: book.isbn ?? "",
     language: book.language ?? "",
     format: book.format ?? "",
@@ -158,14 +158,13 @@ export default function BookDetails() {
 
   const status = watch("status") ?? book?.status ?? "Not Started";
   const seriesId = watch("series_id");
-  const genresInput = watch("genresInput") ?? "";
+  const genres = watch("genres") ?? book?.genres ?? [];
   const languageValue = watch("language") ?? "";
   const formatValue = watch("format") ?? "";
   const belongsToValue = watch("belongs_to") ?? "";
   const dateStartedValue = watch("date_started") ?? "";
   const dateFinishedValue = watch("date_finished") ?? "";
   const isbnValue = watch("isbn") ?? "";
-  const parsedGenres = parseGenresInput(genresInput);
   const showDateStarted = ["Reading", "Finished", "DNF"].includes(status);
   const showDateFinished = ["Finished", "DNF"].includes(status);
 
@@ -232,9 +231,9 @@ export default function BookDetails() {
       payload.authors = authors;
     }
     if (dirtyFields.status) payload.status = values.status;
-    if (dirtyFields.genresInput) {
-      const genres = parseGenresInput(values.genresInput);
-      payload.genres = genres.length > 0 ? genres : undefined;
+    if (dirtyFields.genres) {
+      const allowedGenres = getAllowedGenres(values.genres);
+      payload.genres = allowedGenres.length > 0 ? allowedGenres : undefined;
     }
     if (dirtyFields.isbn) {
       payload.isbn = values.isbn.trim() || undefined;
@@ -594,12 +593,20 @@ export default function BookDetails() {
 
                   {isEditMode ? (
                     <div className="space-y-1.5 md:col-span-2">
-                      <Label htmlFor="detail-genresInput">Genres</Label>
-                      <Input id="detail-genresInput" {...register("genresInput")} />
+                      <Label>Genres</Label>
+                      <Controller
+                        name="genres"
+                        control={control}
+                        render={({ field }) => (
+                          <GenreMultiSelect value={field.value ?? []} onChange={field.onChange} />
+                        )}
+                      />
                     </div>
                   ) : (
                     <PropertyBox title="Genres" className="md:col-span-2">
-                      <p className="text-sm font-medium">{parsedGenres.length > 0 ? parsedGenres.join(", ") : "Not set"}</p>
+                      <p className="text-sm font-medium">
+                        {genres.length > 0 ? genres.join(", ") : "Not set"}
+                      </p>
                     </PropertyBox>
                   )}
 

--- a/tests/bookGenres.test.ts
+++ b/tests/bookGenres.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getAllowedGenres } from "../src/lib/bookGenres";
+
+test("keeps approved genres and normalizes their display casing", () => {
+  assert.deepEqual(getAllowedGenres(["fantasy", "Science fiction", "Mystery"]), [
+    "Fantasy",
+    "Science Fiction",
+    "Mystery",
+  ]);
+});
+
+test("ignores unknown genres from external metadata", () => {
+  assert.deepEqual(getAllowedGenres(["Juvenile Fiction", "Fiction", "Romance"]), ["Romance"]);
+});
+
+test("removes duplicate approved genres", () => {
+  assert.deepEqual(getAllowedGenres(["History", "history", "History"]), ["History"]);
+});


### PR DESCRIPTION
## Summary

- Add a fixed essential genre list and a reusable multi-select genre picker.
- Replace free-text genre inputs in Add Book and Book Details with the controlled picker.
- Filter ISBN lookup genres so only approved genres are saved.
- Add tests for genre filtering and normalization.

## Validation

- npm run typecheck
- npm test
- npm run build

Closes #128