### PR TITLE
[codex] series stats redesign

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -42,7 +42,7 @@ type NavLink = {
 const sidebarNavLinks: NavLink[] = [
   { to: "/", label: "Dashboard", icon: LayoutDashboard },
   { to: "/library", label: "My Books", icon: Library },
-  { to: "/library/explore?view=series", label: "Series", icon: BookMarked },
+  { to: "/series", label: "Series", icon: BookMarked },
   { to: "/authors", label: "Authors", icon: UserRound },
   { to: "/analytics", label: "Stats", icon: BarChart3 },
   { to: "/shelves", label: "Shelves", icon: Bookmark },
@@ -58,7 +58,7 @@ const mobilePrimaryLinks: NavLink[] = [
 const mobileMenuLinks: NavLink[] = [
   { to: "/search", label: "Search", icon: Search },
   { to: "/library", label: "My Books", icon: Library },
-  { to: "/library/explore?view=series", label: "Series", icon: BookMarked },
+  { to: "/series", label: "Series", icon: BookMarked },
   { to: "/authors", label: "Authors", icon: UserRound },
   { to: "/shelves", label: "Shelves", icon: Bookmark },
   { to: "/groups", label: "Groups", icon: Users },

--- a/src/lib/libraryShelves.ts
+++ b/src/lib/libraryShelves.ts
@@ -6,6 +6,10 @@ export type BookGroup = {
   books: Book[];
 };
 
+export type SeriesBookGroup = BookGroup & {
+  seriesId: string;
+};
+
 export type LibraryNote = BookNote & {
   book: Book;
 };
@@ -55,7 +59,7 @@ function sortBooksByVolume(books: Book[]) {
   });
 }
 
-function sortGroups(groups: BookGroup[]) {
+function sortGroups<T extends BookGroup>(groups: T[]): T[] {
   return [...groups].sort((a, b) => {
     if (a.name === UNCATEGORIZED) return 1;
     if (b.name === UNCATEGORIZED) return -1;
@@ -126,22 +130,23 @@ export function buildSingleValueGroups(books: Book[], getValue: (book: Book) => 
   );
 }
 
-export function buildSeriesGroups(books: Book[], series: Series[]) {
-  const seriesById = new Map(series.map((item) => [item.id, item.name]));
+export function buildSeriesGroups(books: Book[], series: Series[]): SeriesBookGroup[] {
+  const seriesById = new Map(series.map((item) => [item.id, item]));
   const groups = new Map<string, Book[]>();
 
   books.forEach((book) => {
     if (!book.series_id) return;
 
-    const seriesName = seriesById.get(book.series_id);
-    if (!seriesName) return;
+    const seriesItem = seriesById.get(book.series_id);
+    if (!seriesItem) return;
 
-    addBookToGroup(groups, seriesName, book);
+    addBookToGroup(groups, seriesItem.id, book);
   });
 
   return sortGroups(
-    Array.from(groups, ([name, groupBooks]) => ({
-      name,
+    Array.from(groups, ([seriesId, groupBooks]) => ({
+      seriesId,
+      name: seriesById.get(seriesId)!.name,
       books: sortBooksByVolume(groupBooks),
     })),
   );

--- a/src/lib/router.tsx
+++ b/src/lib/router.tsx
@@ -6,6 +6,8 @@ import AppLayout from "@/components/AppLayout";
 const Login = lazy(() => import("@/pages/Login"));
 const Dashboard = lazy(() => import("@/pages/Dashboard"));
 const Library = lazy(() => import("@/pages/Library"));
+const Series = lazy(() => import("@/pages/Series"));
+const SeriesDetails = lazy(() => import("@/pages/SeriesDetails"));
 const ExploreLibrary = lazy(() => import("@/pages/ExploreLibrary"));
 const Authors = lazy(() => import("@/pages/Authors"));
 const AuthorDetails = lazy(() => import("@/pages/AuthorDetails"));
@@ -45,6 +47,8 @@ export const router = createBrowserRouter([
         children: [
           { path: "/", element: lazyRoute(<Dashboard />) },
           { path: "/library", element: lazyRoute(<Library />) },
+          { path: "/series", element: lazyRoute(<Series />) },
+          { path: "/series/:seriesId", element: lazyRoute(<SeriesDetails />) },
           { path: "/library/explore", element: lazyRoute(<ExploreLibrary />) },
           { path: "/authors", element: lazyRoute(<Authors />) },
           { path: "/authors/:authorName", element: lazyRoute(<AuthorDetails />) },

--- a/src/lib/seriesDetails.ts
+++ b/src/lib/seriesDetails.ts
@@ -1,0 +1,472 @@
+import {
+  calculateCalendarSpan,
+  parseLocalDateOnly,
+  sumReadingMinutes,
+  type CalendarSpan,
+} from "@/lib/bookAnalytics";
+import type { Book, BookNote, ReadingLog } from "@/types";
+
+export type SeriesProgress = {
+  isAvailable: boolean;
+  percentage: number | null;
+  readPages: number | null;
+  totalPages: number | null;
+  finishedBooks: number;
+};
+
+export type LatestSeriesActivity = {
+  book: Book;
+  log: ReadingLog;
+};
+
+export type JourneyBookDates = {
+  started: string | null;
+  finished: string | null;
+};
+
+export type SeriesJourneyRecap = {
+  started: string | null;
+  timeSpentDays: number;
+  finishedBooks: number;
+  completedMonths: number | null;
+  favoriteBook: Book | null;
+};
+
+export type SeriesJourneyTransition =
+  | {
+      kind: "continued";
+      days: number;
+      started: string;
+    }
+  | {
+      kind: "break";
+      days: number;
+      finished: string;
+      started: string;
+    };
+
+export type SeriesBookWinners = {
+  books: Book[];
+  value: number;
+};
+
+export type SeriesDurationChartRow = {
+  book: Book;
+  days: number;
+};
+
+export type SeriesPaceChartRow = {
+  book: Book;
+  pagesPerDay: number;
+};
+
+export type SeriesStats = {
+  overview: {
+    finishedBooks: number;
+    totalBooks: number;
+    pagesRead: number | null;
+    readingMinutes: number;
+    journeySpan: CalendarSpan | null;
+    journeyDays: number | null;
+  };
+  averageDaysPerBook: number | null;
+  fastestRead: SeriesBookWinners | null;
+  slowestRead: SeriesBookWinners | null;
+  longestBook: SeriesBookWinners | null;
+  shortestBook: SeriesBookWinners | null;
+  mostAnnotated: SeriesBookWinners | null;
+  mostHighlighted: SeriesBookWinners | null;
+  durationChart: SeriesDurationChartRow[];
+  paceChart: SeriesPaceChartRow[];
+};
+
+function compareBookTitles(a: Book, b: Book): number {
+  return a.title.localeCompare(b.title, undefined, { sensitivity: "base", numeric: true });
+}
+
+function dateToDateOnly(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function getLogDateOnly(log: ReadingLog): string | null {
+  const date = new Date(log.logged_at);
+  return Number.isNaN(date.getTime()) ? null : dateToDateOnly(date);
+}
+
+function getLogsForBook(book: Book, logs: ReadingLog[]): ReadingLog[] {
+  return logs.filter((log) => log.book_id === book.id);
+}
+
+function daysBetween(started: string, finished: string): number | null {
+  const startDate = parseLocalDateOnly(started);
+  const finishedDate = parseLocalDateOnly(finished);
+  if (!startDate || !finishedDate || finishedDate < startDate) return null;
+  return Math.round((finishedDate.getTime() - startDate.getTime()) / (24 * 60 * 60 * 1000));
+}
+
+export function sortSeriesBooks(books: Book[]): Book[] {
+  return [...books].sort((a, b) => {
+    const volumeA = a.volume_number ?? Number.MAX_SAFE_INTEGER;
+    const volumeB = b.volume_number ?? Number.MAX_SAFE_INTEGER;
+
+    return volumeA - volumeB || compareBookTitles(a, b);
+  });
+}
+
+export function getSeriesAuthors(books: Book[]): string[] {
+  return Array.from(
+    new Set(books.flatMap((book) => book.authors.map((author) => author.trim()).filter(Boolean))),
+  ).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base", numeric: true }));
+}
+
+export function getMostCommonGenre(books: Book[]): string | null {
+  const counts = new Map<string, number>();
+
+  books.forEach((book) => {
+    Array.from(new Set(book.genres?.map((genre) => genre.trim()).filter(Boolean) ?? [])).forEach(
+      (genre) => counts.set(genre, (counts.get(genre) ?? 0) + 1),
+    );
+  });
+
+  return (
+    [...counts.entries()].sort(
+      ([nameA, countA], [nameB, countB]) =>
+        countB - countA ||
+        nameA.localeCompare(nameB, undefined, { sensitivity: "base", numeric: true }),
+    )[0]?.[0] ?? null
+  );
+}
+
+export function getAverageSeriesRating(books: Book[]): number | null {
+  const ratings = books.flatMap((book) =>
+    typeof book.rating === "number" ? [book.rating] : [],
+  );
+  if (ratings.length === 0) return null;
+
+  return ratings.reduce((sum, rating) => sum + rating, 0) / ratings.length;
+}
+
+export function getBookProgressPercent(book: Book): number | null {
+  const totalPages = book.total_pages ?? 0;
+  if (totalPages <= 0) return null;
+
+  const pagesRead =
+    book.status === "Finished"
+      ? totalPages
+      : Math.min(totalPages, Math.max(0, book.current_page ?? 0));
+  return Math.round((pagesRead / totalPages) * 100);
+}
+
+export function getSeriesProgress(books: Book[]): SeriesProgress {
+  const finishedBooks = books.filter((book) => book.status === "Finished").length;
+  if (books.length === 0 || books.some((book) => !book.total_pages || book.total_pages <= 0)) {
+    return {
+      isAvailable: false,
+      percentage: null,
+      readPages: null,
+      totalPages: null,
+      finishedBooks,
+    };
+  }
+
+  const totalPages = books.reduce((sum, book) => sum + (book.total_pages ?? 0), 0);
+  const readPages = books.reduce((sum, book) => {
+    const total = book.total_pages ?? 0;
+    if (book.status === "Finished") return sum + total;
+    if (book.status === "Reading" || book.status === "DNF") {
+      return sum + Math.min(total, Math.max(0, book.current_page ?? 0));
+    }
+    return sum;
+  }, 0);
+
+  return {
+    isAvailable: true,
+    percentage: Math.round((readPages / totalPages) * 100),
+    readPages,
+    totalPages,
+    finishedBooks,
+  };
+}
+
+export function getNextUpBook(books: Book[]): Book | null {
+  return (
+    sortSeriesBooks(books).find(
+      (book) => !["Finished", "DNF", "Reading"].includes(book.status),
+    ) ?? null
+  );
+}
+
+export function getLatestSeriesActivity(
+  books: Book[],
+  logs: ReadingLog[],
+): LatestSeriesActivity | null {
+  const booksById = new Map(books.map((book) => [book.id, book]));
+  const latestLog = [...logs]
+    .filter((log) => booksById.has(log.book_id))
+    .sort((a, b) => new Date(b.logged_at).getTime() - new Date(a.logged_at).getTime())[0];
+
+  if (!latestLog) return null;
+  return { book: booksById.get(latestLog.book_id)!, log: latestLog };
+}
+
+export function filterSeriesLogs(books: Book[], logs: ReadingLog[]): ReadingLog[] {
+  const bookIds = new Set(books.map((book) => book.id));
+  return logs.filter((log) => bookIds.has(log.book_id));
+}
+
+export function getJourneyBookDates(book: Book, logs: ReadingLog[]): JourneyBookDates {
+  const logDates = getLogsForBook(book, logs)
+    .flatMap((log) => {
+      const date = getLogDateOnly(log);
+      return date ? [date] : [];
+    })
+    .sort();
+
+  return {
+    started: book.date_started ?? logDates[0] ?? null,
+    finished:
+      book.status === "Finished"
+        ? book.date_finished ?? logDates[logDates.length - 1] ?? null
+        : null,
+  };
+}
+
+export function getBookReadingMinutes(book: Book, logs: ReadingLog[]): number {
+  return sumReadingMinutes(getLogsForBook(book, logs));
+}
+
+export function getJourneyDurationDays(
+  book: Book,
+  logs: ReadingLog[],
+  now = new Date(),
+): number | null {
+  const dates = getJourneyBookDates(book, logs);
+  if (!dates.started) return null;
+
+  const finished =
+    dates.finished ??
+    (book.status === "Reading" ? dateToDateOnly(now) : null);
+  if (!finished) return null;
+
+  return daysBetween(dates.started, finished);
+}
+
+export function getSeriesJourneyRecap(
+  books: Book[],
+  logs: ReadingLog[],
+  now = new Date(),
+): SeriesJourneyRecap {
+  const sortedBooks = sortSeriesBooks(books);
+  const dates = sortedBooks.map((book) => getJourneyBookDates(book, logs));
+  const started =
+    dates.flatMap((date) => (date.started ? [date.started] : [])).sort()[0] ?? null;
+  const sortedFinishedDates = dates
+    .flatMap((date) => (date.finished ? [date.finished] : []))
+    .sort();
+  const latestFinish = sortedFinishedDates[sortedFinishedDates.length - 1] ?? null;
+  const startedDate = parseLocalDateOnly(started ?? undefined);
+  const latestFinishDate = parseLocalDateOnly(latestFinish ?? undefined);
+  const favoriteBook =
+    sortedBooks.find((book) => book.is_favorite) ??
+    [...sortedBooks]
+      .filter((book) => typeof book.rating === "number")
+      .sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0))[0] ??
+    null;
+
+  return {
+    started,
+    timeSpentDays: sortedBooks.reduce(
+      (total, book) => total + (getJourneyDurationDays(book, logs, now) ?? 0),
+      0,
+    ),
+    finishedBooks: books.filter((book) => book.status === "Finished").length,
+    completedMonths:
+      startedDate && latestFinishDate && latestFinishDate >= startedDate
+        ? calculateCalendarSpan(startedDate, latestFinishDate).months
+        : null,
+    favoriteBook,
+  };
+}
+
+function getWinnerBooks(
+  candidates: Array<{ book: Book; value: number }>,
+  selectValue: (values: number[]) => number,
+): SeriesBookWinners | null {
+  if (candidates.length === 0) return null;
+
+  const value = selectValue(candidates.map((candidate) => candidate.value));
+  return {
+    books: candidates
+      .filter((candidate) => candidate.value === value)
+      .map((candidate) => candidate.book),
+    value,
+  };
+}
+
+function getSeriesPagesRead(books: Book[]): number | null {
+  let pagesRead = 0;
+
+  for (const book of books) {
+    if (book.status === "Finished") {
+      if (typeof book.total_pages !== "number" || book.total_pages <= 0) return null;
+      pagesRead += book.total_pages;
+    } else if (book.status === "Reading") {
+      if (
+        typeof book.current_page !== "number" ||
+        !Number.isFinite(book.current_page) ||
+        book.current_page < 0
+      ) {
+        return null;
+      }
+      pagesRead += book.current_page;
+    }
+  }
+
+  return pagesRead;
+}
+
+function getSeriesJourneySpan(
+  books: Book[],
+  logs: ReadingLog[],
+  now: Date,
+): Pick<SeriesStats["overview"], "journeySpan" | "journeyDays"> {
+  const dates = books.map((book) => getJourneyBookDates(book, logs));
+  const started =
+    dates.flatMap((date) => (date.started ? [date.started] : [])).sort()[0] ?? null;
+  const startDate = parseLocalDateOnly(started ?? undefined);
+  if (!startDate) return { journeySpan: null, journeyDays: null };
+
+  const hasActiveBook = books.some((book) => book.status === "Reading");
+  const finishedDates = dates
+    .flatMap((date) => (date.finished ? [date.finished] : []))
+    .sort();
+  const latestFinished = finishedDates[finishedDates.length - 1] ?? null;
+  const endDate = hasActiveBook
+    ? parseLocalDateOnly(dateToDateOnly(now))
+    : parseLocalDateOnly(latestFinished ?? undefined);
+
+  if (!endDate || endDate < startDate) {
+    return { journeySpan: null, journeyDays: null };
+  }
+
+  return {
+    journeySpan: calculateCalendarSpan(startDate, endDate),
+    journeyDays: daysBetween(dateToDateOnly(startDate), dateToDateOnly(endDate)),
+  };
+}
+
+export function getSeriesStats(
+  books: Book[],
+  logs: ReadingLog[],
+  notes: BookNote[],
+  now = new Date(),
+): SeriesStats {
+  const sortedBooks = sortSeriesBooks(books);
+  const bookIds = new Set(sortedBooks.map((book) => book.id));
+  const seriesLogs = filterSeriesLogs(sortedBooks, logs);
+  const seriesNotes = notes.filter((note) => bookIds.has(note.book_id));
+  const finishedBooks = sortedBooks.filter((book) => book.status === "Finished");
+  const durations = finishedBooks.flatMap((book) => {
+    const days = getJourneyDurationDays(book, seriesLogs, now);
+    return days === null ? [] : [{ book, value: days }];
+  });
+  const lengths = sortedBooks.flatMap((book) =>
+    typeof book.total_pages === "number" && book.total_pages > 0
+      ? [{ book, value: book.total_pages }]
+      : [],
+  );
+  const notesByBook = new Map(
+    sortedBooks.map((book) => [
+      book.id,
+      {
+        annotated: seriesNotes.filter(
+          (note) => note.book_id === book.id && (note.label === "note" || note.label === "review"),
+        ).length,
+        highlighted: seriesNotes.filter(
+          (note) => note.book_id === book.id && note.label === "quote",
+        ).length,
+      },
+    ]),
+  );
+  const annotations = sortedBooks.map((book) => ({
+    book,
+    value: notesByBook.get(book.id)?.annotated ?? 0,
+  }));
+  const highlights = sortedBooks.map((book) => ({
+    book,
+    value: notesByBook.get(book.id)?.highlighted ?? 0,
+  }));
+  const journey = getSeriesJourneySpan(sortedBooks, seriesLogs, now);
+  return {
+    overview: {
+      finishedBooks: finishedBooks.length,
+      totalBooks: sortedBooks.length,
+      pagesRead: getSeriesPagesRead(sortedBooks),
+      readingMinutes: sumReadingMinutes(seriesLogs),
+      ...journey,
+    },
+    averageDaysPerBook:
+      durations.length > 0
+        ? durations.reduce((sum, duration) => sum + duration.value, 0) / durations.length
+        : null,
+    fastestRead: getWinnerBooks(durations, (values) => Math.min(...values)),
+    slowestRead: getWinnerBooks(durations, (values) => Math.max(...values)),
+    longestBook: getWinnerBooks(lengths, (values) => Math.max(...values)),
+    shortestBook: getWinnerBooks(lengths, (values) => Math.min(...values)),
+    mostAnnotated:
+      annotations.some((candidate) => candidate.value > 0)
+        ? getWinnerBooks(annotations, (values) => Math.max(...values))
+        : null,
+    mostHighlighted:
+      highlights.some((candidate) => candidate.value > 0)
+        ? getWinnerBooks(highlights, (values) => Math.max(...values))
+        : null,
+    durationChart: durations.map(({ book, value }) => ({ book, days: value })),
+    paceChart: durations.flatMap(({ book, value }) =>
+      value > 0 && typeof book.total_pages === "number" && book.total_pages > 0
+        ? [{ book, pagesPerDay: book.total_pages / value }]
+        : [],
+    ),
+  };
+}
+
+export function getSeriesJourneyTransition(
+  previousBook: Book,
+  nextBook: Book,
+  logs: ReadingLog[],
+): SeriesJourneyTransition | null {
+  if (previousBook.status !== "Finished") return null;
+
+  const previousFinished = getJourneyBookDates(previousBook, logs).finished;
+  const nextStarted = getJourneyBookDates(nextBook, logs).started;
+  if (!previousFinished || !nextStarted) return null;
+
+  const days = daysBetween(previousFinished, nextStarted);
+  if (days === null) return null;
+  if (days <= 1) {
+    return { kind: "continued", days, started: nextStarted };
+  }
+  if (days > 10) {
+    return {
+      kind: "break",
+      days,
+      finished: previousFinished,
+      started: nextStarted,
+    };
+  }
+  return null;
+}
+
+export function getFeaturedNoteCandidates(notes: BookNote[]): BookNote[] {
+  return [...notes]
+    .filter((note) => note.content.trim().length > 0)
+    .sort(
+      (a, b) =>
+        a.content.trim().length - b.content.trim().length ||
+        Number(b.is_favorite) - Number(a.is_favorite) ||
+        b.note_date.localeCompare(a.note_date),
+    );
+}

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import { useForm, Controller } from "react-hook-form";
-import { useNavigate, useParams, Link } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams, Link } from "react-router-dom";
 import {
   ArrowLeft,
   BookOpen,
@@ -71,6 +71,12 @@ const STATUS_OPTIONS: BookStatus[] = [
   "DNF",
 ];
 
+type BookDetailTab = "properties" | "notes" | "analytics";
+
+function getBookDetailTab(value: string | null): BookDetailTab {
+  return value === "notes" || value === "analytics" ? value : "properties";
+}
+
 function metadataSourceLabel(source: Book["metadata_source"]): string {
   switch (source) {
     case "open_library":
@@ -110,6 +116,7 @@ function formatDateForDisplay(value: string): string {
 export default function BookDetails() {
   const { bookId } = useParams<{ bookId: string }>();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { books, loading, error, updateBook, updateCover, deleteBook, reload } = useBooksContext();
   const { series } = useSeries();
 
@@ -128,7 +135,23 @@ export default function BookDetails() {
   const [deleting, setDeleting] = useState(false);
   const [uploadingCover, setUploadingCover] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<BookDetailTab>(() =>
+    getBookDetailTab(searchParams.get("tab")),
+  );
   const coverInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setActiveTab(getBookDetailTab(searchParams.get("tab")));
+  }, [bookId, searchParams]);
+
+  function handleTabChange(value: string) {
+    const nextTab = getBookDetailTab(value);
+    const nextParams = new URLSearchParams(searchParams);
+    if (nextTab === "properties") nextParams.delete("tab");
+    else nextParams.set("tab", nextTab);
+    setActiveTab(nextTab);
+    setSearchParams(nextParams, { replace: true });
+  }
 
   const {
     register,
@@ -561,7 +584,7 @@ export default function BookDetails() {
         </div>
       </div>
 
-      <Tabs defaultValue="properties" className="flex flex-col min-h-0">
+      <Tabs value={activeTab} onValueChange={handleTabChange} className="flex flex-col min-h-0">
         <TabsList className="w-full">
           <TabsTrigger value="properties" className="flex-1">
             Properties

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -4,10 +4,10 @@ import { BookOpen, ChevronLeft, ChevronRight, Plus, RefreshCw } from "lucide-rea
 import { Button } from "@/components/ui/button";
 import { useBooksContext } from "@/context/BooksContext";
 import { useSeries } from "@/hooks/useSeries";
-import { buildSeriesGroups, type BookGroup } from "@/lib/libraryShelves";
-import { cn } from "@/lib/utils";
+import { buildSeriesGroups, type SeriesBookGroup } from "@/lib/libraryShelves";
 import BookShelf from "@/pages/library/BookShelf";
 import LibraryBookCard from "@/pages/library/LibraryBookCard";
+import SeriesStackCard from "@/pages/library/SeriesStackCard";
 import type { Book } from "@/types";
 
 type AppLayoutOutletContext = {
@@ -157,86 +157,14 @@ function buildSmartShelves(books: Book[]): SmartShelf[] {
   ];
 }
 
-function SeriesCoverLayer({
-  book,
-  index,
-}: {
-  book: Book;
-  index: number;
-}) {
-  const layerStyles = [
-    "z-30 translate-x-0 translate-y-0 rotate-0 opacity-100 group-hover:translate-x-0.5 group-hover:rotate-[-0.5deg]",
-    "z-20 translate-x-2 -translate-y-1 rotate-[3deg] opacity-75 group-hover:translate-x-3 group-hover:rotate-[4deg]",
-    "z-10 translate-x-4 -translate-y-2 rotate-[5deg] opacity-55 group-hover:translate-x-5 group-hover:rotate-[6deg]",
-  ];
-
-  return (
-    <div
-      aria-hidden={index > 0}
-      className={cn(
-        "absolute left-0 top-2 h-[135px] w-[90px] overflow-hidden rounded-md bg-muted shadow-sm ring-1 ring-border transition-transform duration-300 ease-out motion-reduce:transition-none sm:h-[168px] sm:w-[112px]",
-        layerStyles[index],
-      )}
-    >
-      {book.cover_url ? (
-        <img
-          src={book.cover_url}
-          alt={index === 0 ? book.title : ""}
-          loading="lazy"
-          className="block h-full w-full scale-[1.035] object-cover"
-        />
-      ) : (
-        <div className="flex h-full w-full items-center justify-center">
-          <BookOpen className="h-8 w-8 text-muted-foreground/40" />
-        </div>
-      )}
-    </div>
-  );
-}
-
-function SeriesStackCard({
-  group,
-  onSeries,
-}: {
-  group: BookGroup;
-  onSeries: (seriesName: string) => void;
-}) {
-  const visibleBooks = group.books.slice(0, 3);
-
-  return (
-    <button
-      type="button"
-      onClick={() => onSeries(group.name)}
-      className="group block w-[122px] shrink-0 rounded-lg text-left transition-shadow duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:w-[148px]"
-      data-shelf-item
-    >
-      <div className="relative h-[145px] w-[122px] sm:h-[178px] sm:w-[148px]">
-        {[...visibleBooks].reverse().map((book, reversedIndex) => {
-          const index = visibleBooks.length - 1 - reversedIndex;
-
-          return <SeriesCoverLayer key={book.id} book={book} index={index} />;
-        })}
-      </div>
-      <div className="mt-2 min-w-0">
-        <p className="line-clamp-2 text-xs font-medium leading-tight text-foreground">
-          {group.name}
-        </p>
-        <p className="mt-1 text-[11px] text-muted-foreground">
-          {bookCountLabel(group.books.length)}
-        </p>
-      </div>
-    </button>
-  );
-}
-
 function SeriesShelf({
   groups,
   onViewAll,
   onSeries,
 }: {
-  groups: BookGroup[];
+  groups: SeriesBookGroup[];
   onViewAll: () => void;
-  onSeries: (seriesName: string) => void;
+  onSeries: (seriesId: string) => void;
 }) {
   const rowRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -344,7 +272,7 @@ function SeriesShelf({
               onWheel={handleRowWheel}
             >
               {groups.map((group) => (
-                <SeriesStackCard key={group.name} group={group} onSeries={onSeries} />
+                <SeriesStackCard key={group.seriesId} group={group} onSeries={onSeries} />
               ))}
             </div>
 
@@ -400,13 +328,8 @@ export default function Library() {
     navigate(path);
   }
 
-  function openSeries(seriesName: string) {
-    const params = new URLSearchParams({
-      view: "series",
-      value: seriesName,
-    });
-
-    navigate(`/library/explore?${params.toString()}`);
+  function openSeries(seriesId: string) {
+    navigate(`/series/${seriesId}`);
   }
 
   return (
@@ -458,7 +381,7 @@ export default function Library() {
         ) : (
           <SeriesShelf
             groups={seriesGroups}
-            onViewAll={() => openExplore("/library/explore?view=series")}
+            onViewAll={() => navigate("/series")}
             onSeries={openSeries}
           />
         )}

--- a/src/pages/Series.tsx
+++ b/src/pages/Series.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { BookOpen } from "lucide-react";
+import { useBooksContext } from "@/context/BooksContext";
+import { useSeries } from "@/hooks/useSeries";
+import { buildSeriesGroups } from "@/lib/libraryShelves";
+import SeriesStackCard from "@/pages/library/SeriesStackCard";
+
+function LoadingSeriesGrid() {
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-6">
+      {Array.from({ length: 8 }).map((_, index) => (
+        <div key={index} className="w-[122px] sm:w-[148px]">
+          <div className="h-[145px] animate-pulse rounded-md bg-muted sm:h-[178px]" />
+          <div className="mt-2 h-3 w-24 animate-pulse rounded bg-muted" />
+          <div className="mt-2 h-3 w-14 animate-pulse rounded bg-muted" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function Series() {
+  const { books, loading: booksLoading, error: booksError } = useBooksContext();
+  const { series, loading: seriesLoading, error: seriesError } = useSeries();
+  const navigate = useNavigate();
+  const groups = useMemo(() => buildSeriesGroups(books, series), [books, series]);
+  const loading = booksLoading || seriesLoading;
+  const error = booksError || seriesError;
+
+  function openSeries(seriesId: string) {
+    navigate(`/series/${seriesId}`);
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="font-heading text-4xl font-bold leading-tight">Series</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Browse the series in your library.
+        </p>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-destructive">{error}</p>
+      ) : loading ? (
+        <LoadingSeriesGrid />
+      ) : groups.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <BookOpen className="h-10 w-10 text-muted-foreground/40" />
+          <p className="text-sm text-muted-foreground">
+            Series you add to books will appear here.
+          </p>
+        </div>
+      ) : (
+        <div
+          aria-label="Series collection"
+          className="flex flex-wrap gap-x-4 gap-y-7 sm:gap-x-6"
+        >
+          {groups.map((group) => (
+            <SeriesStackCard key={group.seriesId} group={group} onSeries={openSeries} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/SeriesDetails.tsx
+++ b/src/pages/SeriesDetails.tsx
@@ -1,0 +1,1117 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { Link, useParams } from "react-router-dom";
+import { ArrowLeft, BookOpen, Check, Flag, Star } from "lucide-react";
+import ReadingProgressDialog from "@/components/ReadingProgressDialog";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useBooksContext } from "@/context/BooksContext";
+import { useSeries } from "@/hooks/useSeries";
+import { parseLocalDateOnly, type CalendarSpan } from "@/lib/bookAnalytics";
+import { fetchAllBookNotes } from "@/lib/bookNotes";
+import { fetchReadingLogs } from "@/lib/books";
+import {
+  filterSeriesLogs,
+  getAverageSeriesRating,
+  getBookProgressPercent,
+  getFeaturedNoteCandidates,
+  getJourneyBookDates,
+  getJourneyDurationDays,
+  getLatestSeriesActivity,
+  getMostCommonGenre,
+  getNextUpBook,
+  getSeriesAuthors,
+  getSeriesJourneyRecap,
+  getSeriesJourneyTransition,
+  getSeriesProgress,
+  getSeriesStats,
+  sortSeriesBooks,
+  type SeriesJourneyTransition,
+} from "@/lib/seriesDetails";
+import { cn, getTodayLocalDate } from "@/lib/utils";
+import type { Book, BookNote, ReadingLog } from "@/types";
+
+function bookCountLabel(count: number): string {
+  return `${count} book${count === 1 ? "" : "s"}`;
+}
+
+function formatAverageRating(value: number | null): string {
+  return value === null ? "No rating" : `${value.toFixed(1)} avg rating`;
+}
+
+function formatActivityDate(value: string): string {
+  return new Date(value).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatDate(value: string | null): string {
+  const date = parseLocalDateOnly(value ?? undefined);
+  if (!date) return "--";
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatMonthYear(value: string | null): string {
+  const date = parseLocalDateOnly(value ?? undefined);
+  if (!date) return "--";
+  return date.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+}
+
+function formatDaysSpent(days: number | null): string {
+  if (days === null) return "--";
+  return `${days} day${days === 1 ? "" : "s"}`;
+}
+
+function BookThumbnail({ book }: { book: Book }) {
+  return (
+    <div className="h-16 w-11 shrink-0 overflow-hidden rounded-md bg-muted shadow-sm">
+      {book.cover_url ? (
+        <img src={book.cover_url} alt="" className="h-full w-full object-cover" />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center">
+          <BookOpen className="h-4 w-4 text-muted-foreground/40" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  children,
+  className = "",
+  compact = false,
+}: {
+  title?: string;
+  children: ReactNode;
+  className?: string;
+  compact?: boolean;
+}) {
+  return (
+    <section className={`rounded-xl border bg-card ${compact ? "p-4" : "p-5"} ${className}`}>
+      {title && <h2 className="text-sm font-medium text-muted-foreground">{title}</h2>}
+      <div className={title ? (compact ? "mt-3" : "mt-4") : ""}>{children}</div>
+    </section>
+  );
+}
+
+function formatStatsReadingTime(minutes: number): string {
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours === 0 && remainingMinutes === 0) return "0h";
+  if (hours === 0) return `${remainingMinutes}m`;
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}
+
+function formatStatsJourneySpan(span: CalendarSpan): string {
+  const parts: string[] = [];
+  if (span.months > 0) parts.push(`${span.months} mo`);
+  if (span.weeks > 0) parts.push(`${span.weeks} wk`);
+  if (span.days > 0) parts.push(`${span.days} d`);
+  return parts.join(" ") || "0 d";
+}
+
+function StatsOverviewCard({
+  label,
+  value,
+  unavailableLabel,
+}: {
+  label: string;
+  value: ReactNode | null;
+  unavailableLabel?: string;
+}) {
+  return (
+    <div className="rounded-xl border bg-card px-4 py-4">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-2 font-heading text-2xl font-semibold">{value ?? "--"}</p>
+      {value === null && unavailableLabel && (
+        <p className="mt-2 text-xs text-muted-foreground">{unavailableLabel}</p>
+      )}
+    </div>
+  );
+}
+
+function WinnerStatsCard({
+  title,
+  books,
+  detail,
+  emptyLabel,
+}: {
+  title: string;
+  books: Book[];
+  detail: string | null;
+  emptyLabel: string;
+}) {
+  return (
+    <SummaryCard title={title} compact>
+      {books.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{emptyLabel}</p>
+      ) : (
+        <div className="space-y-2">
+          {books.map((book) => (
+            <SmallBookRow key={book.id} book={book} metadata={detail} />
+          ))}
+        </div>
+      )}
+    </SummaryCard>
+  );
+}
+
+function StatsBarChart({
+  title,
+  rows,
+  emptyLabel,
+}: {
+  title: string;
+  rows: Array<{ book: Book; value: number; formattedValue: string }>;
+  emptyLabel: string;
+}) {
+  const maximumValue = Math.max(...rows.map((row) => row.value), 0);
+
+  return (
+    <SummaryCard title={title} compact>
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{emptyLabel}</p>
+      ) : (
+        <div className="space-y-4">
+          {rows.map((row) => (
+            <div key={row.book.id} className="grid gap-2 sm:grid-cols-[minmax(9rem,13rem)_minmax(0,1fr)_7rem] sm:items-center">
+              <Link to={`/books/${row.book.id}`} className="truncate text-sm font-medium hover:underline">
+                {row.book.title}
+              </Link>
+              <div className="h-3 overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-zinc-800"
+                  style={{ width: `${maximumValue > 0 ? (row.value / maximumValue) * 100 : 0}%` }}
+                />
+              </div>
+              <p className="text-sm tabular-nums text-muted-foreground sm:text-right">
+                {row.formattedValue}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </SummaryCard>
+  );
+}
+
+function SmallBookRow({
+  book,
+  prefix,
+  metadata,
+}: {
+  book: Book;
+  prefix?: string;
+  metadata?: string | null;
+}) {
+  return (
+    <Link
+      to={`/books/${book.id}`}
+      className="flex items-center gap-3 rounded-lg p-1 transition-colors hover:bg-muted/50"
+    >
+      <BookThumbnail book={book} />
+      <div className="min-w-0">
+        {prefix && <p className="text-xs text-muted-foreground">{prefix}</p>}
+        <p className="line-clamp-2 text-sm font-medium">{book.title}</p>
+        {metadata ? (
+          <p className="text-xs font-medium text-muted-foreground">{metadata}</p>
+        ) : book.volume_number != null && (
+          <p className="text-xs text-muted-foreground">Volume {book.volume_number}</p>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+function SeriesOverviewBookTile({ book, index }: { book: Book; index: number }) {
+  const isFinished = book.status === "Finished";
+  const isReading = book.status === "Reading";
+  const sequenceNumber = book.volume_number ?? index + 1;
+  const percent = getBookProgressPercent(book);
+  const statusLabel = isFinished
+    ? "Completed"
+    : isReading
+      ? "Currently Reading"
+      : book.status === "DNF"
+        ? "DNF"
+        : "Unread";
+
+  return (
+    <Link
+      to={`/books/${book.id}`}
+      className={cn(
+        "group relative flex min-w-0 flex-col items-center rounded-xl border bg-background px-3 pb-4 pt-3 text-foreground shadow-[0_1px_3px_rgb(0_0_0/0.035)] transition-shadow hover:shadow-[0_2px_6px_rgb(0_0_0/0.06)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        isReading && "border-foreground ring-1 ring-foreground",
+      )}
+      aria-label={`Open ${book.title}`}
+    >
+      <span
+        className={cn(
+          "absolute left-3 top-3 z-10 flex h-6 w-6 items-center justify-center rounded-full border text-xs font-semibold shadow-sm",
+          isFinished && "border-zinc-400 bg-zinc-400 text-white",
+          isReading && "border-foreground bg-foreground text-background",
+          !isFinished && !isReading && "border-border bg-background text-muted-foreground",
+        )}
+      >
+        {sequenceNumber}
+      </span>
+
+      <div
+        className="h-[190px] w-[126px] overflow-hidden rounded-md bg-muted shadow-sm sm:h-[210px] sm:w-[140px]"
+      >
+        {book.cover_url ? (
+          <img
+            src={book.cover_url}
+            alt={book.title}
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.025]"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <BookOpen className="h-8 w-8 text-muted-foreground/40" />
+          </div>
+        )}
+      </div>
+
+      <p className="mt-3 line-clamp-2 min-h-10 text-center text-sm font-semibold leading-snug">
+        {book.title}
+      </p>
+
+      <div
+        className="mt-0.5 flex items-center gap-0.5 text-muted-foreground"
+        aria-label={book.rating ? `${book.rating} out of 5 stars` : "Not rated"}
+      >
+        {[1, 2, 3, 4, 5].map((rating) => (
+          <Star
+            key={rating}
+            className={cn(
+              "h-4 w-4",
+              book.rating && rating <= book.rating
+                ? "fill-foreground text-foreground"
+                : "fill-muted text-muted-foreground/45",
+            )}
+          />
+        ))}
+      </div>
+
+      <p className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-foreground">
+        {isFinished ? (
+          <span
+            className="flex h-3.5 w-3.5 items-center justify-center rounded-full border border-zinc-500 bg-zinc-500 text-white"
+            aria-hidden
+          >
+            <Check className="h-2.5 w-2.5 stroke-[3]" />
+          </span>
+        ) : (
+          <span
+            className={cn(
+              "h-3 w-3 rounded-full border",
+              isReading ? "border-foreground bg-foreground" : "border-muted-foreground bg-background",
+            )}
+            aria-hidden
+          />
+        )}
+        {statusLabel}
+      </p>
+
+      {isReading && percent !== null && (
+        <div className="mt-3 flex w-full items-center gap-2">
+          <Progress value={percent} className="h-1.5 bg-muted [&_[data-slot=progress-indicator]]:bg-foreground" />
+          <span className="text-xs text-muted-foreground">{percent}%</span>
+        </div>
+      )}
+    </Link>
+  );
+}
+
+function RatingStars({ rating }: { rating?: number | null }) {
+  return (
+    <div className="flex items-center gap-1" aria-label={rating ? `${rating} out of 5 stars` : "Not rated"}>
+      {[1, 2, 3, 4, 5].map((value) => (
+        <Star
+          key={value}
+          className={cn(
+            "h-4 w-4",
+            rating && value <= rating
+              ? "fill-foreground text-foreground"
+              : "fill-background text-muted-foreground/50",
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+
+function JourneyFeaturedNote({ bookId, notes }: { bookId: string; notes: BookNote[] }) {
+  const maximumVisibleLines = 4;
+  const candidates = useMemo(() => getFeaturedNoteCandidates(notes), [notes]);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const noteRefs = useRef(new Map<string, HTMLParagraphElement>());
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+
+  useLayoutEffect(() => {
+    const selectNote = () => {
+      const nextNote = candidates.find((note) => {
+        const element = noteRefs.current.get(note.id);
+        if (!element) return false;
+        const lineHeight = Number.parseFloat(getComputedStyle(element).lineHeight);
+        return element.scrollHeight <= lineHeight * maximumVisibleLines + 1;
+      });
+      setSelectedNoteId(nextNote?.id ?? null);
+    };
+
+    selectNote();
+    const observer = new ResizeObserver(selectNote);
+    if (containerRef.current) observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [candidates]);
+
+  const selectedNote = candidates.find((note) => note.id === selectedNoteId) ?? null;
+
+  return (
+    <div ref={containerRef} className="relative flex min-h-0 flex-1 flex-col">
+      <div className="pointer-events-none invisible absolute inset-x-0 top-0" aria-hidden>
+        {candidates.map((note) => (
+          <p
+            key={note.id}
+            ref={(element) => {
+              if (element) noteRefs.current.set(note.id, element);
+              else noteRefs.current.delete(note.id);
+            }}
+            className="absolute inset-x-0 whitespace-pre-line font-serif text-sm italic leading-6"
+          >
+            &ldquo;{note.content.trim()}&rdquo;
+          </p>
+        ))}
+      </div>
+      {selectedNote && (
+        <p className="line-clamp-4 whitespace-pre-line font-serif text-sm italic leading-6 text-foreground">
+          &ldquo;{selectedNote.content.trim()}&rdquo;
+        </p>
+      )}
+      {notes.length > 0 && (
+        <Link
+          to={`/books/${bookId}?tab=notes`}
+          className="mt-auto self-end pt-4 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground hover:underline"
+        >
+          All Notes -&gt;
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function TimelineMetric({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <div className="text-sm font-medium text-foreground">{value}</div>
+    </div>
+  );
+}
+
+function SeriesJourneyTransitionRow({
+  transition,
+  connectsToCurrent,
+}: {
+  transition: SeriesJourneyTransition;
+  connectsToCurrent: boolean;
+}) {
+  return (
+    <div className="relative grid grid-cols-[5rem_minmax(0,1fr)] gap-4 py-3 sm:grid-cols-[6.5rem_minmax(0,1fr)]">
+      <span
+        className={cn(
+          "absolute bottom-0 left-10 top-0 w-px sm:left-[3.25rem]",
+          connectsToCurrent ? "bg-foreground" : "bg-border",
+        )}
+        aria-hidden
+      />
+      <div />
+      <div className="flex max-w-md items-center gap-4 rounded-lg bg-muted/45 px-5 py-3 text-sm">
+        <Flag className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="font-medium">
+          {transition.kind === "break"
+            ? `Took a ${transition.days} day break`
+            : "Started right after previous book"}
+        </span>
+        <span className="text-muted-foreground">
+          {transition.kind === "break"
+            ? `${formatDate(transition.finished)} - ${formatDate(transition.started)}`
+            : formatDate(transition.started)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function SeriesJourneyItem({
+  book,
+  logs,
+  notes,
+  isFirst,
+  isLast,
+  nextBookIsReading,
+  transition,
+}: {
+  book: Book;
+  logs: ReadingLog[];
+  notes: BookNote[];
+  isFirst: boolean;
+  isLast: boolean;
+  nextBookIsReading: boolean;
+  transition: SeriesJourneyTransition | null;
+}) {
+  const isFinished = book.status === "Finished";
+  const isReading = book.status === "Reading";
+  const percent = getBookProgressPercent(book);
+  const dates = getJourneyBookDates(book, logs);
+  const durationDays = getJourneyDurationDays(book, logs);
+  const volumeLabel =
+    book.volume_number != null ? `Volume ${book.volume_number}` : "Volume not set";
+  const pageProgress =
+    book.total_pages && book.current_page != null
+      ? `${book.current_page.toLocaleString()} / ${book.total_pages.toLocaleString()} pages`
+      : null;
+
+  return (
+    <div>
+      <div className="relative grid grid-cols-[5rem_minmax(0,1fr)] gap-4 pb-6 sm:grid-cols-[6.5rem_minmax(0,1fr)]">
+        <div className="relative flex flex-col items-center">
+          {!isFirst && (
+            <span
+              className={cn(
+                "absolute top-0 h-7 w-px",
+                isReading ? "bg-foreground" : "bg-border",
+              )}
+              aria-hidden
+            />
+          )}
+          <span
+            className={cn(
+              "relative z-10 mt-7 flex h-7 w-7 items-center justify-center rounded-full border bg-background",
+              isFinished && "border-zinc-400 bg-zinc-400 text-background",
+              isReading && "border-foreground bg-foreground text-background",
+              !isFinished && !isReading && "border-muted-foreground/70 text-muted-foreground",
+            )}
+            aria-hidden
+          >
+            {isFinished ? (
+              <Check className="h-3.5 w-3.5 stroke-[3]" />
+            ) : null}
+          </span>
+          <p className="mt-3 text-center text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            {isFinished
+              ? formatDate(dates.finished)
+              : isReading
+                ? formatDate(dates.started)
+                : book.status === "Up Next"
+                  ? "Up next"
+                  : "Future"}
+          </p>
+          {!isLast && (
+            <span
+              className={cn(
+                "-mb-6 mt-4 min-h-4 w-px flex-1",
+                isReading || nextBookIsReading ? "bg-foreground" : "bg-border",
+              )}
+              aria-hidden
+            />
+          )}
+        </div>
+
+        <article
+          className={cn(
+            "grid min-w-0 gap-5 rounded-xl border bg-card p-4 shadow-[0_1px_3px_rgb(0_0_0/0.04)] sm:grid-cols-[7rem_minmax(13rem,1fr)] lg:grid-cols-[7rem_minmax(17rem,1fr)_minmax(13rem,17rem)]",
+            isReading && "border-foreground ring-1 ring-foreground",
+          )}
+        >
+          <Link
+            to={`/books/${book.id}`}
+            className="h-[168px] w-28 overflow-hidden rounded-lg bg-muted shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={`Open ${book.title}`}
+          >
+            {book.cover_url ? (
+              <img src={book.cover_url} alt={book.title} className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <BookOpen className="h-8 w-8 text-muted-foreground/40" />
+              </div>
+            )}
+          </Link>
+
+          <div className="min-w-0 space-y-6 py-1">
+            <div>
+              <Link
+                to={`/books/${book.id}`}
+                className="line-clamp-2 font-heading text-xl font-semibold hover:underline"
+              >
+                {book.title}
+              </Link>
+              <p className="mt-1 text-sm text-muted-foreground">{volumeLabel}</p>
+            </div>
+
+            {isFinished && (
+              <div className="grid gap-4 sm:grid-cols-3">
+                <TimelineMetric label="Started" value={formatDate(dates.started)} />
+                <TimelineMetric label="Finished" value={formatDate(dates.finished)} />
+                <TimelineMetric
+                  label="Time Spent"
+                  value={formatDaysSpent(durationDays)}
+                />
+              </div>
+            )}
+
+            {isReading && (
+              <div className="grid gap-4 sm:grid-cols-3">
+                <TimelineMetric label="Started" value={formatDate(dates.started)} />
+                <TimelineMetric
+                  label="Progress"
+                  value={
+                    percent !== null ? (
+                      <div className="space-y-2">
+                        <span>{percent}%</span>
+                        <Progress
+                          value={percent}
+                          className="h-1.5 bg-muted [&_[data-slot=progress-indicator]]:bg-foreground"
+                        />
+                        {pageProgress && (
+                          <p className="text-xs font-normal text-muted-foreground">{pageProgress}</p>
+                        )}
+                      </div>
+                    ) : (
+                      "--"
+                    )
+                  }
+                />
+                <TimelineMetric label="Time Spent" value={formatDaysSpent(durationDays)} />
+              </div>
+            )}
+
+            {!isFinished && !isReading && (
+              <p className="text-sm text-muted-foreground">Not started yet</p>
+            )}
+          </div>
+
+          {(isFinished || isReading) && (
+            <div className="flex min-h-full flex-col gap-5 border-t pt-4 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-2">
+              <RatingStars rating={book.rating} />
+              <JourneyFeaturedNote bookId={book.id} notes={notes} />
+            </div>
+          )}
+        </article>
+      </div>
+      {transition && (
+        <SeriesJourneyTransitionRow
+          transition={transition}
+          connectsToCurrent={nextBookIsReading}
+        />
+      )}
+    </div>
+  );
+}
+
+function PageLoading() {
+  return (
+    <div className="space-y-6">
+      <div className="h-64 animate-pulse rounded-2xl bg-muted" />
+      <div className="grid gap-4 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="h-56 animate-pulse rounded-xl bg-muted" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function SeriesDetails() {
+  const { seriesId } = useParams<{ seriesId: string }>();
+  const { books, loading: booksLoading, error: booksError, updateBook } = useBooksContext();
+  const { series, loading: seriesLoading, error: seriesError } = useSeries();
+  const [logs, setLogs] = useState<ReadingLog[]>([]);
+  const [logsLoading, setLogsLoading] = useState(true);
+  const [logsError, setLogsError] = useState<string | null>(null);
+  const [notes, setNotes] = useState<BookNote[]>([]);
+
+  const seriesRecord = series.find((item) => item.id === seriesId) ?? null;
+  const seriesBooks = useMemo(
+    () => sortSeriesBooks(books.filter((book) => book.series_id === seriesId)),
+    [books, seriesId],
+  );
+
+  const loadLogs = useCallback(async () => {
+    try {
+      setLogsLoading(true);
+      setLogsError(null);
+      setLogs(await fetchReadingLogs());
+    } catch (error) {
+      setLogsError(error instanceof Error ? error.message : "Failed to load reading activity");
+    } finally {
+      setLogsLoading(false);
+    }
+  }, []);
+
+  const loadNotes = useCallback(async () => {
+    try {
+      setNotes(await fetchAllBookNotes());
+    } catch {
+      setNotes([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!seriesRecord) {
+      if (!seriesLoading) setLogsLoading(false);
+      return;
+    }
+    if (seriesBooks.length === 0) {
+      setLogs([]);
+      setNotes([]);
+      setLogsError(null);
+      setLogsLoading(false);
+      return;
+    }
+    void loadLogs();
+    void loadNotes();
+  }, [loadLogs, loadNotes, seriesBooks.length, seriesLoading, seriesRecord]);
+
+  const seriesLogs = useMemo(() => filterSeriesLogs(seriesBooks, logs), [logs, seriesBooks]);
+  const seriesBookIds = useMemo(() => new Set(seriesBooks.map((book) => book.id)), [seriesBooks]);
+  const notesByBook = useMemo(() => {
+    const map = new Map<string, BookNote[]>();
+    notes
+      .filter((note) => seriesBookIds.has(note.book_id))
+      .forEach((note) => {
+        map.set(note.book_id, [...(map.get(note.book_id) ?? []), note]);
+      });
+    return map;
+  }, [notes, seriesBookIds]);
+  const progress = useMemo(() => getSeriesProgress(seriesBooks), [seriesBooks]);
+  const authors = useMemo(() => getSeriesAuthors(seriesBooks), [seriesBooks]);
+  const primaryGenre = useMemo(() => getMostCommonGenre(seriesBooks), [seriesBooks]);
+  const averageRating = useMemo(() => getAverageSeriesRating(seriesBooks), [seriesBooks]);
+  const readingBooks = useMemo(
+    () => seriesBooks.filter((book) => book.status === "Reading"),
+    [seriesBooks],
+  );
+  const nextUp = useMemo(() => getNextUpBook(seriesBooks), [seriesBooks]);
+  const latestActivity = useMemo(
+    () => getLatestSeriesActivity(seriesBooks, seriesLogs),
+    [seriesBooks, seriesLogs],
+  );
+  const journeyRecap = useMemo(
+    () => getSeriesJourneyRecap(seriesBooks, seriesLogs),
+    [seriesBooks, seriesLogs],
+  );
+  const stats = useMemo(
+    () => getSeriesStats(seriesBooks, seriesLogs, notes),
+    [notes, seriesBooks, seriesLogs],
+  );
+
+  async function saveProgress(book: Book, newPage: number) {
+    const shouldFinish = Boolean(book.total_pages && newPage >= book.total_pages);
+
+    await updateBook(book.id, {
+      current_page: newPage,
+      ...(shouldFinish
+        ? {
+            status: "Finished",
+            ...(book.date_finished ? {} : { date_finished: getTodayLocalDate() }),
+          }
+        : {}),
+    });
+    await loadLogs();
+  }
+
+  if (booksLoading || seriesLoading) return <PageLoading />;
+
+  if (booksError || seriesError) {
+    return <p className="text-sm text-destructive">{booksError || seriesError}</p>;
+  }
+
+  if (!seriesRecord) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-16 text-center">
+        <BookOpen className="h-10 w-10 text-muted-foreground/40" />
+        <h1 className="font-heading text-xl font-medium">Series not found</h1>
+        <p className="text-sm text-muted-foreground">
+          This series may have been deleted or you may not have access.
+        </p>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/series">Back to Series</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const headerAuthors = authors.length > 0 ? authors.join(", ") : "Unknown author";
+  const allFinished =
+    seriesBooks.length > 0 && seriesBooks.every((book) => book.status === "Finished");
+
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" className="px-2" asChild>
+        <Link to="/series">
+          <ArrowLeft className="mr-1.5 h-4 w-4" />
+          Back to Series
+        </Link>
+      </Button>
+
+      <header className="relative flex min-h-64 items-end overflow-hidden rounded-2xl border bg-muted">
+        <div
+          className="absolute inset-0 bg-gradient-to-br from-emerald-950 via-slate-800 to-stone-700"
+          aria-label="Series banner placeholder"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/75 via-black/30 to-black/10" />
+        <div className="relative space-y-3 p-6 text-white sm:p-8">
+          <p className="text-xs font-medium uppercase tracking-[0.18em] text-white/70">
+            Series
+          </p>
+          <h1 className="font-heading text-3xl font-semibold leading-tight sm:text-4xl">
+            {seriesRecord.name}
+          </h1>
+          <p className="text-base text-white/85">by {headerAuthors}</p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-white/80">
+            <span>{bookCountLabel(seriesBooks.length)}</span>
+            <span aria-hidden>·</span>
+            <span>{primaryGenre ?? "No genre"}</span>
+            <span aria-hidden>·</span>
+            <span className="inline-flex items-center gap-1">
+              <Star className="h-4 w-4 fill-current" />
+              {formatAverageRating(averageRating)}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <Tabs defaultValue="overview" className="space-y-6">
+        <TabsList variant="line" className="w-full justify-start gap-8 rounded-none border-b pb-0">
+          <TabsTrigger value="overview" className="min-w-20 px-0">Overview</TabsTrigger>
+          <TabsTrigger value="journey" className="min-w-20 px-0">Journey</TabsTrigger>
+          <TabsTrigger value="stats" className="min-w-20 px-0">Stats</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview">
+          {seriesBooks.length === 0 ? (
+            <p className="rounded-lg border border-dashed p-5 text-sm text-muted-foreground">
+              Books added to this series will appear here.
+            </p>
+          ) : (
+            <div className="space-y-8">
+              <div className="grid gap-4 lg:grid-cols-3">
+                <SummaryCard title="Overall Progress">
+              {progress.isAvailable ? (
+                <>
+                  <p className="font-heading text-5xl font-semibold">{progress.percentage}%</p>
+                  <Progress value={progress.percentage ?? 0} className="mt-4 h-2" />
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    {progress.finishedBooks} of {seriesBooks.length} books read
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="font-heading text-3xl font-semibold">--</p>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Add total pages to every volume to calculate series progress.
+                  </p>
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    {progress.finishedBooks} of {seriesBooks.length} books read
+                  </p>
+                </>
+              )}
+                </SummaryCard>
+
+                <SummaryCard title="Currently Reading">
+              {readingBooks.length > 0 ? (
+                <div className="space-y-4">
+                  {readingBooks.map((book) => {
+                    const percent = getBookProgressPercent(book);
+                    return (
+                      <div key={book.id} className="space-y-2">
+                        <SmallBookRow book={book} />
+                        {percent !== null && (
+                          <div className="space-y-1">
+                            <Progress value={percent} className="h-1.5" />
+                            <p className="text-xs text-muted-foreground">{percent}% read</p>
+                          </div>
+                        )}
+                        <ReadingProgressDialog
+                          book={book}
+                          onProgressSaved={(newPage) => saveProgress(book, newPage)}
+                          trigger={
+                            <Button type="button" size="sm" variant="outline">
+                              Update Progress
+                            </Button>
+                          }
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">No book currently reading</p>
+              )}
+                </SummaryCard>
+
+                <SummaryCard>
+              <div className="space-y-5">
+                <div>
+                  <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Next up
+                  </p>
+                  {nextUp ? (
+                    <SmallBookRow book={nextUp} />
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      {allFinished ? "Series complete" : "No next book available"}
+                    </p>
+                  )}
+                </div>
+                <div className="border-t pt-5">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Latest read
+                  </p>
+                  {logsLoading ? (
+                    <p className="mt-2 text-sm text-muted-foreground">Loading activity...</p>
+                  ) : logsError ? (
+                    <p className="mt-2 text-sm text-muted-foreground">Unavailable</p>
+                  ) : latestActivity ? (
+                    <p className="mt-2 text-sm">
+                      {latestActivity.book.title}
+                      <span className="block text-xs text-muted-foreground">
+                        {formatActivityDate(latestActivity.log.logged_at)}
+                      </span>
+                    </p>
+                  ) : (
+                    <p className="mt-2 text-sm text-muted-foreground">No reading activity yet</p>
+                  )}
+                </div>
+              </div>
+                </SummaryCard>
+              </div>
+
+              <section className="space-y-4">
+                <h2 className="font-heading text-xl font-medium">Books in this series</h2>
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5">
+                  {seriesBooks.map((book, index) => (
+                    <SeriesOverviewBookTile key={book.id} book={book} index={index} />
+                  ))}
+                </div>
+              </section>
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="journey" className="space-y-6">
+          <h2 className="font-heading text-xl font-medium">Reading Journey</h2>
+          {seriesBooks.length === 0 ? (
+            <p className="rounded-lg border border-dashed p-5 text-sm text-muted-foreground">
+              Books added to this series will appear here.
+            </p>
+          ) : (
+            <div className="space-y-8">
+              <section className="grid gap-5 rounded-xl border bg-card p-5 sm:grid-cols-2 xl:grid-cols-4">
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground">Started this series</p>
+                  <p className="mt-2 text-lg font-semibold">{formatMonthYear(journeyRecap.started)}</p>
+                </div>
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground">Journey Length</p>
+                  <p className="mt-2 text-lg font-semibold">
+                    {stats.overview.journeySpan
+                      ? formatStatsJourneySpan(stats.overview.journeySpan)
+                      : "--"}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground">Completed</p>
+                  <p className="mt-2 text-lg font-semibold">
+                    {journeyRecap.finishedBooks} book{journeyRecap.finishedBooks === 1 ? "" : "s"}
+                    {journeyRecap.completedMonths !== null && (
+                      <span className="block text-sm font-normal text-muted-foreground">
+                        over{" "}
+                        {journeyRecap.completedMonths === 0
+                          ? "less than 1 month"
+                          : `${journeyRecap.completedMonths} month${journeyRecap.completedMonths === 1 ? "" : "s"}`}
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-xs font-medium text-muted-foreground">Favorite book</p>
+                  <p className="mt-2 line-clamp-2 text-lg font-semibold">
+                    {journeyRecap.favoriteBook?.title ?? "No favorite selected"}
+                  </p>
+                </div>
+              </section>
+
+              <div>
+                {seriesBooks.map((book, index) => {
+                  const nextBook = seriesBooks[index + 1];
+                  const transition = nextBook
+                    ? getSeriesJourneyTransition(book, nextBook, seriesLogs)
+                    : null;
+
+                  return (
+                    <SeriesJourneyItem
+                      key={book.id}
+                      book={book}
+                      logs={seriesLogs}
+                      notes={notesByBook.get(book.id) ?? []}
+                      isFirst={index === 0}
+                      isLast={index === seriesBooks.length - 1}
+                      nextBookIsReading={nextBook?.status === "Reading"}
+                      transition={transition}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="stats" className="space-y-7">
+          <h2 className="font-heading text-xl font-medium">Series Stats</h2>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+            <StatsOverviewCard
+              label="Books Completed"
+              value={`${stats.overview.finishedBooks}/${stats.overview.totalBooks}`}
+            />
+            <StatsOverviewCard
+              label="Pages Read"
+              value={
+                stats.overview.pagesRead === null
+                  ? null
+                  : stats.overview.pagesRead.toLocaleString()
+              }
+              unavailableLabel="Page progress is incomplete."
+            />
+            <StatsOverviewCard
+              label="Hours Read"
+              value={
+                logsLoading
+                  ? "..."
+                  : logsError
+                    ? null
+                    : formatStatsReadingTime(stats.overview.readingMinutes)
+              }
+              unavailableLabel="Reading logs are unavailable."
+            />
+            <StatsOverviewCard
+              label="Days Read"
+              value={
+                stats.overview.journeyDays !== null
+                  ? formatDaysSpent(stats.overview.journeyDays)
+                  : null
+              }
+              unavailableLabel="Reading dates are incomplete."
+            />
+            <StatsOverviewCard
+              label="Average Days per Book"
+              value={
+                stats.averageDaysPerBook === null
+                  ? null
+                  : `${stats.averageDaysPerBook.toFixed(1)} days`
+              }
+              unavailableLabel="No completed books with dates."
+            />
+          </div>
+
+          <section className="space-y-4">
+            <h3 className="font-heading text-lg font-medium">Detailed Statistics</h3>
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+              <WinnerStatsCard
+                title="Fastest read"
+                books={stats.fastestRead?.books ?? []}
+                detail={stats.fastestRead ? formatDaysSpent(stats.fastestRead.value) : null}
+                emptyLabel="No completed books with dates"
+              />
+              <WinnerStatsCard
+                title="Slowest read"
+                books={stats.slowestRead?.books ?? []}
+                detail={stats.slowestRead ? formatDaysSpent(stats.slowestRead.value) : null}
+                emptyLabel="No completed books with dates"
+              />
+              <WinnerStatsCard
+                title="Longest book"
+                books={stats.longestBook?.books ?? []}
+                detail={stats.longestBook ? `${stats.longestBook.value.toLocaleString()} pages` : null}
+                emptyLabel="No page totals yet"
+              />
+              <WinnerStatsCard
+                title="Shortest book"
+                books={stats.shortestBook?.books ?? []}
+                detail={stats.shortestBook ? `${stats.shortestBook.value.toLocaleString()} pages` : null}
+                emptyLabel="No page totals yet"
+              />
+              <WinnerStatsCard
+                title="Most annotated book"
+                books={stats.mostAnnotated?.books ?? []}
+                detail={
+                  stats.mostAnnotated
+                    ? `${stats.mostAnnotated.value} note${stats.mostAnnotated.value === 1 ? "" : "s"}`
+                    : null
+                }
+                emptyLabel="No notes yet"
+              />
+              <WinnerStatsCard
+                title="Most highlighted book"
+                books={stats.mostHighlighted?.books ?? []}
+                detail={
+                  stats.mostHighlighted
+                    ? `${stats.mostHighlighted.value} highlight${stats.mostHighlighted.value === 1 ? "" : "s"}`
+                    : null
+                }
+                emptyLabel="No highlights yet"
+              />
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="font-heading text-lg font-medium">Reading Pace</h3>
+            <div className="grid gap-4 xl:grid-cols-2">
+              <StatsBarChart
+                title="Reading Duration by Book"
+                rows={stats.durationChart.map((row) => ({
+                  book: row.book,
+                  value: row.days,
+                  formattedValue: formatDaysSpent(row.days),
+                }))}
+                emptyLabel="No completed books with start and finish dates yet."
+              />
+              <StatsBarChart
+                title="Reading Pace by Book"
+                rows={stats.paceChart.map((row) => ({
+                  book: row.book,
+                  value: row.pagesPerDay,
+                  formattedValue: `${row.pagesPerDay.toFixed(1)} pages/day`,
+                }))}
+                emptyLabel="Add completed-book dates and page totals to compare reading pace."
+              />
+            </div>
+          </section>
+
+          {logsError && (
+            <p className="text-sm text-muted-foreground">
+              Reading activity could not be loaded, so logged hours and date fallbacks may be unavailable.
+            </p>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,6 +1,8 @@
 export { default as Login } from "./Login";
 export { default as Dashboard } from "./Dashboard";
 export { default as Library } from "./Library";
+export { default as Series } from "./Series";
+export { default as SeriesDetails } from "./SeriesDetails";
 export { default as Authors } from "./Authors";
 export { default as AuthorDetails } from "./AuthorDetails";
 export { default as Search } from "./Search";

--- a/src/pages/library/SeriesStackCard.tsx
+++ b/src/pages/library/SeriesStackCard.tsx
@@ -1,0 +1,80 @@
+import { BookOpen } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SeriesBookGroup } from "@/lib/libraryShelves";
+import type { Book } from "@/types";
+
+function bookCountLabel(count: number) {
+  return `${count} book${count === 1 ? "" : "s"}`;
+}
+
+function SeriesCoverLayer({
+  book,
+  index,
+}: {
+  book: Book;
+  index: number;
+}) {
+  const layerStyles = [
+    "z-30 translate-x-0 translate-y-0 rotate-0 opacity-100 group-hover:translate-x-0.5 group-hover:rotate-[-0.5deg]",
+    "z-20 translate-x-2 -translate-y-1 rotate-[3deg] opacity-75 group-hover:translate-x-3 group-hover:rotate-[4deg]",
+    "z-10 translate-x-4 -translate-y-2 rotate-[5deg] opacity-55 group-hover:translate-x-5 group-hover:rotate-[6deg]",
+  ];
+
+  return (
+    <div
+      aria-hidden={index > 0}
+      className={cn(
+        "absolute left-0 top-2 h-[135px] w-[90px] overflow-hidden rounded-md bg-muted shadow-sm ring-1 ring-border transition-transform duration-300 ease-out motion-reduce:transition-none sm:h-[168px] sm:w-[112px]",
+        layerStyles[index],
+      )}
+    >
+      {book.cover_url ? (
+        <img
+          src={book.cover_url}
+          alt={index === 0 ? book.title : ""}
+          loading="lazy"
+          className="block h-full w-full scale-[1.035] object-cover"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center">
+          <BookOpen className="h-8 w-8 text-muted-foreground/40" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SeriesStackCard({
+  group,
+  onSeries,
+}: {
+  group: SeriesBookGroup;
+  onSeries: (seriesId: string) => void;
+}) {
+  const visibleBooks = group.books.slice(0, 3);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSeries(group.seriesId)}
+      className="group block w-[122px] shrink-0 rounded-lg text-left transition-shadow duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:w-[148px]"
+      data-shelf-item
+    >
+      <div className="relative h-[145px] w-[122px] sm:h-[178px] sm:w-[148px]">
+        {[...visibleBooks].reverse().map((book, reversedIndex) => {
+          const index = visibleBooks.length - 1 - reversedIndex;
+
+          return <SeriesCoverLayer key={book.id} book={book} index={index} />;
+        })}
+      </div>
+      <div className="mt-2 min-w-0">
+        <p className="line-clamp-2 text-xs font-medium leading-tight text-foreground">
+          {group.name}
+        </p>
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          {bookCountLabel(group.books.length)}
+        </p>
+      </div>
+    </button>
+  );
+}

--- a/tests/libraryShelves.test.ts
+++ b/tests/libraryShelves.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   buildNoteGroups,
   buildRatingGroups,
+  buildSeriesGroups,
   buildShelfValueSummaries,
   filterBooksByShelfValue,
 } from "../src/lib/libraryShelves";
@@ -176,6 +177,18 @@ test("filters books by selected series name", () => {
   });
 
   assert.deepEqual(filteredBooks.map((book) => book.id), ["assassin"]);
+});
+
+test("retains the stable series id when grouping series books", () => {
+  const groups = buildSeriesGroups(
+    [makeBook({ id: "assassin", title: "Assassin's Apprentice", series_id: "series-1" })],
+    [makeSeries({ id: "series-1", name: "Realm of the Elderlings" })],
+  );
+
+  assert.deepEqual(
+    groups.map((group) => ({ seriesId: group.seriesId, name: group.name })),
+    [{ seriesId: "series-1", name: "Realm of the Elderlings" }],
+  );
 });
 
 function makeBook(overrides: Partial<Book>): Book {

--- a/tests/seriesDetails.test.ts
+++ b/tests/seriesDetails.test.ts
@@ -1,0 +1,428 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  filterSeriesLogs,
+  getAverageSeriesRating,
+  getBookReadingMinutes,
+  getFeaturedNoteCandidates,
+  getJourneyBookDates,
+  getJourneyDurationDays,
+  getLatestSeriesActivity,
+  getMostCommonGenre,
+  getNextUpBook,
+  getSeriesAuthors,
+  getSeriesJourneyRecap,
+  getSeriesJourneyTransition,
+  getSeriesProgress,
+  getSeriesStats,
+  sortSeriesBooks,
+} from "../src/lib/seriesDetails";
+import type { Book, BookNote, ReadingLog } from "../src/types";
+
+test("orders numbered series books before unnumbered books with title fallback", () => {
+  const sorted = sortSeriesBooks([
+    makeBook({ id: "unknown-b", title: "Zeta" }),
+    makeBook({ id: "volume-2", title: "Second", volume_number: 2 }),
+    makeBook({ id: "unknown-a", title: "Alpha" }),
+    makeBook({ id: "volume-1", title: "First", volume_number: 1 }),
+  ]);
+
+  assert.deepEqual(sorted.map((book) => book.id), [
+    "volume-1",
+    "volume-2",
+    "unknown-a",
+    "unknown-b",
+  ]);
+});
+
+test("builds series banner metadata from all books", () => {
+  const books = [
+    makeBook({ authors: ["Robin Hobb"], genres: ["Fantasy"], rating: 5 }),
+    makeBook({ id: "two", authors: ["Robin Hobb", "Editor"], genres: ["Fantasy", "Drama"], rating: 3 }),
+    makeBook({ id: "three", authors: ["Editor"], genres: ["Drama"] }),
+  ];
+
+  assert.deepEqual(getSeriesAuthors(books), ["Editor", "Robin Hobb"]);
+  assert.equal(getMostCommonGenre(books), "Drama");
+  assert.equal(getAverageSeriesRating(books), 4);
+});
+
+test("calculates page-based progress with finished books full and reading or DNF pages recorded", () => {
+  const progress = getSeriesProgress([
+    makeBook({ status: "Finished", current_page: 1, total_pages: 100 }),
+    makeBook({ id: "reading", status: "Reading", current_page: 50, total_pages: 100 }),
+    makeBook({ id: "dnf", status: "DNF", current_page: 25, total_pages: 100 }),
+    makeBook({ id: "next", status: "Up Next", current_page: 80, total_pages: 100 }),
+  ]);
+
+  assert.deepEqual(progress, {
+    isAvailable: true,
+    percentage: 44,
+    readPages: 175,
+    totalPages: 400,
+    finishedBooks: 1,
+  });
+});
+
+test("marks page-based progress unavailable when a series volume has no total pages", () => {
+  const progress = getSeriesProgress([
+    makeBook({ status: "Finished", total_pages: 100 }),
+    makeBook({ id: "missing-pages", status: "Reading", current_page: 20 }),
+  ]);
+
+  assert.deepEqual(progress, {
+    isAvailable: false,
+    percentage: null,
+    readPages: null,
+    totalPages: null,
+    finishedBooks: 1,
+  });
+});
+
+test("chooses next up by series order rather than explicit up-next status", () => {
+  const nextUp = getNextUpBook([
+    makeBook({ id: "volume-3", status: "Up Next", volume_number: 3 }),
+    makeBook({ id: "volume-1", status: "Finished", volume_number: 1 }),
+    makeBook({ id: "volume-2", status: "Not Started", volume_number: 2 }),
+  ]);
+
+  assert.equal(nextUp?.id, "volume-2");
+});
+
+test("gets latest activity and aggregated logs only from books in the series", () => {
+  const books = [makeBook({ id: "volume-1" }), makeBook({ id: "volume-2" })];
+  const logs = [
+    makeLog({ id: "old", book_id: "volume-1", logged_at: "2026-05-01T12:00:00Z" }),
+    makeLog({ id: "latest", book_id: "volume-2", logged_at: "2026-05-03T12:00:00Z" }),
+    makeLog({ id: "other-series", book_id: "other", logged_at: "2026-05-04T12:00:00Z" }),
+  ];
+
+  assert.deepEqual(filterSeriesLogs(books, logs).map((log) => log.id), ["old", "latest"]);
+  assert.equal(getLatestSeriesActivity(books, logs)?.book.id, "volume-2");
+  assert.equal(getLatestSeriesActivity(books, logs)?.log.id, "latest");
+});
+
+test("builds journey dates from explicit book dates with reading log fallback", () => {
+  const explicit = makeBook({
+    status: "Finished",
+    date_started: "2026-01-02",
+    date_finished: "2026-01-08",
+  });
+  const logs = [
+    makeLog({ logged_at: "2026-01-01T12:00:00Z", reading_time_minutes: 15 }),
+    makeLog({ id: "last", logged_at: "2026-01-09T12:00:00Z", reading_time_minutes: 30 }),
+  ];
+
+  assert.deepEqual(getJourneyBookDates(explicit, logs), {
+    started: "2026-01-02",
+    finished: "2026-01-08",
+  });
+  assert.equal(getJourneyDurationDays(explicit, logs), 6);
+  assert.equal(getBookReadingMinutes(explicit, logs), 45);
+
+  const derived = makeBook({ status: "Finished" });
+  assert.deepEqual(getJourneyBookDates(derived, logs), {
+    started: "2026-01-01",
+    finished: "2026-01-09",
+  });
+
+  const reading = makeBook({ status: "Reading", date_started: "2026-01-05" });
+  assert.equal(getJourneyDurationDays(reading, [], new Date("2026-01-12T09:00:00")), 7);
+});
+
+test("builds journey recap with earliest favorite and highest-rated fallback", () => {
+  const books = [
+    makeBook({
+      id: "one",
+      volume_number: 1,
+      status: "Finished",
+      is_favorite: true,
+      rating: 3,
+      date_started: "2025-01-04",
+      date_finished: "2025-01-29",
+    }),
+    makeBook({
+      id: "two",
+      volume_number: 2,
+      status: "Finished",
+      is_favorite: true,
+      rating: 5,
+      date_started: "2026-02-01",
+      date_finished: "2026-03-04",
+    }),
+  ];
+
+  const recap = getSeriesJourneyRecap(books, [
+    makeLog({ book_id: "one", reading_time_minutes: 60 }),
+    makeLog({ id: "second", book_id: "two", reading_time_minutes: 30 }),
+  ]);
+  assert.equal(recap.started, "2025-01-04");
+  assert.equal(recap.timeSpentDays, 56);
+  assert.equal(recap.finishedBooks, 2);
+  assert.equal(recap.completedMonths, 14);
+  assert.equal(recap.favoriteBook?.id, "one");
+
+  const fallback = getSeriesJourneyRecap(
+    books.map((book) => ({ ...book, is_favorite: false })),
+    [],
+  );
+  assert.equal(fallback.favoriteBook?.id, "two");
+});
+
+test("only inserts immediate starts and breaks longer than ten days", () => {
+  const previous = makeBook({
+    status: "Finished",
+    date_finished: "2026-01-10",
+  });
+
+  assert.deepEqual(
+    getSeriesJourneyTransition(previous, makeBook({ date_started: "2026-01-11" }), []),
+    { kind: "continued", days: 1, started: "2026-01-11" },
+  );
+  assert.equal(
+    getSeriesJourneyTransition(previous, makeBook({ date_started: "2026-01-15" }), []),
+    null,
+  );
+  assert.deepEqual(
+    getSeriesJourneyTransition(previous, makeBook({ date_started: "2026-01-25" }), []),
+    {
+      kind: "break",
+      days: 15,
+      finished: "2026-01-10",
+      started: "2026-01-25",
+    },
+  );
+});
+
+test("orders featured note candidates shortest first and prefers a favorite tie", () => {
+  const ordered = getFeaturedNoteCandidates([
+    makeNote({ id: "long", content: "A longer journal thought" }),
+    makeNote({ id: "plain", content: "Short note" }),
+    makeNote({ id: "favorite", content: "Short note", is_favorite: true }),
+  ]);
+
+  assert.deepEqual(ordered.map((note) => note.id), ["favorite", "plain", "long"]);
+});
+
+test("builds series stats overview using read pages, series logs, and active journey span", () => {
+  const stats = getSeriesStats(
+    [
+      makeBook({
+        id: "finished",
+        status: "Finished",
+        total_pages: 300,
+        date_started: "2026-01-01",
+        date_finished: "2026-01-11",
+      }),
+      makeBook({
+        id: "reading",
+        status: "Reading",
+        total_pages: 200,
+        current_page: 40,
+        date_started: "2026-02-01",
+      }),
+      makeBook({ id: "unread", status: "Not Started", total_pages: 250 }),
+    ],
+    [
+      makeLog({ id: "first", book_id: "finished", reading_time_minutes: 90 }),
+      makeLog({ id: "second", book_id: "reading", reading_time_minutes: 45 }),
+      makeLog({ id: "outside", book_id: "other", reading_time_minutes: 999 }),
+    ],
+    [],
+    new Date("2026-02-15T09:00:00"),
+  );
+
+  assert.equal(stats.overview.finishedBooks, 1);
+  assert.equal(stats.overview.totalBooks, 3);
+  assert.equal(stats.overview.pagesRead, 340);
+  assert.equal(stats.overview.readingMinutes, 135);
+  assert.equal(stats.overview.journeyDays, 45);
+  assert.deepEqual(stats.overview.journeySpan, { months: 1, weeks: 2, days: 0 });
+
+  const completed = getSeriesStats(
+    [
+      makeBook({
+        status: "Finished",
+        date_started: "2026-01-01",
+        date_finished: "2026-01-11",
+        total_pages: 100,
+      }),
+    ],
+    [],
+    [],
+    new Date("2026-04-01T09:00:00"),
+  );
+  assert.equal(completed.overview.journeyDays, 10);
+});
+
+test("calculates timing series stats from eligible books only", () => {
+  const stats = getSeriesStats(
+    [
+      makeBook({
+        id: "first",
+        status: "Finished",
+        rating: 4,
+        date_started: "2026-01-01",
+        date_finished: "2026-01-11",
+      }),
+      makeBook({
+        id: "second",
+        status: "Finished",
+        rating: 2,
+        date_started: "2026-01-12",
+        date_finished: "2026-02-01",
+      }),
+      makeBook({ id: "unread", rating: null }),
+    ],
+    [],
+    [],
+  );
+
+  assert.equal(stats.averageDaysPerBook, 15);
+});
+
+test("selects duration and length winners with ties while excluding missing inputs", () => {
+  const stats = getSeriesStats(
+    [
+      makeBook({
+        id: "a",
+        volume_number: 1,
+        status: "Finished",
+        total_pages: 100,
+        date_started: "2026-01-01",
+        date_finished: "2026-01-06",
+      }),
+      makeBook({
+        id: "b",
+        volume_number: 2,
+        status: "Finished",
+        total_pages: 100,
+        date_started: "2026-02-01",
+        date_finished: "2026-02-06",
+      }),
+      makeBook({ id: "c", volume_number: 3, status: "Finished", total_pages: 300 }),
+      makeBook({ id: "missing-pages", volume_number: 4 }),
+    ],
+    [],
+    [],
+  );
+
+  assert.deepEqual(stats.fastestRead?.books.map((book) => book.id), ["a", "b"]);
+  assert.deepEqual(stats.slowestRead?.books.map((book) => book.id), ["a", "b"]);
+  assert.equal(stats.fastestRead?.value, 5);
+  assert.deepEqual(stats.longestBook?.books.map((book) => book.id), ["c"]);
+  assert.deepEqual(stats.shortestBook?.books.map((book) => book.id), ["a", "b"]);
+});
+
+test("counts annotation and highlight note types separately", () => {
+  const books = [
+    makeBook({ id: "one", volume_number: 1, is_favorite: true, rating: 2 }),
+    makeBook({ id: "two", volume_number: 2, is_favorite: true, rating: 5 }),
+    makeBook({ id: "three", volume_number: 3, rating: 4 }),
+  ];
+  const notes = [
+    makeNote({ id: "one-note", book_id: "one", label: "note" }),
+    makeNote({ id: "one-review", book_id: "one", label: "review" }),
+    makeNote({ id: "one-quote", book_id: "one", label: "quote" }),
+    makeNote({ id: "two-quote", book_id: "two", label: "quote" }),
+    makeNote({ id: "outside", book_id: "outside", label: "note" }),
+  ];
+
+  const stats = getSeriesStats(books, [], notes);
+  assert.deepEqual(stats.mostAnnotated?.books.map((book) => book.id), ["one"]);
+  assert.equal(stats.mostAnnotated?.value, 2);
+  assert.deepEqual(stats.mostHighlighted?.books.map((book) => book.id), ["one", "two"]);
+  assert.equal(stats.mostHighlighted?.value, 1);
+});
+
+test("builds duration and pace chart rows in series order and excludes unusable pace data", () => {
+  const stats = getSeriesStats(
+    [
+      makeBook({
+        id: "volume-2",
+        volume_number: 2,
+        status: "Finished",
+        date_started: "2026-02-01",
+        date_finished: "2026-02-03",
+      }),
+      makeBook({
+        id: "volume-1",
+        volume_number: 1,
+        status: "Finished",
+        total_pages: 80,
+        date_started: "2026-01-01",
+        date_finished: "2026-01-05",
+      }),
+      makeBook({ id: "unread", volume_number: 3, total_pages: 100 }),
+    ],
+    [],
+    [],
+  );
+
+  assert.deepEqual(stats.durationChart.map((row) => row.book.id), ["volume-1", "volume-2"]);
+  assert.deepEqual(stats.durationChart.map((row) => row.days), [4, 2]);
+  assert.deepEqual(stats.paceChart.map((row) => row.book.id), ["volume-1"]);
+  assert.equal(stats.paceChart[0].pagesPerDay, 20);
+});
+
+test("keeps series stats neutral when required data is absent", () => {
+  const empty = getSeriesStats([], [], []);
+  assert.equal(empty.overview.pagesRead, 0);
+  assert.equal(empty.overview.journeySpan, null);
+  assert.equal(empty.mostAnnotated, null);
+  assert.equal(empty.mostHighlighted, null);
+  assert.deepEqual(empty.durationChart, []);
+  assert.deepEqual(empty.paceChart, []);
+
+  const incomplete = getSeriesStats(
+    [
+      makeBook({ status: "Finished" }),
+      makeBook({ id: "reading", status: "Reading" }),
+    ],
+    [],
+    [],
+  );
+  assert.equal(incomplete.overview.pagesRead, null);
+  assert.equal(incomplete.fastestRead, null);
+  assert.equal(incomplete.longestBook, null);
+});
+
+function makeBook(overrides: Partial<Book> = {}): Book {
+  return {
+    id: "volume",
+    title: "Volume",
+    authors: ["Author"],
+    status: "Not Started",
+    rating: null,
+    is_favorite: false,
+    user_id: "user-1",
+    created_at: "2026-05-01T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeLog(overrides: Partial<ReadingLog>): ReadingLog {
+  return {
+    id: "log",
+    book_id: "volume",
+    user_id: "user-1",
+    current_page: 10,
+    logged_at: "2026-05-01T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeNote(overrides: Partial<BookNote>): BookNote {
+  return {
+    id: "note",
+    book_id: "volume",
+    user_id: "user-1",
+    label: "note",
+    content: "Note",
+    is_favorite: false,
+    note_date: "2026-05-01",
+    created_at: "2026-05-01T08:00:00Z",
+    updated_at: "2026-05-01T08:00:00Z",
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## What changed
- Added a derived SeriesStats helper for series-level overview metrics, tied book winners, note/highlight counts, and ordered pace charts.
- Reworked the Series Details Stats tab into a richer analytics view with compact summary tiles, cover-backed winner cards, and pace charts.
- Added helper coverage for the new calculations and edge cases.
- Wired the Series pages into navigation and the library/series grouping flow.

## Why
The previous Stats tab was too generic and duplicated information that belonged in Journey. This change makes the series view more useful by surfacing the metrics that matter for a series at a glance.

## Validation
- npm run typecheck
- npm test
- npm run build
