### PR TITLE
[codex] Redesign My Books browsing and management

### DIFF
--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -39,8 +39,17 @@ export default function BookCard({
 
   return (
     <Card
-      className="cursor-pointer overflow-hidden pt-0 gap-0 pb-2 hover:ring-2 hover:ring-primary/40 transition-shadow"
+      role="button"
+      tabIndex={0}
+      className="cursor-pointer overflow-hidden pt-0 gap-0 pb-2 transition-shadow hover:ring-2 hover:ring-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
       onClick={() => onClick(book)}
+      onKeyDown={(event) => {
+        if (event.target !== event.currentTarget) return;
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onClick(book);
+        }
+      }}
     >
       {/* Cover */}
       <div className="relative aspect-[2/3] w-full bg-muted flex-shrink-0">
@@ -48,6 +57,7 @@ export default function BookCard({
           <img
             src={book.cover_url}
             alt={book.title}
+            loading="lazy"
             className="h-full w-full object-cover"
           />
         ) : (

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -4,10 +4,11 @@ import {
   BookOpen,
   Grid2X2,
   Heart,
-  List,
   Plus,
   RefreshCw,
+  Rows3,
   Star,
+  Table2,
   X,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -51,6 +52,10 @@ import {
 } from "@/lib/libraryShelves";
 import { cn, statusVariant } from "@/lib/utils";
 import BookCard from "@/components/BookCard";
+import BookShelf from "@/pages/library/BookShelf";
+import CompactBookCard from "@/pages/library/CompactBookCard";
+import ContinueReadingCard from "@/pages/library/ContinueReadingCard";
+import ShelfCarousel from "@/pages/library/ShelfCarousel";
 import type { Book, BookNote, Series } from "@/types";
 
 type LibraryView =
@@ -60,6 +65,7 @@ type LibraryView =
   | "finished"
   | "wishlist"
   | "dnf"
+  | "favorites"
   | "series"
   | "authors"
   | "genres"
@@ -100,6 +106,14 @@ type LibraryFilterOptions = Record<LibraryFilterKey, string[]>;
 type ActiveFilterChip = {
   keys: LibraryFilterKey[];
   label: string;
+};
+
+type SmartShelf = {
+  key: "currently-reading" | "want-to-read" | "recently-finished" | "favorites";
+  title: string;
+  books: Book[];
+  view: LibraryView;
+  emptyMessage: string;
 };
 
 const filterKeys: LibraryFilterKey[] = [
@@ -161,6 +175,12 @@ const primaryShelves: PrimaryShelf[] = [
     matches: (book) => book.status === "DNF",
     emptyMessage: "No DNF books yet.",
   },
+  {
+    value: "favorites",
+    label: "Favorites",
+    matches: (book) => book.is_favorite,
+    emptyMessage: "No favorite books yet.",
+  },
 ];
 
 const categoryShelves: CategoryShelf[] = [
@@ -211,9 +231,20 @@ function EmptyLibraryView({ message }: { message: string }) {
 function BooksGrid({ books, onBook }: { books: Book[]; onBook: (b: Book) => void }) {
   if (books.length === 0) return null;
   return (
-    <div className="grid grid-cols-3 gap-2.5 sm:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+    <div className="grid grid-cols-[repeat(auto-fill,110px)] justify-start gap-3 sm:grid-cols-[repeat(auto-fill,140px)]">
       {books.map((book) => (
         <BookCard key={book.id} book={book} onClick={onBook} textSize="compact" />
+      ))}
+    </div>
+  );
+}
+
+function CompactBooksGrid({ books, onBook }: { books: Book[]; onBook: (b: Book) => void }) {
+  if (books.length === 0) return null;
+  return (
+    <div className="grid gap-2.5 sm:grid-cols-2 xl:grid-cols-3">
+      {books.map((book) => (
+        <CompactBookCard key={book.id} book={book} onBook={onBook} />
       ))}
     </div>
   );
@@ -277,6 +308,7 @@ function BookTableRow({ book, onBook }: { book: Book; onBook: (b: Book) => void 
               <img
                 src={book.cover_url}
                 alt={book.title}
+                loading="lazy"
                 className="h-full w-full object-cover"
               />
             ) : (
@@ -330,11 +362,18 @@ function BooksView({
   display: LibraryDisplay;
   onBook: (b: Book) => void;
 }) {
-  return display === "table" ? (
-    <BooksTable books={books} onBook={onBook} />
-  ) : (
-    <BooksGrid books={books} onBook={onBook} />
-  );
+  if (display === "table") {
+    return (
+      <div className="space-y-3">
+        <div className="rounded-lg border bg-muted/20 p-4">
+          <h3 className="font-heading text-base font-medium leading-snug">Management Mode</h3>
+        </div>
+        <BooksTable books={books} onBook={onBook} />
+      </div>
+    );
+  }
+  if (display === "compact") return <CompactBooksGrid books={books} onBook={onBook} />;
+  return <BooksGrid books={books} onBook={onBook} />;
 }
 
 function LibraryViewModeSwitcher({
@@ -359,12 +398,22 @@ function LibraryViewModeSwitcher({
       <Button
         type="button"
         size="icon-sm"
+        variant={display === "compact" ? "secondary" : "ghost"}
+        aria-label="Compact view"
+        aria-pressed={display === "compact"}
+        onClick={() => onDisplayChange("compact")}
+      >
+        <Rows3 className="h-4 w-4" />
+      </Button>
+      <Button
+        type="button"
+        size="icon-sm"
         variant={display === "table" ? "secondary" : "ghost"}
         aria-label="Table view"
         aria-pressed={display === "table"}
         onClick={() => onDisplayChange("table")}
       >
-        <List className="h-4 w-4" />
+        <Table2 className="h-4 w-4" />
       </Button>
     </div>
   );
@@ -403,6 +452,32 @@ function LibraryPlaceholder({ message }: { message: string }) {
       {message}
     </div>
   );
+}
+
+function libraryResultsEmptyMessage({
+  hasSearch,
+  hasActiveFilters,
+  fallback,
+}: {
+  hasSearch: boolean;
+  hasActiveFilters: boolean;
+  fallback: string;
+}) {
+  if (hasSearch) return "No books match your search.";
+  if (hasActiveFilters) return "No books match your filters.";
+  return fallback;
+}
+
+function continueReadingEmptyMessage({
+  hasSearch,
+  hasActiveFilters,
+}: {
+  hasSearch: boolean;
+  hasActiveFilters: boolean;
+}) {
+  if (hasSearch) return "No current reads match your search.";
+  if (hasActiveFilters) return "No current reads match your filters.";
+  return "Books you are currently reading will appear here first.";
 }
 
 function groupCountLabel(count: number) {
@@ -1094,9 +1169,61 @@ function readingShelfBooks(books: Book[], series: Series[], query: string, sort:
   });
 }
 
+function compareRecentlyFinishedBooks(a: Book, b: Book): number {
+  const finishedA = a.date_finished ? new Date(a.date_finished).getTime() : 0;
+  const finishedB = b.date_finished ? new Date(b.date_finished).getTime() : 0;
+  const addedA = new Date(a.created_at).getTime();
+  const addedB = new Date(b.created_at).getTime();
+
+  return finishedB - finishedA || addedB - addedA || a.title.localeCompare(b.title);
+}
+
+function buildSmartShelves(books: Book[]): SmartShelf[] {
+  const currentlyReading = books.filter((book) => book.status === "Reading");
+  const wantToRead = books.filter((book) =>
+    ["Wishlist", "Not Started", "Up Next"].includes(book.status),
+  );
+  const recentlyFinished = books
+    .filter((book) => book.status === "Finished")
+    .sort(compareRecentlyFinishedBooks);
+  const favorites = books.filter((book) => book.is_favorite);
+
+  return [
+    {
+      key: "currently-reading",
+      title: "Currently Reading",
+      books: currentlyReading,
+      view: "reading",
+      emptyMessage: "Books you are currently reading will appear here.",
+    },
+    {
+      key: "want-to-read",
+      title: "Want to Read",
+      books: wantToRead,
+      view: "tbr",
+      emptyMessage: "Wishlist, Not Started, and Up Next books will appear here.",
+    },
+    {
+      key: "recently-finished",
+      title: "Recently Finished",
+      books: recentlyFinished,
+      view: "finished",
+      emptyMessage: "Finished books will appear here.",
+    },
+    {
+      key: "favorites",
+      title: "Favorites",
+      books: favorites,
+      view: "favorites",
+      emptyMessage: "Tap the heart on a book to collect favorites here.",
+    },
+  ];
+}
+
 function MyBooksOverview({
   books,
   continueReadingBooks,
+  smartShelves,
   display,
   loading,
   hasActiveFilters,
@@ -1104,10 +1231,12 @@ function MyBooksOverview({
   countLabel,
   controls,
   onDisplayChange,
+  onViewAll,
   onBook,
 }: {
   books: Book[];
   continueReadingBooks: Book[];
+  smartShelves: SmartShelf[];
   display: LibraryDisplay;
   loading: boolean;
   hasActiveFilters: boolean;
@@ -1115,6 +1244,7 @@ function MyBooksOverview({
   countLabel: string;
   controls: ReactNode;
   onDisplayChange: (display: LibraryDisplay) => void;
+  onViewAll: (view: LibraryView) => void;
   onBook: (book: Book) => void;
 }) {
   const hasSearch = Boolean(normalizeSearchText(query));
@@ -1125,14 +1255,39 @@ function MyBooksOverview({
         {loading ? (
           <LoadingGrid />
         ) : continueReadingBooks.length > 0 ? (
-          <BooksGrid books={continueReadingBooks.slice(0, 6)} onBook={onBook} />
+          <ShelfCarousel
+            ariaLabel="Continue reading books"
+            itemClassName="w-[72vw] max-w-[18rem] shrink-0 sm:w-[15rem] lg:w-[13.5rem]"
+            className="gap-4"
+          >
+            {continueReadingBooks.slice(0, 8).map((book) => (
+              <ContinueReadingCard key={book.id} book={book} onBook={onBook} />
+            ))}
+          </ShelfCarousel>
         ) : (
-          <LibraryPlaceholder message="Books you are currently reading will appear here first." />
+          <LibraryPlaceholder
+            message={continueReadingEmptyMessage({ hasSearch, hasActiveFilters })}
+          />
         )}
       </LibrarySection>
 
       <LibrarySection title="Your Shelves">
-        <LibraryPlaceholder message="Smart shelf rows for Currently Reading, Want to Read, Recently Finished, and Favorites will be added in the next step." />
+        {loading ? (
+          <LoadingGrid />
+        ) : (
+          <div className="space-y-7">
+            {smartShelves.map((shelf) => (
+              <BookShelf
+                key={shelf.key}
+                title={shelf.title}
+                books={shelf.books}
+                onBook={onBook}
+                onViewAll={() => onViewAll(shelf.view)}
+                emptyMessage={shelf.emptyMessage}
+              />
+            ))}
+          </div>
+        )}
       </LibrarySection>
 
       <LibrarySection
@@ -1150,13 +1305,11 @@ function MyBooksOverview({
           <LoadingGrid />
         ) : books.length === 0 ? (
           <EmptyLibraryView
-            message={
-              hasSearch
-                ? "No books match your search."
-                : hasActiveFilters
-                  ? "No books match your filters."
-                  : "No books yet. Tap + to add one."
-            }
+            message={libraryResultsEmptyMessage({
+              hasSearch,
+              hasActiveFilters,
+              fallback: "No books yet. Tap + to add one.",
+            })}
           />
         ) : (
           <BooksView books={books} display={display} onBook={onBook} />
@@ -1320,6 +1473,11 @@ export default function Library() {
     [books, libraryFilters, libraryQuery, librarySort, series],
   );
 
+  const smartShelves = useMemo(
+    () => buildSmartShelves(visibleBooks),
+    [visibleBooks],
+  );
+
   const filteredBooks = useMemo(() => {
     if (!activeValueShelf || !selectedValue || activeValueShelf === "notes") return [];
     return filterAndSortBooks({
@@ -1450,6 +1608,7 @@ export default function Library() {
         <MyBooksOverview
           books={visibleBooks}
           continueReadingBooks={continueReadingBooks}
+          smartShelves={smartShelves}
           display={libraryDisplay}
           loading={loading}
           hasActiveFilters={hasActiveFilters}
@@ -1457,6 +1616,7 @@ export default function Library() {
           countLabel={displayedCountLabel}
           controls={controlsBar}
           onDisplayChange={(display) => updateLibraryParam("display", display)}
+          onViewAll={updateLibraryView}
           onBook={openBook}
         />
       ) : (
@@ -1468,13 +1628,11 @@ export default function Library() {
             ) : activePrimaryShelf ? (
               visibleBooks.length === 0 ? (
                 <EmptyLibraryView
-                  message={
-                    normalizeSearchText(libraryQuery)
-                      ? "No books match your search."
-                      : hasActiveFilters
-                        ? "No books match your filters."
-                      : activePrimaryShelf.emptyMessage
-                  }
+                  message={libraryResultsEmptyMessage({
+                    hasSearch: Boolean(normalizeSearchText(libraryQuery)),
+                    hasActiveFilters,
+                    fallback: activePrimaryShelf.emptyMessage,
+                  })}
                 />
               ) : (
                 <BooksView books={visibleBooks} display={libraryDisplay} onBook={openBook} />

--- a/src/pages/library/BookShelf.tsx
+++ b/src/pages/library/BookShelf.tsx
@@ -1,0 +1,55 @@
+import { ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { Book } from "@/types";
+import LibraryBookCard from "./LibraryBookCard";
+
+interface BookShelfProps {
+  title: string;
+  books: Book[];
+  onBook: (book: Book) => void;
+  onViewAll?: () => void;
+  emptyMessage?: string;
+}
+
+function bookCountLabel(count: number) {
+  return `${count} book${count === 1 ? "" : "s"}`;
+}
+
+export default function BookShelf({
+  title,
+  books,
+  onBook,
+  onViewAll,
+  emptyMessage = "No books here yet.",
+}: BookShelfProps) {
+  return (
+    <section className="min-w-0 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="font-heading text-lg font-medium leading-snug">{title}</h3>
+          <p className="text-xs text-muted-foreground">{bookCountLabel(books.length)}</p>
+        </div>
+        {onViewAll && (
+          <Button type="button" variant="ghost" size="sm" onClick={onViewAll}>
+            View All
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+      {books.length > 0 ? (
+        <div
+          aria-label={`${title} shelf`}
+          className="grid grid-cols-[repeat(auto-fill,110px)] justify-start gap-3 sm:grid-cols-[repeat(auto-fill,140px)]"
+        >
+          {books.map((book) => (
+            <LibraryBookCard key={book.id} book={book} onBook={onBook} variant="shelf" />
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed bg-muted/20 p-4 text-sm text-muted-foreground">
+          {emptyMessage}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/pages/library/CompactBookCard.tsx
+++ b/src/pages/library/CompactBookCard.tsx
@@ -1,0 +1,69 @@
+import { BookOpen, Heart, Star } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { statusVariant } from "@/lib/utils";
+import type { Book } from "@/types";
+
+interface CompactBookCardProps {
+  book: Book;
+  onBook: (book: Book) => void;
+}
+
+function getProgress(book: Book) {
+  if (book.status !== "Reading") return null;
+
+  const currentPage = Math.max(0, book.current_page ?? 0);
+  const totalPages = Math.max(0, book.total_pages ?? 0);
+
+  if (totalPages <= 0) return null;
+  return Math.min(100, Math.max(0, Math.round((currentPage / totalPages) * 100)));
+}
+
+export default function CompactBookCard({ book, onBook }: CompactBookCardProps) {
+  const progress = getProgress(book);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onBook(book)}
+      className="group flex min-w-0 gap-3 rounded-lg border bg-background p-2 text-left shadow-sm transition duration-200 ease-out hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:bg-card"
+    >
+      <div className="relative aspect-[2/3] w-14 shrink-0 overflow-hidden rounded-md bg-muted">
+        {book.cover_url ? (
+          <img
+            src={book.cover_url}
+            alt={book.title}
+            loading="lazy"
+            className="h-full w-full object-cover transition duration-200 ease-out group-hover:scale-[1.015]"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <BookOpen className="h-5 w-5 text-muted-foreground/40" />
+          </div>
+        )}
+        {book.is_favorite && (
+          <Heart className="absolute right-1 top-1 h-3.5 w-3.5 fill-rose-500 text-rose-500 drop-shadow" />
+        )}
+      </div>
+
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <div className="min-w-0">
+          <p className="line-clamp-2 text-sm font-medium leading-tight">{book.title}</p>
+          <p className="line-clamp-1 text-xs text-muted-foreground">{book.authors.join(", ")}</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant={statusVariant(book.status)} className="text-[10px]">
+            {book.status}
+          </Badge>
+          {book.rating ? (
+            <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+              <Star className="h-3.5 w-3.5 fill-current" />
+              {book.rating}
+            </span>
+          ) : null}
+        </div>
+        {progress !== null && <Progress value={progress} className="h-1" />}
+      </div>
+    </button>
+  );
+}

--- a/src/pages/library/ContinueReadingCard.tsx
+++ b/src/pages/library/ContinueReadingCard.tsx
@@ -1,0 +1,17 @@
+import BookCard from "@/components/BookCard";
+import type { Book } from "@/types";
+
+interface ContinueReadingCardProps {
+  book: Book;
+  onBook: (book: Book) => void;
+}
+
+export default function ContinueReadingCard({ book, onBook }: ContinueReadingCardProps) {
+  return (
+    <BookCard
+      book={book}
+      onClick={onBook}
+      showQuickProgress
+    />
+  );
+}

--- a/src/pages/library/LibraryBookCard.tsx
+++ b/src/pages/library/LibraryBookCard.tsx
@@ -1,0 +1,98 @@
+import { BookOpen, Heart, Star } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { cn, statusVariant } from "@/lib/utils";
+import type { Book } from "@/types";
+
+interface LibraryBookCardProps {
+  book: Book;
+  onBook: (book: Book) => void;
+  variant?: "grid" | "shelf";
+}
+
+function getProgress(book: Book): number | null {
+  if (book.status !== "Reading") return null;
+
+  const currentPage = Math.max(0, book.current_page ?? 0);
+  const totalPages = Math.max(0, book.total_pages ?? 0);
+
+  if (totalPages <= 0) return null;
+  return Math.min(100, Math.max(0, Math.round((currentPage / totalPages) * 100)));
+}
+
+export default function LibraryBookCard({
+  book,
+  onBook,
+  variant = "grid",
+}: LibraryBookCardProps) {
+  const progress = getProgress(book);
+  const isShelf = variant === "shelf";
+
+  return (
+    <button
+      type="button"
+      onClick={() => onBook(book)}
+      className={cn(
+        "group block rounded-lg text-left transition duration-200 ease-out hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        isShelf
+          ? "w-full space-y-2"
+          : "w-[110px] overflow-hidden border bg-background shadow-sm hover:shadow-md sm:w-[140px] dark:bg-card",
+      )}
+    >
+      <div
+        className={cn(
+          "relative h-[165px] w-[110px] overflow-hidden bg-muted shadow-sm sm:h-[210px] sm:w-[140px]",
+          isShelf && "rounded-md",
+        )}
+      >
+        {book.cover_url ? (
+          <img
+            src={book.cover_url}
+            alt={book.title}
+            loading="lazy"
+            className="absolute inset-0 block h-full w-full scale-[1.035] object-cover transition duration-200 ease-out group-hover:scale-[1.055]"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <BookOpen className="h-8 w-8 text-muted-foreground/40" />
+          </div>
+        )}
+        {book.is_favorite && (
+          <Heart
+            className="absolute right-2 top-2 h-4 w-4 fill-rose-500 text-rose-500 drop-shadow"
+            aria-label="Favorite"
+          />
+        )}
+      </div>
+
+      {!isShelf && (
+        <div className="min-w-0 space-y-2 p-2">
+          <div className="min-w-0">
+            <p className="line-clamp-2 text-sm font-medium leading-tight">{book.title}</p>
+            <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+              {book.authors.join(", ")}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Badge variant={statusVariant(book.status)} className="text-[10px]">
+              {book.status}
+            </Badge>
+            {book.rating ? (
+              <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                <Star className="h-3.5 w-3.5 fill-current" />
+                {book.rating}
+              </span>
+            ) : null}
+          </div>
+          {progress !== null && (
+            <div className="space-y-1">
+              <Progress value={progress} className="h-1" />
+              <p className="text-[11px] text-muted-foreground">{progress}% read</p>
+            </div>
+          )}
+        </div>
+      )}
+    </button>
+  );
+}

--- a/src/pages/library/ShelfCarousel.tsx
+++ b/src/pages/library/ShelfCarousel.tsx
@@ -1,0 +1,40 @@
+import { Children, type ReactNode, type WheelEvent } from "react";
+import { cn } from "@/lib/utils";
+
+interface ShelfCarouselProps {
+  children: ReactNode;
+  className?: string;
+  itemClassName?: string;
+  ariaLabel: string;
+}
+
+export default function ShelfCarousel({
+  children,
+  className,
+  itemClassName,
+  ariaLabel,
+}: ShelfCarouselProps) {
+  function handleWheel(event: WheelEvent<HTMLDivElement>) {
+    if (Math.abs(event.deltaY) <= Math.abs(event.deltaX)) return;
+
+    event.preventDefault();
+    event.currentTarget.scrollLeft += event.deltaY;
+  }
+
+  return (
+    <div
+      aria-label={ariaLabel}
+      className={cn(
+        "-mx-4 flex snap-x gap-3 overflow-x-auto scroll-smooth px-4 pb-2 pt-1 sm:-mx-2 sm:px-2",
+        className,
+      )}
+      onWheel={handleWheel}
+    >
+      {Children.map(children, (child, index) => (
+        <div key={index} className={cn("snap-start", itemClassName)}>
+          {child}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds the shelf-based My Books browsing layout with Continue Reading, Your Shelves, and All Books sections.
- Adds reusable local shelf/card components for the library page.
- Treats the existing table display as opt-in Management Mode while keeping the grid as the default exploration view.
- Improves empty states, card keyboard access, and lazy loading for book cover images.

## Validation

- npm run typecheck
- npm run build
- npm test