### PR TITLE
[codex] Add note pages and quote cards

### DIFF
--- a/src/components/BookNotesPanel.tsx
+++ b/src/components/BookNotesPanel.tsx
@@ -19,6 +19,7 @@ import {
   createBookNote,
   deleteBookNote,
   fetchBookNotes,
+  formatBookNotePageRange,
   updateBookNote,
 } from "@/lib/bookNotes";
 import { cn } from "@/lib/utils";
@@ -57,6 +58,8 @@ export default function BookNotesPanel({ book }: BookNotesPanelProps) {
   const [label, setLabel] = useState<BookNoteLabel>("note");
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
+  const [pageStart, setPageStart] = useState("");
+  const [pageEnd, setPageEnd] = useState("");
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -105,6 +108,8 @@ export default function BookNotesPanel({ book }: BookNotesPanelProps) {
     setLabel("note");
     setTitle("");
     setContent("");
+    setPageStart("");
+    setPageEnd("");
     setEditingNoteId(null);
   }
 
@@ -125,6 +130,8 @@ export default function BookNotesPanel({ book }: BookNotesPanelProps) {
     setLabel(note.label);
     setTitle(note.title ?? "");
     setContent(note.content);
+    setPageStart(note.page_start ? String(note.page_start) : "");
+    setPageEnd(note.page_end ? String(note.page_end) : "");
     setIsComposerOpen(true);
 
     window.requestAnimationFrame(() => {
@@ -164,6 +171,8 @@ export default function BookNotesPanel({ book }: BookNotesPanelProps) {
           label,
           title,
           content,
+          pageStart,
+          pageEnd,
         });
         setNotes((current) =>
           current.map((currentNote) =>
@@ -177,6 +186,8 @@ export default function BookNotesPanel({ book }: BookNotesPanelProps) {
           label,
           title,
           content,
+          pageStart,
+          pageEnd,
         });
         setNotes((current) => [note, ...current]);
       }
@@ -308,6 +319,38 @@ export default function BookNotesPanel({ book }: BookNotesPanelProps) {
           </div>
 
           <div className="p-3">
+            <div className="mb-3 grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="note-page-start" className="text-xs">
+                  Page
+                </Label>
+                <Input
+                  id="note-page-start"
+                  type="number"
+                  min={1}
+                  step={1}
+                  inputMode="numeric"
+                  value={pageStart}
+                  onChange={(event) => setPageStart(event.target.value)}
+                  placeholder="42"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="note-page-end" className="text-xs">
+                  End page
+                </Label>
+                <Input
+                  id="note-page-end"
+                  type="number"
+                  min={1}
+                  step={1}
+                  inputMode="numeric"
+                  value={pageEnd}
+                  onChange={(event) => setPageEnd(event.target.value)}
+                  placeholder="45"
+                />
+              </div>
+            </div>
             <Label htmlFor="note-content" className="sr-only">
               Note content
             </Label>
@@ -383,40 +426,110 @@ export default function BookNotesPanel({ book }: BookNotesPanelProps) {
         </div>
       ) : (
         <div className="space-y-3">
-          {notes.map((note) => (
-            <article key={note.id} className="rounded-lg border p-3">
-              <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-                <Badge variant="outline" className={LABEL_STYLES[note.label]}>
-                  {labelText(note.label)}
-                </Badge>
-                <time className="text-xs text-muted-foreground" dateTime={note.created_at}>
-                  {formatNoteDate(note.created_at)}
-                </time>
-              </div>
-              {note.title && (
-                <h3 className="mb-1 text-sm font-heading leading-snug font-medium">
-                  {note.title}
-                </h3>
-              )}
-              <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
-                {note.content}
-              </p>
-              <div className="mt-3 flex justify-end">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  aria-label="Edit note"
-                  title="Edit note"
-                  className="text-muted-foreground hover:text-foreground"
-                  disabled={saving || deleting}
-                  onClick={() => openEditComposer(note)}
+          {notes.map((note) => {
+            const pageRangeLabel = formatBookNotePageRange(note);
+
+            if (note.label === "quote") {
+              return (
+                <article
+                  key={note.id}
+                  className="rounded-lg border bg-background p-3 dark:bg-card"
                 >
-                  <Pencil className="h-4 w-4" />
-                </Button>
-              </div>
-            </article>
-          ))}
+                  <div className="grid grid-cols-[2.25rem_1fr] gap-x-3">
+                    <div
+                      aria-hidden="true"
+                      className="text-5xl font-serif leading-none text-sky-600 dark:text-sky-400"
+                    >
+                      “
+                    </div>
+                    <div className="flex flex-wrap items-start justify-between gap-2">
+                      <div>
+                        {note.title && (
+                          <h3 className="mb-1 text-sm font-heading leading-snug font-medium">
+                            {note.title}
+                          </h3>
+                        )}
+                      </div>
+                      <time className="text-xs text-muted-foreground" dateTime={note.created_at}>
+                        {formatNoteDate(note.created_at)}
+                      </time>
+                    </div>
+
+                    <div className="ml-[0.7rem] border-l border-sky-500 dark:border-sky-400" />
+                    <div className="min-w-0">
+                      <blockquote className="whitespace-pre-wrap font-serif text-sm italic leading-6 text-foreground">
+                        {note.content}
+                      </blockquote>
+
+                      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          {pageRangeLabel && (
+                            <span className="text-xs font-medium text-muted-foreground">
+                              {pageRangeLabel}
+                            </span>
+                          )}
+                        </div>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label="Edit quote"
+                          title="Edit quote"
+                          className="text-muted-foreground hover:text-foreground"
+                          disabled={saving || deleting}
+                          onClick={() => openEditComposer(note)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              );
+            }
+
+            return (
+              <article key={note.id} className="rounded-lg border p-3">
+                <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline" className={LABEL_STYLES[note.label]}>
+                      {labelText(note.label)}
+                    </Badge>
+                    {pageRangeLabel && (
+                      <span className="text-xs font-medium text-muted-foreground">
+                        {pageRangeLabel}
+                      </span>
+                    )}
+                  </div>
+                  <time className="text-xs text-muted-foreground" dateTime={note.created_at}>
+                    {formatNoteDate(note.created_at)}
+                  </time>
+                </div>
+                {note.title && (
+                  <h3 className="mb-1 text-sm font-heading leading-snug font-medium">
+                    {note.title}
+                  </h3>
+                )}
+                <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">
+                  {note.content}
+                </p>
+                <div className="mt-3 flex justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label="Edit note"
+                    title="Edit note"
+                    className="text-muted-foreground hover:text-foreground"
+                    disabled={saving || deleting}
+                    onClick={() => openEditComposer(note)}
+                  >
+                    <Pencil className="h-4 w-4" />
+                  </Button>
+                </div>
+              </article>
+            );
+          })}
         </div>
       )}
     </section>

--- a/src/lib/bookNotes.ts
+++ b/src/lib/bookNotes.ts
@@ -6,12 +6,16 @@ export interface CreateBookNoteInput {
   label: BookNoteLabel;
   title?: string;
   content: string;
+  pageStart?: string | number | null;
+  pageEnd?: string | number | null;
 }
 
 export interface BookNoteFieldsInput {
   label: BookNoteLabel;
   title?: string;
   content: string;
+  pageStart?: string | number | null;
+  pageEnd?: string | number | null;
 }
 
 export interface NormalizedBookNoteInput {
@@ -20,31 +24,74 @@ export interface NormalizedBookNoteInput {
   label: BookNoteLabel;
   title: string | null;
   content: string;
+  page_start: number | null;
+  page_end: number | null;
 }
 
 export interface NormalizedBookNoteFields {
   label: BookNoteLabel;
   title: string | null;
   content: string;
+  page_start: number | null;
+  page_end: number | null;
 }
 
 export interface UpdateBookNoteInput extends BookNoteFieldsInput {
   noteId: string;
 }
 
+function normalizePageValue(
+  value: string | number | null | undefined,
+  fieldLabel: string,
+): number | null {
+  if (value === null || value === undefined) return null;
+
+  const normalizedValue = typeof value === "string" ? value.trim() : value;
+  if (normalizedValue === "") return null;
+
+  const page =
+    typeof normalizedValue === "number" ? normalizedValue : Number(normalizedValue);
+
+  if (!Number.isInteger(page) || page < 1) {
+    throw new Error(`${fieldLabel} must be a whole page number greater than 0`);
+  }
+
+  return page;
+}
+
+export function formatBookNotePageRange(
+  note: Pick<BookNote, "page_start" | "page_end">,
+): string | null {
+  if (!note.page_start) return null;
+  if (!note.page_end || note.page_end === note.page_start) return `p. ${note.page_start}`;
+  return `pp. ${note.page_start}-${note.page_end}`;
+}
+
 export function normalizeBookNoteFields(
   input: BookNoteFieldsInput,
 ): NormalizedBookNoteFields {
   const content = input.content.trim();
+  const pageStart = normalizePageValue(input.pageStart, "Start page");
+  const pageEnd = normalizePageValue(input.pageEnd, "End page");
 
   if (!content) {
     throw new Error("Note content is required");
+  }
+
+  if (pageEnd && !pageStart) {
+    throw new Error("Add a start page before adding an end page");
+  }
+
+  if (pageStart && pageEnd && pageEnd < pageStart) {
+    throw new Error("End page must be the same as or after the start page");
   }
 
   return {
     label: input.label,
     title: input.title?.trim() || null,
     content,
+    page_start: pageStart,
+    page_end: pageEnd && pageEnd !== pageStart ? pageEnd : null,
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,8 @@ export interface BookNote {
   label: BookNoteLabel;
   title?: string | null;
   content: string;
+  page_start?: number | null;
+  page_end?: number | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/20260504_add_book_note_pages.sql
+++ b/supabase/migrations/20260504_add_book_note_pages.sql
@@ -1,0 +1,18 @@
+ALTER TABLE public.book_notes
+ADD COLUMN IF NOT EXISTS page_start integer,
+ADD COLUMN IF NOT EXISTS page_end integer;
+
+ALTER TABLE public.book_notes
+DROP CONSTRAINT IF EXISTS book_notes_page_start_valid,
+ADD CONSTRAINT book_notes_page_start_valid
+  CHECK (page_start IS NULL OR page_start > 0);
+
+ALTER TABLE public.book_notes
+DROP CONSTRAINT IF EXISTS book_notes_page_end_valid,
+ADD CONSTRAINT book_notes_page_end_valid
+  CHECK (page_end IS NULL OR page_end > 0);
+
+ALTER TABLE public.book_notes
+DROP CONSTRAINT IF EXISTS book_notes_page_range_valid,
+ADD CONSTRAINT book_notes_page_range_valid
+  CHECK (page_end IS NULL OR (page_start IS NOT NULL AND page_end >= page_start));

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -59,6 +59,10 @@ CREATE TABLE IF NOT EXISTS book_notes (
   label      text NOT NULL CHECK (label IN ('quote','review','note')),
   title      text,
   content    text NOT NULL CHECK (length(btrim(content)) > 0),
+  page_start integer CHECK (page_start IS NULL OR page_start > 0),
+  page_end   integer CHECK (page_end IS NULL OR page_end > 0),
+  CONSTRAINT book_notes_page_range_valid
+    CHECK (page_end IS NULL OR (page_start IS NOT NULL AND page_end >= page_start)),
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );

--- a/tests/bookNotes.test.ts
+++ b/tests/bookNotes.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  formatBookNotePageRange,
   normalizeBookNoteFields,
   normalizeBookNoteInput,
 } from "../src/lib/bookNotes";
@@ -20,6 +21,8 @@ test("normalizes book note title and content before insert", () => {
       label: "quote",
       title: "Favorite line",
       content: "This stayed with me.",
+      page_start: null,
+      page_end: null,
     },
   );
 });
@@ -61,6 +64,75 @@ test("normalizes editable book note fields", () => {
       label: "review",
       title: "Final thoughts",
       content: "Strong ending.",
+      page_start: null,
+      page_end: null,
     },
   );
+});
+
+test("normalizes a single source page", () => {
+  assert.deepEqual(
+    normalizeBookNoteFields({
+      label: "quote",
+      content: "Important line.",
+      pageStart: "42",
+      pageEnd: "",
+    }),
+    {
+      label: "quote",
+      title: null,
+      content: "Important line.",
+      page_start: 42,
+      page_end: null,
+    },
+  );
+});
+
+test("normalizes a source page range", () => {
+  assert.deepEqual(
+    normalizeBookNoteFields({
+      label: "note",
+      content: "This section matters.",
+      pageStart: "42",
+      pageEnd: "45",
+    }),
+    {
+      label: "note",
+      title: null,
+      content: "This section matters.",
+      page_start: 42,
+      page_end: 45,
+    },
+  );
+});
+
+test("rejects invalid source page ranges clearly", () => {
+  assert.throws(
+    () =>
+      normalizeBookNoteFields({
+        label: "note",
+        content: "Bad range.",
+        pageStart: "45",
+        pageEnd: "42",
+      }),
+    /End page must be the same as or after the start page/,
+  );
+});
+
+test("rejects an end page without a start page clearly", () => {
+  assert.throws(
+    () =>
+      normalizeBookNoteFields({
+        label: "quote",
+        content: "Missing start.",
+        pageEnd: "45",
+      }),
+    /Add a start page before adding an end page/,
+  );
+});
+
+test("formats source page labels", () => {
+  assert.equal(formatBookNotePageRange({ page_start: null, page_end: null }), null);
+  assert.equal(formatBookNotePageRange({ page_start: 42, page_end: null }), "p. 42");
+  assert.equal(formatBookNotePageRange({ page_start: 42, page_end: 45 }), "pp. 42-45");
 });


### PR DESCRIPTION
## Summary
- Add optional page and page range fields for book notes, including create/edit support and display as `p. 42` or `pp. 42-45`.
- Add shared validation for page metadata so invalid ranges are rejected clearly before saving.
- Render quote-labeled notes with a dedicated quote layout while leaving review and note cards in their existing style.

## Validation
- `npm test`
- `npm run build`

Closes #133
Closes #134