### PR TITLE
[codex] refine series stats insights

### DIFF
--- a/src/lib/seriesDetails.ts
+++ b/src/lib/seriesDetails.ts
@@ -60,6 +60,16 @@ export type SeriesPaceChartRow = {
   pagesPerDay: number;
 };
 
+export type SeriesRankedBook = {
+  book: Book;
+  value: number;
+};
+
+export type SeriesFavoriteQuote = {
+  book: Book;
+  note: BookNote;
+};
+
 export type SeriesStats = {
   overview: {
     finishedBooks: number;
@@ -74,10 +84,14 @@ export type SeriesStats = {
   slowestRead: SeriesBookWinners | null;
   longestBook: SeriesBookWinners | null;
   shortestBook: SeriesBookWinners | null;
-  mostAnnotated: SeriesBookWinners | null;
-  mostHighlighted: SeriesBookWinners | null;
   durationChart: SeriesDurationChartRow[];
   paceChart: SeriesPaceChartRow[];
+  rankings: {
+    rating: SeriesRankedBook[];
+    pace: SeriesRankedBook[];
+    annotations: SeriesRankedBook[];
+  };
+  favoriteQuotes: SeriesFavoriteQuote[];
 };
 
 function compareBookTitles(a: Book, b: Book): number {
@@ -366,6 +380,7 @@ export function getSeriesStats(
 ): SeriesStats {
   const sortedBooks = sortSeriesBooks(books);
   const bookIds = new Set(sortedBooks.map((book) => book.id));
+  const bookOrder = new Map(sortedBooks.map((book, index) => [book.id, index]));
   const seriesLogs = filterSeriesLogs(sortedBooks, logs);
   const seriesNotes = notes.filter((note) => bookIds.has(note.book_id));
   const finishedBooks = sortedBooks.filter((book) => book.status === "Finished");
@@ -373,6 +388,11 @@ export function getSeriesStats(
     const days = getJourneyDurationDays(book, seriesLogs, now);
     return days === null ? [] : [{ book, value: days }];
   });
+  const paces = durations.flatMap(({ book, value }) =>
+    value > 0 && typeof book.total_pages === "number" && book.total_pages > 0
+      ? [{ book, value: book.total_pages / value }]
+      : [],
+  );
   const lengths = sortedBooks.flatMap((book) =>
     typeof book.total_pages === "number" && book.total_pages > 0
       ? [{ book, value: book.total_pages }]
@@ -383,10 +403,7 @@ export function getSeriesStats(
       book.id,
       {
         annotated: seriesNotes.filter(
-          (note) => note.book_id === book.id && (note.label === "note" || note.label === "review"),
-        ).length,
-        highlighted: seriesNotes.filter(
-          (note) => note.book_id === book.id && note.label === "quote",
+          (note) => note.book_id === book.id && (note.label === "note" || note.label === "quote"),
         ).length,
       },
     ]),
@@ -395,10 +412,33 @@ export function getSeriesStats(
     book,
     value: notesByBook.get(book.id)?.annotated ?? 0,
   }));
-  const highlights = sortedBooks.map((book) => ({
-    book,
-    value: notesByBook.get(book.id)?.highlighted ?? 0,
-  }));
+  const ratingRanking = sortedBooks
+    .flatMap((book) =>
+      typeof book.rating === "number" ? [{ book, value: book.rating }] : [],
+    )
+    .sort((a, b) => b.value - a.value || Number(b.book.is_favorite) - Number(a.book.is_favorite));
+  const paceRanking = [...paces].sort((a, b) => b.value - a.value);
+  const annotationRanking = annotations
+    .filter((candidate) => candidate.value > 0)
+    .sort((a, b) => b.value - a.value);
+  const favoriteQuotes = seriesNotes
+    .filter(
+      (note) =>
+        note.label === "quote" &&
+        note.is_favorite &&
+        note.content.trim().length > 0,
+    )
+    .sort(
+      (a, b) =>
+        (bookOrder.get(a.book_id) ?? Number.MAX_SAFE_INTEGER) -
+          (bookOrder.get(b.book_id) ?? Number.MAX_SAFE_INTEGER) ||
+        b.note_date.localeCompare(a.note_date) ||
+        b.created_at.localeCompare(a.created_at),
+    )
+    .map((note) => ({
+      book: sortedBooks.find((book) => book.id === note.book_id)!,
+      note,
+    }));
   const journey = getSeriesJourneySpan(sortedBooks, seriesLogs, now);
   return {
     overview: {
@@ -412,24 +452,18 @@ export function getSeriesStats(
       durations.length > 0
         ? durations.reduce((sum, duration) => sum + duration.value, 0) / durations.length
         : null,
-    fastestRead: getWinnerBooks(durations, (values) => Math.min(...values)),
-    slowestRead: getWinnerBooks(durations, (values) => Math.max(...values)),
+    fastestRead: getWinnerBooks(paces, (values) => Math.max(...values)),
+    slowestRead: getWinnerBooks(paces, (values) => Math.min(...values)),
     longestBook: getWinnerBooks(lengths, (values) => Math.max(...values)),
     shortestBook: getWinnerBooks(lengths, (values) => Math.min(...values)),
-    mostAnnotated:
-      annotations.some((candidate) => candidate.value > 0)
-        ? getWinnerBooks(annotations, (values) => Math.max(...values))
-        : null,
-    mostHighlighted:
-      highlights.some((candidate) => candidate.value > 0)
-        ? getWinnerBooks(highlights, (values) => Math.max(...values))
-        : null,
     durationChart: durations.map(({ book, value }) => ({ book, days: value })),
-    paceChart: durations.flatMap(({ book, value }) =>
-      value > 0 && typeof book.total_pages === "number" && book.total_pages > 0
-        ? [{ book, pagesPerDay: book.total_pages / value }]
-        : [],
-    ),
+    paceChart: paces.map(({ book, value }) => ({ book, pagesPerDay: value })),
+    rankings: {
+      rating: ratingRanking,
+      pace: paceRanking,
+      annotations: annotationRanking,
+    },
+    favoriteQuotes,
   };
 }
 

--- a/src/pages/SeriesDetails.tsx
+++ b/src/pages/SeriesDetails.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { Link, useParams } from "react-router-dom";
-import { ArrowLeft, BookOpen, Check, Flag, Star } from "lucide-react";
+import { ArrowLeft, BookOpen, Check, Flag, Heart, Star } from "lucide-react";
 import ReadingProgressDialog from "@/components/ReadingProgressDialog";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -150,14 +150,20 @@ function WinnerStatsCard({
   books,
   detail,
   emptyLabel,
+  coveredByPair = false,
 }: {
   title: string;
   books: Book[];
   detail: string | null;
   emptyLabel: string;
+  coveredByPair?: boolean;
 }) {
   return (
-    <SummaryCard title={title} compact>
+    <SummaryCard
+      title={title}
+      compact
+      className={cn("h-full", coveredByPair && "pr-12")}
+    >
       {books.length === 0 ? (
         <p className="text-sm text-muted-foreground">{emptyLabel}</p>
       ) : (
@@ -235,6 +241,110 @@ function SmallBookRow({
         )}
       </div>
     </Link>
+  );
+}
+
+function SeriesRankingCard({
+  title,
+  rows,
+  formatValue,
+  emptyLabel,
+  getTieKey = (row) => row.value,
+}: {
+  title: string;
+  rows: Array<{ book: Book; value: number }>;
+  formatValue: (value: number, book: Book) => string;
+  emptyLabel: string;
+  getTieKey?: (row: { book: Book; value: number }) => string | number;
+}) {
+  const rankingGroups = rows.reduce<
+    Array<{ key: string | number; value: number; rows: Array<{ book: Book; value: number }> }>
+  >(
+    (groups, row) => {
+      const key = getTieKey(row);
+      const lastGroup = groups[groups.length - 1];
+      if (lastGroup?.key === key) {
+        lastGroup.rows.push(row);
+      } else {
+        groups.push({ key, value: row.value, rows: [row] });
+      }
+      return groups;
+    },
+    [],
+  );
+
+  return (
+    <SummaryCard title={title} compact>
+      {rows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{emptyLabel}</p>
+      ) : (
+        <ol className="space-y-3">
+          {rankingGroups.map((group, index) => {
+            const rank = index + 1;
+            const hasSharedFirstPlace = rank === 1 && group.rows.length > 1;
+            return (
+              <li key={`${group.value}-${group.rows[0].book.id}`}>
+                <div
+                  className={cn(
+                    "space-y-3",
+                    hasSharedFirstPlace && "rounded-lg bg-muted/50 p-1 ring-1 ring-border",
+                  )}
+                >
+                  {group.rows.map((row, rowIndex) => (
+                    <Link
+                      key={row.book.id}
+                      to={`/books/${row.book.id}`}
+                      className={cn(
+                        "flex items-center gap-3 rounded-lg p-1 transition-colors hover:bg-muted/50",
+                        rank === 1 && !hasSharedFirstPlace && "bg-muted/50 ring-1 ring-border",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "w-5 shrink-0 text-center text-sm font-semibold text-muted-foreground",
+                          rank === 1 && "text-foreground",
+                        )}
+                      >
+                        {rowIndex === 0 ? rank : null}
+                      </span>
+                      <BookThumbnail book={row.book} />
+                      <div className="min-w-0">
+                        <p className="line-clamp-2 text-sm font-medium">{row.book.title}</p>
+                        <p className="text-xs text-muted-foreground">{formatValue(row.value, row.book)}</p>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </SummaryCard>
+  );
+}
+
+function FavoriteQuoteCard({ book, note }: { book: Book; note: BookNote }) {
+  return (
+    <article className="flex min-h-48 flex-col rounded-xl border bg-card p-5">
+      <Heart className="h-4 w-4 fill-foreground text-foreground" aria-hidden />
+      <p className="mt-4 line-clamp-5 whitespace-pre-line font-serif text-base italic leading-7">
+        &ldquo;{note.content.trim()}&rdquo;
+      </p>
+      {note.quote_speaker && (
+        <p className="mt-2 text-sm text-muted-foreground">- {note.quote_speaker}</p>
+      )}
+      <Link
+        to={`/books/${book.id}?tab=notes`}
+        className="mt-auto flex items-center gap-3 pt-5 transition-colors hover:text-muted-foreground"
+      >
+        <BookThumbnail book={book} />
+        <div className="min-w-0">
+          <p className="line-clamp-2 text-sm font-medium">{book.title}</p>
+          <p className="text-xs text-muted-foreground">View quote</p>
+        </div>
+      </Link>
+    </article>
   );
 }
 
@@ -905,12 +1015,27 @@ export default function SeriesDetails() {
               </div>
 
               <section className="space-y-4">
-                <h2 className="font-heading text-xl font-medium">Books in this series</h2>
+                <h2 className="font-heading text-xl font-medium">Books</h2>
                 <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-5">
                   {seriesBooks.map((book, index) => (
                     <SeriesOverviewBookTile key={book.id} book={book} index={index} />
                   ))}
                 </div>
+              </section>
+
+              <section className="space-y-4">
+                <h2 className="font-heading text-xl font-medium">Favorite Quotes</h2>
+                {stats.favoriteQuotes.length === 0 ? (
+                  <p className="rounded-xl border border-dashed p-5 text-sm text-muted-foreground">
+                    Quotes marked as favorite in this series will appear here.
+                  </p>
+                ) : (
+                  <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                    {stats.favoriteQuotes.map(({ book, note }) => (
+                      <FavoriteQuoteCard key={note.id} book={book} note={note} />
+                    ))}
+                  </div>
+                )}
               </section>
             </div>
           )}
@@ -986,11 +1111,7 @@ export default function SeriesDetails() {
 
         <TabsContent value="stats" className="space-y-7">
           <h2 className="font-heading text-xl font-medium">Series Stats</h2>
-          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
-            <StatsOverviewCard
-              label="Books Completed"
-              value={`${stats.overview.finishedBooks}/${stats.overview.totalBooks}`}
-            />
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
             <StatsOverviewCard
               label="Pages Read"
               value={
@@ -1032,51 +1153,31 @@ export default function SeriesDetails() {
           </div>
 
           <section className="space-y-4">
-            <h3 className="font-heading text-lg font-medium">Detailed Statistics</h3>
-            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-              <WinnerStatsCard
-                title="Fastest read"
-                books={stats.fastestRead?.books ?? []}
-                detail={stats.fastestRead ? formatDaysSpent(stats.fastestRead.value) : null}
-                emptyLabel="No completed books with dates"
+            <div>
+              <h3 className="font-heading text-lg font-medium">Book Rankings</h3>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Compare volumes by rating, reading pace, and annotations.
+              </p>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-3">
+              <SeriesRankingCard
+                title="Top Rated"
+                rows={stats.rankings.rating}
+                formatValue={(value, book) => (book.is_favorite ? "Favorite" : `${value.toFixed(1)} / 5`)}
+                emptyLabel="No ratings yet"
+                getTieKey={(row) => `${row.value}-${row.book.is_favorite ? "favorite" : "regular"}`}
               />
-              <WinnerStatsCard
-                title="Slowest read"
-                books={stats.slowestRead?.books ?? []}
-                detail={stats.slowestRead ? formatDaysSpent(stats.slowestRead.value) : null}
-                emptyLabel="No completed books with dates"
+              <SeriesRankingCard
+                title="Fastest Pace"
+                rows={stats.rankings.pace}
+                formatValue={(value) => `${value.toFixed(1)} pages/day`}
+                emptyLabel="No completed books with dates and pages"
               />
-              <WinnerStatsCard
-                title="Longest book"
-                books={stats.longestBook?.books ?? []}
-                detail={stats.longestBook ? `${stats.longestBook.value.toLocaleString()} pages` : null}
-                emptyLabel="No page totals yet"
-              />
-              <WinnerStatsCard
-                title="Shortest book"
-                books={stats.shortestBook?.books ?? []}
-                detail={stats.shortestBook ? `${stats.shortestBook.value.toLocaleString()} pages` : null}
-                emptyLabel="No page totals yet"
-              />
-              <WinnerStatsCard
-                title="Most annotated book"
-                books={stats.mostAnnotated?.books ?? []}
-                detail={
-                  stats.mostAnnotated
-                    ? `${stats.mostAnnotated.value} note${stats.mostAnnotated.value === 1 ? "" : "s"}`
-                    : null
-                }
-                emptyLabel="No notes yet"
-              />
-              <WinnerStatsCard
-                title="Most highlighted book"
-                books={stats.mostHighlighted?.books ?? []}
-                detail={
-                  stats.mostHighlighted
-                    ? `${stats.mostHighlighted.value} highlight${stats.mostHighlighted.value === 1 ? "" : "s"}`
-                    : null
-                }
-                emptyLabel="No highlights yet"
+              <SeriesRankingCard
+                title="Most Annotated"
+                rows={stats.rankings.annotations}
+                formatValue={(value) => `${value} annotation${value === 1 ? "" : "s"}`}
+                emptyLabel="No annotations yet"
               />
             </div>
           </section>
@@ -1102,6 +1203,50 @@ export default function SeriesDetails() {
                 }))}
                 emptyLabel="Add completed-book dates and page totals to compare reading pace."
               />
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="font-heading text-lg font-medium">Records</h3>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)] items-start">
+                <div className="relative z-10">
+                  <WinnerStatsCard
+                    title="Longest"
+                    books={stats.longestBook?.books ?? []}
+                    detail={stats.longestBook ? `${stats.longestBook.value.toLocaleString()} pages` : null}
+                    emptyLabel="No page totals yet"
+                    coveredByPair
+                  />
+                </div>
+                <div className="relative z-20 -ml-10">
+                  <WinnerStatsCard
+                    title="Shortest"
+                    books={stats.shortestBook?.books ?? []}
+                    detail={stats.shortestBook ? `${stats.shortestBook.value.toLocaleString()} pages` : null}
+                    emptyLabel="No page totals yet"
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)] items-start">
+                <div className="relative z-10">
+                  <WinnerStatsCard
+                    title="Fastest"
+                    books={stats.fastestRead?.books ?? []}
+                    detail={stats.fastestRead ? `${stats.fastestRead.value.toFixed(1)} pages/day` : null}
+                    emptyLabel="No completed books with dates and pages"
+                    coveredByPair
+                  />
+                </div>
+                <div className="relative z-20 -ml-10">
+                  <WinnerStatsCard
+                    title="Slowest"
+                    books={stats.slowestRead?.books ?? []}
+                    detail={stats.slowestRead ? `${stats.slowestRead.value.toFixed(1)} pages/day` : null}
+                    emptyLabel="No completed books with dates and pages"
+                  />
+                </div>
+              </div>
             </div>
           </section>
 

--- a/tests/seriesDetails.test.ts
+++ b/tests/seriesDetails.test.ts
@@ -281,7 +281,7 @@ test("calculates timing series stats from eligible books only", () => {
   assert.equal(stats.averageDaysPerBook, 15);
 });
 
-test("selects duration and length winners with ties while excluding missing inputs", () => {
+test("selects pace and length winners with ties while excluding missing inputs", () => {
   const stats = getSeriesStats(
     [
       makeBook({
@@ -296,25 +296,34 @@ test("selects duration and length winners with ties while excluding missing inpu
         id: "b",
         volume_number: 2,
         status: "Finished",
-        total_pages: 100,
+        total_pages: 200,
         date_started: "2026-02-01",
         date_finished: "2026-02-06",
       }),
-      makeBook({ id: "c", volume_number: 3, status: "Finished", total_pages: 300 }),
-      makeBook({ id: "missing-pages", volume_number: 4 }),
+      makeBook({
+        id: "d",
+        volume_number: 3,
+        status: "Finished",
+        total_pages: 200,
+        date_started: "2026-03-01",
+        date_finished: "2026-03-11",
+      }),
+      makeBook({ id: "c", volume_number: 4, status: "Finished", total_pages: 300 }),
+      makeBook({ id: "missing-pages", volume_number: 5, status: "Finished", date_started: "2026-04-01", date_finished: "2026-04-02" }),
     ],
     [],
     [],
   );
 
-  assert.deepEqual(stats.fastestRead?.books.map((book) => book.id), ["a", "b"]);
-  assert.deepEqual(stats.slowestRead?.books.map((book) => book.id), ["a", "b"]);
-  assert.equal(stats.fastestRead?.value, 5);
+  assert.deepEqual(stats.fastestRead?.books.map((book) => book.id), ["b"]);
+  assert.equal(stats.fastestRead?.value, 40);
+  assert.deepEqual(stats.slowestRead?.books.map((book) => book.id), ["a", "d"]);
+  assert.equal(stats.slowestRead?.value, 20);
   assert.deepEqual(stats.longestBook?.books.map((book) => book.id), ["c"]);
-  assert.deepEqual(stats.shortestBook?.books.map((book) => book.id), ["a", "b"]);
+  assert.deepEqual(stats.shortestBook?.books.map((book) => book.id), ["a"]);
 });
 
-test("counts annotation and highlight note types separately", () => {
+test("counts notes and quotes as annotations while excluding reviews", () => {
   const books = [
     makeBook({ id: "one", volume_number: 1, is_favorite: true, rating: 2 }),
     makeBook({ id: "two", volume_number: 2, is_favorite: true, rating: 5 }),
@@ -325,14 +334,38 @@ test("counts annotation and highlight note types separately", () => {
     makeNote({ id: "one-review", book_id: "one", label: "review" }),
     makeNote({ id: "one-quote", book_id: "one", label: "quote" }),
     makeNote({ id: "two-quote", book_id: "two", label: "quote" }),
+    makeNote({ id: "two-review", book_id: "two", label: "review" }),
     makeNote({ id: "outside", book_id: "outside", label: "note" }),
   ];
 
   const stats = getSeriesStats(books, [], notes);
-  assert.deepEqual(stats.mostAnnotated?.books.map((book) => book.id), ["one"]);
-  assert.equal(stats.mostAnnotated?.value, 2);
-  assert.deepEqual(stats.mostHighlighted?.books.map((book) => book.id), ["one", "two"]);
-  assert.equal(stats.mostHighlighted?.value, 1);
+  assert.deepEqual(stats.rankings.annotations.map((row) => row.book.id), ["one", "two"]);
+  assert.deepEqual(stats.rankings.annotations.map((row) => row.value), [2, 1]);
+});
+
+test("builds rankings with favorite books first among equal ratings and includes only favorited series quotes", () => {
+  const books = [
+    makeBook({ id: "one", volume_number: 1, status: "Finished", rating: 3, total_pages: 100, date_started: "2026-01-01", date_finished: "2026-01-11" }),
+    makeBook({ id: "two", volume_number: 2, status: "Finished", rating: 5, total_pages: 180, date_started: "2026-02-01", date_finished: "2026-02-11" }),
+    makeBook({ id: "three", volume_number: 3, rating: 4 }),
+    makeBook({ id: "favorite-five", volume_number: 4, rating: 5, is_favorite: true }),
+  ];
+  const notes = [
+    makeNote({ id: "one-annotation", book_id: "one", label: "note" }),
+    makeNote({ id: "two-review", book_id: "two", label: "review" }),
+    makeNote({ id: "two-annotation", book_id: "two", label: "note" }),
+    makeNote({ id: "favorite-one", book_id: "one", label: "quote", is_favorite: true, content: "First" }),
+    makeNote({ id: "plain-quote", book_id: "one", label: "quote", content: "Not selected" }),
+    makeNote({ id: "favorite-three", book_id: "three", label: "quote", is_favorite: true, content: "Third" }),
+    makeNote({ id: "outside", book_id: "outside", label: "quote", is_favorite: true }),
+  ];
+
+  const stats = getSeriesStats(books, [], notes);
+
+  assert.deepEqual(stats.rankings.rating.map((row) => row.book.id), ["favorite-five", "two", "three", "one"]);
+  assert.deepEqual(stats.rankings.pace.map((row) => row.book.id), ["two", "one"]);
+  assert.deepEqual(stats.rankings.annotations.map((row) => row.book.id), ["one", "two", "three"]);
+  assert.deepEqual(stats.favoriteQuotes.map((entry) => entry.note.id), ["favorite-one", "favorite-three"]);
 });
 
 test("builds duration and pace chart rows in series order and excludes unusable pace data", () => {
@@ -369,10 +402,10 @@ test("keeps series stats neutral when required data is absent", () => {
   const empty = getSeriesStats([], [], []);
   assert.equal(empty.overview.pagesRead, 0);
   assert.equal(empty.overview.journeySpan, null);
-  assert.equal(empty.mostAnnotated, null);
-  assert.equal(empty.mostHighlighted, null);
   assert.deepEqual(empty.durationChart, []);
   assert.deepEqual(empty.paceChart, []);
+  assert.deepEqual(empty.rankings, { rating: [], pace: [], annotations: [] });
+  assert.deepEqual(empty.favoriteQuotes, []);
 
   const incomplete = getSeriesStats(
     [


### PR DESCRIPTION
## Summary
- Reworks the Series Stats content around ranked insights, pace charts, and compact linked record cards.
- Adds series favorite quote presentation on the Overview tab and renames the books section heading.
- Updates fastest/slowest calculations to compare reading pace (`pages/day`) rather than calendar duration alone.

## Implementation
- Extends derived series stats with ranking rows and favorite quotes assembled from existing books and notes data.
- Adds `Top Rated`, `Fastest Pace`, and `Most Annotated` rankings, with first-place highlighting, tie presentation, and favorite-first ordering for equal ratings.
- Counts notes and quotes for `Most Annotated`, while excluding reviews.
- Replaces the previous detailed-stat card grid with linked Records cards for Longest, Shortest, Fastest, and Slowest, using the standard Stats card style.
- Keeps record-card overlap readable by reserving space for the overlaid card so longer titles wrap visibly.

## Impact
Readers can compare books in a series more directly, identify favorites and annotated volumes, view favorite quotes in context, and understand reading-speed records using comparable pages-per-day data.

## Validation
- `npm run typecheck`
- `npm test` (90 tests passed)
- `npm run build`

The existing Vite bundle-size warning remains non-blocking and is unrelated to this change.
