### PR TITLE
Add library rating and notes shelves

### DIFF
--- a/src/lib/bookNotes.ts
+++ b/src/lib/bookNotes.ts
@@ -146,6 +146,18 @@ export async function fetchBookNotes(bookId: string): Promise<BookNote[]> {
   return sortBookNotes((data ?? []) as BookNote[]);
 }
 
+export async function fetchAllBookNotes(): Promise<BookNote[]> {
+  const { supabase } = await import("./supabase");
+  const { data, error } = await supabase
+    .from("book_notes")
+    .select("*")
+    .order("note_date", { ascending: false })
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+  return sortBookNotes((data ?? []) as BookNote[]);
+}
+
 export async function createBookNote(
   input: CreateBookNoteInput,
 ): Promise<BookNote> {

--- a/src/lib/libraryShelves.ts
+++ b/src/lib/libraryShelves.ts
@@ -1,0 +1,90 @@
+import { sortBookNotes } from "@/lib/bookNotes";
+import type { Book, BookNote, BookNoteLabel } from "@/types";
+
+export type BookGroup = {
+  name: string;
+  books: Book[];
+};
+
+export type LibraryNote = BookNote & {
+  book: Book;
+};
+
+export type NoteGroup = {
+  name: string;
+  notes: LibraryNote[];
+};
+
+const STAR_RATINGS = [5, 4, 3, 2, 1];
+
+const NOTE_GROUPS: Array<{ label: BookNoteLabel; name: string }> = [
+  { label: "quote", name: "Quotes" },
+  { label: "review", name: "Reviews" },
+  { label: "note", name: "Notes" },
+];
+
+export function sortBooksByTitle(books: Book[]) {
+  return [...books].sort((a, b) =>
+    a.title.localeCompare(b.title, undefined, { sensitivity: "base", numeric: true }),
+  );
+}
+
+export function buildRatingGroups(books: Book[]): BookGroup[] {
+  const groups: BookGroup[] = [];
+  const favoriteBooks = sortBooksByTitle(books.filter((book) => book.is_favorite));
+
+  if (favoriteBooks.length > 0) {
+    groups.push({ name: "Favorites", books: favoriteBooks });
+  }
+
+  STAR_RATINGS.forEach((rating) => {
+    const ratedBooks = sortBooksByTitle(
+      books.filter((book) => !book.is_favorite && book.rating === rating),
+    );
+
+    if (ratedBooks.length > 0) {
+      groups.push({
+        name: `${rating} ${rating === 1 ? "Star" : "Stars"}`,
+        books: ratedBooks,
+      });
+    }
+  });
+
+  const unratedBooks = sortBooksByTitle(
+    books.filter((book) => !book.is_favorite && book.rating == null),
+  );
+
+  if (unratedBooks.length > 0) {
+    groups.push({ name: "Unrated", books: unratedBooks });
+  }
+
+  return groups;
+}
+
+export function mergeNotesWithBooks(notes: BookNote[], books: Book[]): LibraryNote[] {
+  const booksById = new Map(books.map((book) => [book.id, book]));
+
+  return notes.flatMap((note) => {
+    const book = booksById.get(note.book_id);
+    return book ? [{ ...note, book }] : [];
+  });
+}
+
+export function sortLibraryNotes(notes: LibraryNote[]): LibraryNote[] {
+  return (sortBookNotes(notes) as LibraryNote[]).sort((a, b) => {
+    if (a.label === "quote" && b.label === "quote" && a.is_favorite !== b.is_favorite) {
+      return a.is_favorite ? -1 : 1;
+    }
+
+    return 0;
+  });
+}
+
+export function buildNoteGroups(notes: BookNote[], books: Book[]): NoteGroup[] {
+  const libraryNotes = mergeNotesWithBooks(notes, books);
+
+  return NOTE_GROUPS.map(({ label, name }) => ({
+    name,
+    notes: sortLibraryNotes(libraryNotes.filter((note) => note.label === label)),
+  })).filter((group) => group.notes.length > 0);
+}

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -1,13 +1,27 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { BookOpen, ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
+import { BookOpen, ChevronLeft, ChevronRight, Heart, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { useBooksContext } from "@/context/BooksContext";
 import { useSeries } from "@/hooks/useSeries";
+import { fetchAllBookNotes, formatBookNotePageRange } from "@/lib/bookNotes";
+import {
+  parseNoteMarkdown,
+  type NoteBlockNode,
+  type NoteInlineNode,
+} from "@/lib/noteFormatting";
+import {
+  buildNoteGroups,
+  buildRatingGroups,
+  sortBooksByTitle,
+  type BookGroup,
+  type LibraryNote,
+  type NoteGroup,
+} from "@/lib/libraryShelves";
 import { cn } from "@/lib/utils";
 import BookCard from "@/components/BookCard";
-import type { Book, Series } from "@/types";
+import type { Book, BookNote, Series } from "@/types";
 
 type LibraryView =
   | "all"
@@ -19,6 +33,8 @@ type LibraryView =
   | "series"
   | "authors"
   | "genres"
+  | "rating"
+  | "notes"
   | "languages"
   | "format"
   | "belongs-to";
@@ -33,11 +49,6 @@ type PrimaryShelf = {
 type CategoryShelf = {
   value: LibraryView;
   label: string;
-};
-
-type BookGroup = {
-  name: string;
-  books: Book[];
 };
 
 const UNCATEGORIZED = "Uncategorized";
@@ -85,6 +96,8 @@ const categoryShelves: CategoryShelf[] = [
   { value: "series", label: "Series" },
   { value: "authors", label: "Authors" },
   { value: "genres", label: "Genres" },
+  { value: "rating", label: "Rating" },
+  { value: "notes", label: "Notes" },
   { value: "languages", label: "Languages" },
   { value: "format", label: "Format" },
   { value: "belongs-to", label: "Belongs to" },
@@ -101,12 +114,6 @@ function isLibraryView(value: string | null): value is LibraryView {
 
 function viewPath(view: LibraryView) {
   return `/library?view=${view}`;
-}
-
-function sortBooksByTitle(books: Book[]) {
-  return [...books].sort((a, b) =>
-    a.title.localeCompare(b.title, undefined, { sensitivity: "base", numeric: true })
-  );
 }
 
 function sortBooksByVolume(books: Book[]) {
@@ -249,6 +256,77 @@ function itemCountLabel(count: number, singular: string, plural = `${singular}s`
   return `${count} ${count === 1 ? singular : plural}`;
 }
 
+function formatNoteDate(value: string): string {
+  const dateValue = value.includes("T") ? value : `${value}T00:00:00`;
+
+  return new Date(dateValue).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function noteGroupCountLabel(count: number) {
+  return `${count} entr${count === 1 ? "y" : "ies"}`;
+}
+
+function renderInlineNodes(nodes: NoteInlineNode[]): ReactNode {
+  return nodes.map((node, index) => {
+    if (node.type === "text") {
+      return node.text.split("\n").map((line, lineIndex) => (
+        <span key={`${index}-${lineIndex}`}>
+          {lineIndex > 0 && <br />}
+          {line}
+        </span>
+      ));
+    }
+
+    if (node.type === "bold") {
+      return <strong key={index}>{renderInlineNodes(node.children)}</strong>;
+    }
+
+    return <em key={index}>{renderInlineNodes(node.children)}</em>;
+  });
+}
+
+function renderNoteBlock(block: NoteBlockNode, index: number): ReactNode {
+  if (block.type === "quote") {
+    return (
+      <blockquote key={index} className="border-l-2 border-border pl-3 italic">
+        {renderInlineNodes(block.children)}
+      </blockquote>
+    );
+  }
+
+  if (block.type === "list") {
+    return (
+      <ul key={index} className="list-disc space-y-1 pl-5">
+        {block.items.map((item, itemIndex) => (
+          <li key={itemIndex}>{renderInlineNodes(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  return <p key={index}>{renderInlineNodes(block.children)}</p>;
+}
+
+function FormattedNoteContent({
+  markdown,
+  className,
+}: {
+  markdown: string;
+  className?: string;
+}) {
+  const blocks = parseNoteMarkdown(markdown);
+
+  return (
+    <div className={cn("space-y-2 whitespace-normal", className)}>
+      {blocks.map(renderNoteBlock)}
+    </div>
+  );
+}
+
 function LibraryShelfList({
   activeView,
   counts,
@@ -364,6 +442,115 @@ function GroupedBooksView({
   );
 }
 
+function LibraryNoteCard({ note, onBook }: { note: LibraryNote; onBook: (book: Book) => void }) {
+  const pageLabel = formatBookNotePageRange(note);
+  const visibleDate = note.note_date ?? note.created_at;
+  const noteMetadata = (
+    <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
+      {note.label === "quote" && note.is_favorite && (
+        <Heart className="h-4 w-4 fill-rose-500 text-rose-500" aria-label="Favorite quote" />
+      )}
+      <time dateTime={visibleDate}>{formatNoteDate(visibleDate)}</time>
+    </div>
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={() => onBook(note.book)}
+      className="block w-full rounded-lg border bg-background p-3 text-left transition-colors hover:bg-muted/50 dark:bg-card"
+    >
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm font-heading font-medium leading-snug">{note.book.title}</p>
+          <p className="truncate text-xs text-muted-foreground">
+            {note.book.authors.join(", ")}
+          </p>
+        </div>
+        {noteMetadata}
+      </div>
+
+      {note.label === "quote" ? (
+        <div className="grid grid-cols-[3rem_1fr] gap-x-4">
+          <div className="flex flex-col items-center">
+            <div
+              aria-hidden="true"
+              className="font-serif text-5xl leading-none text-sky-600 dark:text-sky-400"
+            >
+              “
+            </div>
+            <div className="-mt-3 w-px flex-1 bg-sky-500 dark:bg-sky-400" />
+          </div>
+          <div className="min-w-0">
+            <FormattedNoteContent
+              markdown={note.content}
+              className="line-clamp-4 font-serif text-sm italic leading-6 text-foreground"
+            />
+            {(note.quote_speaker || pageLabel) && (
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                {note.quote_speaker && (
+                  <span className="font-serif text-sm italic text-muted-foreground">
+                    - {note.quote_speaker}
+                  </span>
+                )}
+                {pageLabel && (
+                  <span className="text-xs font-medium text-muted-foreground">{pageLabel}</span>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : (
+        <>
+          {note.title && (
+            <p className="mb-1 text-sm font-medium leading-snug text-foreground">{note.title}</p>
+          )}
+          <FormattedNoteContent
+            markdown={note.content}
+            className="line-clamp-4 text-sm leading-6 text-foreground"
+          />
+          {pageLabel && (
+            <div className="mt-2 flex flex-wrap items-center gap-2 text-xs font-medium text-muted-foreground">
+              <span>{pageLabel}</span>
+            </div>
+          )}
+        </>
+      )}
+    </button>
+  );
+}
+
+function GroupedNotesView({
+  groups,
+  onBook,
+}: {
+  groups: NoteGroup[];
+  onBook: (book: Book) => void;
+}) {
+  if (groups.length === 0) {
+    return <EmptyLibraryView message="No notes yet." />;
+  }
+
+  return (
+    <div className="space-y-6">
+      {groups.map((group) => (
+        <section key={group.name} className="space-y-3">
+          <div>
+            <h3 className="font-heading leading-snug font-medium">{group.name}</h3>
+            <p className="text-xs text-muted-foreground">{noteGroupCountLabel(group.notes.length)}</p>
+          </div>
+          <Separator />
+          <div className="space-y-3">
+            {group.notes.map((note) => (
+              <LibraryNoteCard key={note.id} note={note} onBook={onBook} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
 function getViewLabel(view: LibraryView) {
   return (
     primaryShelves.find((shelf) => shelf.value === view)?.label ??
@@ -375,6 +562,10 @@ function getViewLabel(view: LibraryView) {
 export default function Library() {
   const { books, loading: booksLoading, error, reload } = useBooksContext();
   const { series, loading: seriesLoading } = useSeries();
+  const [notes, setNotes] = useState<BookNote[]>([]);
+  const [notesLoading, setNotesLoading] = useState(false);
+  const [notesLoaded, setNotesLoaded] = useState(false);
+  const [notesError, setNotesError] = useState<string | null>(null);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
@@ -382,7 +573,8 @@ export default function Library() {
   const hasExplicitView = isLibraryView(viewParam);
   const activeView = hasExplicitView ? viewParam : undefined;
   const contentView = activeView ?? "all";
-  const loading = booksLoading || seriesLoading;
+  const isNotesView = contentView === "notes";
+  const loading = booksLoading || seriesLoading || (isNotesView && notesLoading);
   const mobileHeading = activeView ? getViewLabel(activeView) : "Library";
 
   useEffect(() => {
@@ -391,8 +583,40 @@ export default function Library() {
     }
   }, [navigate, viewParam]);
 
+  useEffect(() => {
+    if (!isNotesView || notesLoaded) return;
+
+    let isMounted = true;
+    setNotesLoading(true);
+    setNotesError(null);
+
+    fetchAllBookNotes()
+      .then((data) => {
+        if (!isMounted) return;
+        setNotes(data);
+        setNotesLoaded(true);
+      })
+      .catch((fetchError: unknown) => {
+        if (!isMounted) return;
+        setNotesLoaded(true);
+        setNotesError(fetchError instanceof Error ? fetchError.message : "Could not load notes.");
+      })
+      .finally(() => {
+        if (isMounted) setNotesLoading(false);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isNotesView, notesLoaded]);
+
   function openBook(book: Book) {
     navigate(`/books/${book.id}`);
+  }
+
+  function retryNotes() {
+    setNotesLoaded(false);
+    setNotesError(null);
   }
 
   const primaryCounts = useMemo(
@@ -412,8 +636,9 @@ export default function Library() {
       series: series.filter((item) => books.some((book) => book.series_id === item.id)).length,
       authors: countUniqueBookValues(books, (book) => book.authors),
       genres: countUniqueBookValues(books, (book) => book.genres),
+      notes: notesLoaded ? notes.length : undefined,
     }),
-    [books, series]
+    [books, notes.length, notesLoaded, series]
   );
 
   const activePrimaryShelf = primaryShelves.find((shelf) => shelf.value === contentView);
@@ -426,6 +651,7 @@ export default function Library() {
     if (contentView === "series") return buildSeriesGroups(books, series);
     if (contentView === "authors") return buildMultiValueGroups(books, (book) => book.authors);
     if (contentView === "genres") return buildMultiValueGroups(books, (book) => book.genres);
+    if (contentView === "rating") return buildRatingGroups(books);
     if (contentView === "languages") return buildSingleValueGroups(books, (book) => book.language);
     if (contentView === "format") return buildSingleValueGroups(books, (book) => book.format);
     if (contentView === "belongs-to") {
@@ -434,11 +660,18 @@ export default function Library() {
     return [];
   }, [contentView, books, series]);
 
+  const groupedNotes = useMemo(() => {
+    if (!isNotesView) return [];
+    return buildNoteGroups(notes, books);
+  }, [books, isNotesView, notes]);
+
   const displayedCountLabel = (() => {
     if (activePrimaryShelf) return itemCountLabel(visibleBooks.length, "book");
     if (contentView === "series") return itemCountLabel(categoryCounts.series ?? 0, "series", "series");
     if (contentView === "authors") return itemCountLabel(categoryCounts.authors ?? 0, "author");
     if (contentView === "genres") return itemCountLabel(categoryCounts.genres ?? 0, "genre");
+    if (contentView === "rating") return itemCountLabel(books.length, "book");
+    if (contentView === "notes") return itemCountLabel(notes.length, "entry", "entries");
     return itemCountLabel(books.length, "book");
   })();
 
@@ -458,6 +691,16 @@ export default function Library() {
         <div className="flex flex-col items-center gap-3 py-8 text-center">
           <p className="text-sm text-destructive">{error}</p>
           <Button variant="outline" size="sm" onClick={() => reload()}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Try again
+          </Button>
+        </div>
+      )}
+
+      {notesError && isNotesView && (
+        <div className="flex flex-col items-center gap-3 py-8 text-center">
+          <p className="text-sm text-destructive">{notesError}</p>
+          <Button variant="outline" size="sm" onClick={retryNotes}>
             <RefreshCw className="mr-2 h-4 w-4" />
             Try again
           </Button>
@@ -505,6 +748,8 @@ export default function Library() {
             ) : (
               <BooksGrid books={visibleBooks} onBook={openBook} />
             )
+          ) : isNotesView ? (
+            notesError ? null : <GroupedNotesView groups={groupedNotes} onBook={openBook} />
           ) : (
             <GroupedBooksView groups={groupedBooks} onBook={openBook} />
           )}

--- a/tests/libraryShelves.test.ts
+++ b/tests/libraryShelves.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildNoteGroups, buildRatingGroups } from "../src/lib/libraryShelves";
+import type { Book, BookNote } from "../src/types";
+
+test("groups favorite books above ratings without duplicating them", () => {
+  const groups = buildRatingGroups([
+    makeBook({ id: "favorite-five", title: "Favorite Five", rating: 5, is_favorite: true }),
+    makeBook({ id: "regular-five", title: "Regular Five", rating: 5 }),
+    makeBook({ id: "four-star", title: "Four Star", rating: 4 }),
+    makeBook({ id: "unrated", title: "Unrated", rating: null }),
+  ]);
+
+  assert.deepEqual(
+    groups.map((group) => ({
+      name: group.name,
+      books: group.books.map((book) => book.id),
+    })),
+    [
+      { name: "Favorites", books: ["favorite-five"] },
+      { name: "5 Stars", books: ["regular-five"] },
+      { name: "4 Stars", books: ["four-star"] },
+      { name: "Unrated", books: ["unrated"] },
+    ],
+  );
+});
+
+test("groups notes by label and puts favorite quotes first", () => {
+  const book = makeBook({ id: "book-1", title: "Book One" });
+  const groups = buildNoteGroups(
+    [
+      makeNote({
+        id: "regular-quote",
+        label: "quote",
+        content: "Regular quote",
+        note_date: "2026-05-06",
+      }),
+      makeNote({
+        id: "favorite-quote",
+        label: "quote",
+        content: "Favorite quote",
+        is_favorite: true,
+        note_date: "2026-05-01",
+      }),
+      makeNote({ id: "review", label: "review", content: "Review" }),
+      makeNote({ id: "note", label: "note", content: "Note" }),
+    ],
+    [book],
+  );
+
+  assert.deepEqual(
+    groups.map((group) => ({
+      name: group.name,
+      notes: group.notes.map((note) => note.id),
+    })),
+    [
+      { name: "Quotes", notes: ["favorite-quote", "regular-quote"] },
+      { name: "Reviews", notes: ["review"] },
+      { name: "Notes", notes: ["note"] },
+    ],
+  );
+});
+
+function makeBook(overrides: Partial<Book>): Book {
+  return {
+    id: "book-1",
+    title: "Book",
+    authors: ["Author"],
+    status: "Finished",
+    rating: null,
+    is_favorite: false,
+    user_id: "user-1",
+    created_at: "2026-05-01T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeNote(overrides: Partial<BookNote>): BookNote {
+  return {
+    id: "note-1",
+    user_id: "user-1",
+    book_id: "book-1",
+    label: "note",
+    title: null,
+    quote_speaker: null,
+    content: "Note",
+    page_start: null,
+    is_favorite: false,
+    note_date: "2026-05-01",
+    created_at: "2026-05-01T08:00:00Z",
+    updated_at: "2026-05-01T08:00:00Z",
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
  - Added Rating and Notes shelves to the Library categories.
  - Rating groups favorites first, then books by star rating without duplicating favorites.
  - Notes groups entries by quotes, reviews, and notes, with favorite quotes first and Markdown rendering preserved.

  ## Validation
  - npm test
  - npm run typecheck
  - npm run build

  Closes #140