### PR TITLE
[codex] Add universal quote design

### DIFF
--- a/src/components/BookNotesPanel.tsx
+++ b/src/components/BookNotesPanel.tsx
@@ -10,6 +10,8 @@ import {
   RefreshCw,
   Trash2,
 } from "lucide-react";
+import FormattedNoteContent from "@/components/FormattedNoteContent";
+import QuoteBlock from "@/components/QuoteBlock";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -26,9 +28,6 @@ import {
 } from "@/lib/bookNotes";
 import {
   noteMarkdownToEditorHtml,
-  parseNoteMarkdown,
-  type NoteBlockNode,
-  type NoteInlineNode,
 } from "@/lib/noteFormatting";
 import { cn } from "@/lib/utils";
 import type { Book, BookNote, BookNoteLabel } from "@/types";
@@ -122,63 +121,6 @@ function editorHtmlToMarkdown(html: string): string {
     .filter((block) => block.trim())
     .join("\n")
     .trim();
-}
-
-function renderInlineNodes(nodes: NoteInlineNode[]): ReactNode {
-  return nodes.map((node, index) => {
-    if (node.type === "text") {
-      return node.text.split("\n").map((line, lineIndex) => (
-        <span key={`${index}-${lineIndex}`}>
-          {lineIndex > 0 && <br />}
-          {line}
-        </span>
-      ));
-    }
-
-    if (node.type === "bold") {
-      return <strong key={index}>{renderInlineNodes(node.children)}</strong>;
-    }
-
-    return <em key={index}>{renderInlineNodes(node.children)}</em>;
-  });
-}
-
-function renderNoteBlock(block: NoteBlockNode, index: number): ReactNode {
-  if (block.type === "quote") {
-    return (
-      <blockquote key={index} className="border-l-2 border-border pl-3 italic">
-        {renderInlineNodes(block.children)}
-      </blockquote>
-    );
-  }
-
-  if (block.type === "list") {
-    return (
-      <ul key={index} className="list-disc space-y-1 pl-5">
-        {block.items.map((item, itemIndex) => (
-          <li key={itemIndex}>{renderInlineNodes(item)}</li>
-        ))}
-      </ul>
-    );
-  }
-
-  return <p key={index}>{renderInlineNodes(block.children)}</p>;
-}
-
-function FormattedNoteContent({
-  markdown,
-  className,
-}: {
-  markdown: string;
-  className?: string;
-}) {
-  const blocks = parseNoteMarkdown(markdown);
-
-  return (
-    <div className={cn("space-y-2 whitespace-normal", className)}>
-      {blocks.map(renderNoteBlock)}
-    </div>
-  );
 }
 
 function CollapsibleNoteContent({
@@ -742,36 +684,25 @@ export default function BookNotesPanel({ book }: BookNotesPanelProps) {
                       {formatNoteDate(visibleDate)}
                     </time>
                   </div>
-                  <div className="grid grid-cols-[3rem_1fr] gap-x-4">
-                    <div className="flex flex-col items-center">
-                      <div
-                        aria-hidden="true"
-                        className="font-serif text-5xl leading-none text-sky-600 dark:text-sky-400"
-                      >
-                        “
-                      </div>
-                      <div className="-mt-3 w-px flex-1 bg-sky-500 dark:bg-sky-400" />
-                    </div>
-                    <div className="min-w-0 pr-36 sm:pr-44">
+                  <div className="pr-36 sm:pr-44">
+                    <QuoteBlock
+                      attribution={
+                        <div className="flex flex-wrap items-center gap-2">
+                          {note.quote_speaker && (
+                            <span className="font-serif italic">
+                              - {note.quote_speaker}
+                            </span>
+                          )}
+                          {pageRangeLabel && (
+                            <span className="text-xs font-medium">{pageRangeLabel}</span>
+                          )}
+                        </div>
+                      }
+                    >
                       <CollapsibleNoteContent
                         markdown={note.content}
-                        className="font-serif text-sm italic leading-6 text-foreground"
-                        footerLeft={
-                          <div className="flex flex-wrap items-center gap-2">
-                            {note.quote_speaker && (
-                              <span className="font-serif text-sm italic text-muted-foreground">
-                                - {note.quote_speaker}
-                              </span>
-                            )}
-                            {pageRangeLabel && (
-                              <span className="text-xs font-medium text-muted-foreground">
-                                {pageRangeLabel}
-                              </span>
-                            )}
-                          </div>
-                        }
                       />
-                    </div>
+                    </QuoteBlock>
                   </div>
                 </article>
               );

--- a/src/components/FormattedNoteContent.tsx
+++ b/src/components/FormattedNoteContent.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react";
+import QuoteBlock from "@/components/QuoteBlock";
+import {
+  parseNoteMarkdown,
+  type NoteBlockNode,
+  type NoteInlineNode,
+} from "@/lib/noteFormatting";
+import { cn } from "@/lib/utils";
+
+function renderInlineNodes(nodes: NoteInlineNode[]): ReactNode {
+  return nodes.map((node, index) => {
+    if (node.type === "text") {
+      return node.text.split("\n").map((line, lineIndex) => (
+        <span key={`${index}-${lineIndex}`}>
+          {lineIndex > 0 && <br />}
+          {line}
+        </span>
+      ));
+    }
+
+    if (node.type === "bold") {
+      return <strong key={index}>{renderInlineNodes(node.children)}</strong>;
+    }
+
+    return <em key={index}>{renderInlineNodes(node.children)}</em>;
+  });
+}
+
+function renderNoteBlock(block: NoteBlockNode, index: number): ReactNode {
+  if (block.type === "quote") {
+    return (
+      <QuoteBlock key={index} className="my-3">
+        {renderInlineNodes(block.children)}
+      </QuoteBlock>
+    );
+  }
+
+  if (block.type === "list") {
+    return (
+      <ul key={index} className="list-disc space-y-1 pl-5">
+        {block.items.map((item, itemIndex) => (
+          <li key={itemIndex}>{renderInlineNodes(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  return <p key={index}>{renderInlineNodes(block.children)}</p>;
+}
+
+export default function FormattedNoteContent({
+  markdown,
+  className,
+}: {
+  markdown: string;
+  className?: string;
+}) {
+  const blocks = parseNoteMarkdown(markdown);
+
+  return (
+    <div className={cn("space-y-2 whitespace-normal", className)}>
+      {blocks.map(renderNoteBlock)}
+    </div>
+  );
+}

--- a/src/components/QuoteBlock.tsx
+++ b/src/components/QuoteBlock.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface QuoteBlockProps {
+  children: ReactNode;
+  attribution?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  attributionClassName?: string;
+  markClassName?: string;
+}
+
+export default function QuoteBlock({
+  children,
+  attribution,
+  actions,
+  className,
+  contentClassName,
+  attributionClassName,
+  markClassName,
+}: QuoteBlockProps) {
+  return (
+    <figure className={cn("grid grid-cols-[2.25rem_1fr] gap-x-3", className)}>
+      <div aria-hidden="true" className="flex justify-center">
+        <span
+          className={cn(
+            "font-serif text-4xl font-semibold leading-none text-emerald-700 dark:text-emerald-400",
+            markClassName,
+          )}
+        >
+          “
+        </span>
+      </div>
+      <div className="min-w-0">
+        <blockquote
+          className={cn(
+            "font-serif text-sm italic leading-6 text-foreground",
+            contentClassName,
+          )}
+        >
+          {children}
+        </blockquote>
+        {(attribution || actions) && (
+          <figcaption
+            className={cn(
+              "mt-2 flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground",
+              attributionClassName,
+            )}
+          >
+            <div className="min-w-0">{attribution}</div>
+            {actions}
+          </figcaption>
+        )}
+      </div>
+    </figure>
+  );
+}

--- a/src/pages/AuthorDetails.tsx
+++ b/src/pages/AuthorDetails.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, BookOpen, ChevronRight, Heart, Quote, Star } from "lucide-react";
+import { ArrowLeft, BookOpen, ChevronRight, Heart, Star } from "lucide-react";
+import QuoteBlock from "@/components/QuoteBlock";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useBooksContext } from "@/context/BooksContext";
@@ -118,6 +119,9 @@ export default function AuthorDetails() {
   const authors = useMemo(() => buildAuthorSummaries(books, notes), [books, notes]);
   const author = useMemo(() => findAuthorSummary(authors, authorName), [authors, authorName]);
   const featuredQuote = author?.quotes.find((quote) => quote.is_favorite) ?? author?.quotes[0];
+  const featuredQuoteBook = featuredQuote
+    ? author?.books.find((book) => book.id === featuredQuote.book_id)
+    : undefined;
 
   if (booksLoading) {
     return (
@@ -191,15 +195,17 @@ export default function AuthorDetails() {
             </p>
 
             {featuredQuote && (
-              <figure className="border-l-4 border-emerald-700/70 pl-4">
-                <blockquote className="font-heading text-base italic leading-relaxed">
-                  {featuredQuote.content}
-                </blockquote>
-                <figcaption className="mt-2 text-sm text-muted-foreground">
-                  {featuredQuote.quote_speaker ? `${featuredQuote.quote_speaker}, ` : ""}
-                  {author.books.find((book) => book.id === featuredQuote.book_id)?.title}
-                </figcaption>
-              </figure>
+              <QuoteBlock
+                contentClassName="text-base leading-7"
+                attribution={
+                  <>
+                    {featuredQuote.quote_speaker ? `${featuredQuote.quote_speaker}, ` : ""}
+                    {featuredQuoteBook?.title ?? formatAuthorDate(featuredQuote.note_date)}
+                  </>
+                }
+              >
+                {featuredQuote.content}
+              </QuoteBlock>
             )}
           </div>
         </div>
@@ -247,13 +253,14 @@ export default function AuthorDetails() {
               {notesError ? (
                 <p className="text-sm text-muted-foreground">Quotes could not be loaded right now.</p>
               ) : featuredQuote ? (
-                <article>
-                  <Quote className="mb-3 h-5 w-5 text-emerald-700" />
-                  <p className="font-heading text-base leading-relaxed">{featuredQuote.content}</p>
-                  <p className="mt-4 text-sm text-muted-foreground">
-                    - {author.books.find((book) => book.id === featuredQuote.book_id)?.title}
-                  </p>
-                </article>
+                <QuoteBlock
+                  contentClassName="text-base leading-7"
+                  attribution={`- ${
+                    featuredQuoteBook?.title ?? formatAuthorDate(featuredQuote.note_date)
+                  }`}
+                >
+                  {featuredQuote.content}
+                </QuoteBlock>
               ) : (
                 <p className="text-sm text-muted-foreground">
                   Quotes from this author's books will appear here.
@@ -336,16 +343,19 @@ export default function AuthorDetails() {
 
                 return (
                   <article key={quote.id} className="min-h-44 rounded-lg border bg-card p-4">
-                    <Quote className="mb-3 h-4 w-4 text-emerald-700" />
-                    <p className="line-clamp-5 text-sm leading-relaxed">{quote.content}</p>
-                    <div className="mt-4 flex items-end justify-between gap-3">
-                      <p className="text-xs text-muted-foreground">
-                        {quoteBook ? `- ${quoteBook.title}` : formatAuthorDate(quote.note_date)}
-                      </p>
-                      {quote.is_favorite && (
-                        <Heart className="h-4 w-4 shrink-0 fill-rose-500 text-rose-500" />
-                      )}
-                    </div>
+                    <QuoteBlock
+                      contentClassName="line-clamp-5"
+                      attribution={
+                        quoteBook ? `- ${quoteBook.title}` : formatAuthorDate(quote.note_date)
+                      }
+                      actions={
+                        quote.is_favorite ? (
+                          <Heart className="h-4 w-4 shrink-0 fill-rose-500 text-rose-500" />
+                        ) : null
+                      }
+                    >
+                      {quote.content}
+                    </QuoteBlock>
                   </article>
                 );
               })}

--- a/src/pages/ExploreLibrary.tsx
+++ b/src/pages/ExploreLibrary.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import FormattedNoteContent from "@/components/FormattedNoteContent";
+import QuoteBlock from "@/components/QuoteBlock";
 import {
   Select,
   SelectContent,
@@ -34,11 +36,6 @@ import { Separator } from "@/components/ui/separator";
 import { useBooksContext } from "@/context/BooksContext";
 import { useSeries } from "@/hooks/useSeries";
 import { fetchAllBookNotes, formatBookNotePageRange } from "@/lib/bookNotes";
-import {
-  parseNoteMarkdown,
-  type NoteBlockNode,
-  type NoteInlineNode,
-} from "@/lib/noteFormatting";
 import {
   buildMultiValueGroups,
   buildNoteGroups,
@@ -936,63 +933,6 @@ function noteGroupCountLabel(count: number) {
   return `${count} entr${count === 1 ? "y" : "ies"}`;
 }
 
-function renderInlineNodes(nodes: NoteInlineNode[]): ReactNode {
-  return nodes.map((node, index) => {
-    if (node.type === "text") {
-      return node.text.split("\n").map((line, lineIndex) => (
-        <span key={`${index}-${lineIndex}`}>
-          {lineIndex > 0 && <br />}
-          {line}
-        </span>
-      ));
-    }
-
-    if (node.type === "bold") {
-      return <strong key={index}>{renderInlineNodes(node.children)}</strong>;
-    }
-
-    return <em key={index}>{renderInlineNodes(node.children)}</em>;
-  });
-}
-
-function renderNoteBlock(block: NoteBlockNode, index: number): ReactNode {
-  if (block.type === "quote") {
-    return (
-      <blockquote key={index} className="border-l-2 border-border pl-3 italic">
-        {renderInlineNodes(block.children)}
-      </blockquote>
-    );
-  }
-
-  if (block.type === "list") {
-    return (
-      <ul key={index} className="list-disc space-y-1 pl-5">
-        {block.items.map((item, itemIndex) => (
-          <li key={itemIndex}>{renderInlineNodes(item)}</li>
-        ))}
-      </ul>
-    );
-  }
-
-  return <p key={index}>{renderInlineNodes(block.children)}</p>;
-}
-
-function FormattedNoteContent({
-  markdown,
-  className,
-}: {
-  markdown: string;
-  className?: string;
-}) {
-  const blocks = parseNoteMarkdown(markdown);
-
-  return (
-    <div className={cn("space-y-2 whitespace-normal", className)}>
-      {blocks.map(renderNoteBlock)}
-    </div>
-  );
-}
-
 function FilterSelect({
   label,
   value,
@@ -1343,35 +1283,20 @@ function LibraryNoteCard({ note, onBook }: { note: LibraryNote; onBook: (book: B
       </div>
 
       {note.label === "quote" ? (
-        <div className="grid grid-cols-[3rem_1fr] gap-x-4">
-          <div className="flex flex-col items-center">
-            <div
-              aria-hidden="true"
-              className="font-serif text-5xl leading-none text-sky-600 dark:text-sky-400"
-            >
-              “
-            </div>
-            <div className="-mt-3 w-px flex-1 bg-sky-500 dark:bg-sky-400" />
-          </div>
-          <div className="min-w-0">
-            <FormattedNoteContent
-              markdown={note.content}
-              className="line-clamp-4 font-serif text-sm italic leading-6 text-foreground"
-            />
-            {(note.quote_speaker || pageLabel) && (
-              <div className="mt-2 flex flex-wrap items-center gap-2">
+        <QuoteBlock
+          attribution={
+            note.quote_speaker || pageLabel ? (
+              <div className="flex flex-wrap items-center gap-2">
                 {note.quote_speaker && (
-                  <span className="font-serif text-sm italic text-muted-foreground">
-                    - {note.quote_speaker}
-                  </span>
+                  <span className="font-serif italic">- {note.quote_speaker}</span>
                 )}
-                {pageLabel && (
-                  <span className="text-xs font-medium text-muted-foreground">{pageLabel}</span>
-                )}
+                {pageLabel && <span className="text-xs font-medium">{pageLabel}</span>}
               </div>
-            )}
-          </div>
-        </div>
+            ) : null
+          }
+        >
+          <FormattedNoteContent markdown={note.content} className="line-clamp-4" />
+        </QuoteBlock>
       ) : (
         <>
           {note.title && (

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { BookOpen, Check, SlidersHorizontal } from "lucide-react";
+import QuoteBlock from "@/components/QuoteBlock";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -351,36 +352,21 @@ function NoteSearchResult({
       </div>
 
       {note.label === "quote" ? (
-        <div className="grid grid-cols-[3rem_1fr] gap-x-4">
-          <div className="flex flex-col items-center">
-            <div
-              aria-hidden="true"
-              className="font-serif text-5xl leading-none text-sky-600 dark:text-sky-400"
-            >
-              “
-            </div>
-            <div className="-mt-3 w-px flex-1 bg-sky-500 dark:bg-sky-400" />
-          </div>
-          <div className="min-w-0">
-            <p className="line-clamp-3 whitespace-pre-line font-serif text-sm italic leading-6 text-foreground">
-              <HighlightedText value={match.values[0]} query={query} />
-            </p>
-            {(note.quote_speaker || pageLabel) && (
-              <div className="mt-2 flex flex-wrap items-center gap-2">
+        <QuoteBlock
+          attribution={
+            note.quote_speaker || pageLabel ? (
+              <div className="flex flex-wrap items-center gap-2">
                 {note.quote_speaker && (
-                  <span className="font-serif text-sm italic text-muted-foreground">
-                    - {note.quote_speaker}
-                  </span>
+                  <span className="font-serif italic">- {note.quote_speaker}</span>
                 )}
-                {pageLabel && (
-                  <span className="text-xs font-medium text-muted-foreground">
-                    {pageLabel}
-                  </span>
-                )}
+                {pageLabel && <span className="text-xs font-medium">{pageLabel}</span>}
               </div>
-            )}
-          </div>
-        </div>
+            ) : null
+          }
+          contentClassName="line-clamp-3 whitespace-pre-line"
+        >
+          <HighlightedText value={match.values[0]} query={query} />
+        </QuoteBlock>
       ) : (
         <>
           {note.title && (

--- a/src/pages/SeriesDetails.tsx
+++ b/src/pages/SeriesDetails.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { Link, useParams } from "react-router-dom";
 import { ArrowLeft, BookOpen, Check, Flag, Heart, Star } from "lucide-react";
+import QuoteBlock from "@/components/QuoteBlock";
 import ReadingProgressDialog from "@/components/ReadingProgressDialog";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -327,13 +328,13 @@ function SeriesRankingCard({
 function FavoriteQuoteCard({ book, note }: { book: Book; note: BookNote }) {
   return (
     <article className="flex min-h-48 flex-col rounded-xl border bg-card p-5">
-      <Heart className="h-4 w-4 fill-foreground text-foreground" aria-hidden />
-      <p className="mt-4 line-clamp-5 whitespace-pre-line font-serif text-base italic leading-7">
-        &ldquo;{note.content.trim()}&rdquo;
-      </p>
-      {note.quote_speaker && (
-        <p className="mt-2 text-sm text-muted-foreground">- {note.quote_speaker}</p>
-      )}
+      <QuoteBlock
+        contentClassName="line-clamp-5 whitespace-pre-line text-base leading-7"
+        attribution={note.quote_speaker ? `- ${note.quote_speaker}` : null}
+        actions={<Heart className="h-4 w-4 fill-foreground text-foreground" aria-hidden />}
+      >
+        {note.content.trim()}
+      </QuoteBlock>
       <Link
         to={`/books/${book.id}?tab=notes`}
         className="mt-auto flex items-center gap-3 pt-5 transition-colors hover:text-muted-foreground"
@@ -505,14 +506,20 @@ function JourneyFeaturedNote({ bookId, notes }: { bookId: string; notes: BookNot
             }}
             className="absolute inset-x-0 whitespace-pre-line font-serif text-sm italic leading-6"
           >
-            &ldquo;{note.content.trim()}&rdquo;
+            {note.content.trim()}
           </p>
         ))}
       </div>
       {selectedNote && (
-        <p className="line-clamp-4 whitespace-pre-line font-serif text-sm italic leading-6 text-foreground">
-          &ldquo;{selectedNote.content.trim()}&rdquo;
-        </p>
+        selectedNote.label === "quote" ? (
+          <QuoteBlock contentClassName="line-clamp-4 whitespace-pre-line">
+            {selectedNote.content.trim()}
+          </QuoteBlock>
+        ) : (
+          <p className="line-clamp-4 whitespace-pre-line text-sm leading-6 text-foreground">
+            {selectedNote.content.trim()}
+          </p>
+        )
       )}
       {notes.length > 0 && (
         <Link


### PR DESCRIPTION
## Summary

Adds a universal quote presentation so quote styling is controlled from one shared component instead of being duplicated across pages.

## Implementation

- Added `QuoteBlock` as the single source for the displayed quote layout, including the green quotation mark, italic quote text, attribution area, and optional actions.
- Added `FormattedNoteContent` so rendered Markdown note content can reuse the same quote design for blockquote blocks.
- Replaced one-off quote layouts in book notes, Explore Library, Search, Author Details, and Series Details.
- Kept the note editor’s blockquote styling lightweight while saved/rendered quotes use the shared visual design.
- Slightly reduced the green quote mark size after review.

## Validation

- `npm test` passed: 90 tests.
- `npm run build` passed.
- `npx tsc --noEmit` passed after the final quote-mark size adjustment.

Note: the production build still reports the existing Vite large chunk warning for the main bundle; the build completes successfully.