### PR TITLE
[codex] Implement settings page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { RouterProvider } from "react-router-dom";
-import { AuthProvider, ThemeProvider } from "@/context";
+import { AuthProvider, ThemeProvider, UserSettingsProvider } from "@/context";
 import BookFinishedCelebration from "@/components/BookFinishedCelebration";
 import { router } from "@/lib/router";
 
@@ -7,8 +7,10 @@ export default function App() {
   return (
     <ThemeProvider>
       <AuthProvider>
-        <RouterProvider router={router} />
-        <BookFinishedCelebration />
+        <UserSettingsProvider>
+          <RouterProvider router={router} />
+          <BookFinishedCelebration />
+        </UserSettingsProvider>
       </AuthProvider>
     </ThemeProvider>
   );

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -84,6 +84,8 @@ function getDisplayName(
   profile: ReturnType<typeof useProfile>["profile"],
   email?: string | null,
 ): string {
+  if (profile?.display_name?.trim()) return profile.display_name.trim();
+
   const name = [profile?.first_name, profile?.last_name]
     .map((part) => part?.trim())
     .filter(Boolean)

--- a/src/context/UserSettingsContext.tsx
+++ b/src/context/UserSettingsContext.tsx
@@ -1,0 +1,141 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useAuth } from "@/context/AuthContext";
+import { useTheme } from "@/context/ThemeContext";
+import {
+  buildSectionUpdate,
+  getMySettings,
+  upsertMySettings,
+} from "@/lib/userSettings";
+import { getErrorMessage } from "@/lib/profiles";
+import type {
+  UserSettings,
+  UserSettingsSections,
+  UserSettingsUpdate,
+} from "@/types";
+
+interface UserSettingsContextValue {
+  settings: UserSettings | null;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+  refreshSettings: () => Promise<UserSettings | null>;
+  saveSettings: (update: UserSettingsUpdate) => Promise<UserSettings>;
+  saveSettingsSection: <Key extends keyof UserSettingsSections>(
+    section: Key,
+    values: Partial<UserSettingsSections[Key]>,
+  ) => Promise<UserSettings>;
+}
+
+const UserSettingsContext = createContext<UserSettingsContextValue | null>(null);
+
+export function UserSettingsProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const { setTheme } = useTheme();
+  const [settings, setSettings] = useState<UserSettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshSettings = useCallback(async () => {
+    if (!user) {
+      setSettings(null);
+      setLoading(false);
+      setError(null);
+      return null;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const nextSettings = await getMySettings();
+      setSettings(nextSettings);
+      return nextSettings;
+    } catch (settingsError) {
+      setError(getErrorMessage(settingsError, "Could not load settings."));
+      throw settingsError;
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void refreshSettings();
+  }, [refreshSettings]);
+
+  useEffect(() => {
+    if (!settings) return;
+    setTheme(settings.appearance.theme);
+  }, [setTheme, settings?.appearance.theme]);
+
+  const saveSettings = useCallback(
+    async (update: UserSettingsUpdate) => {
+      if (!user) throw new Error("You must be signed in.");
+
+      setSaving(true);
+      setError(null);
+      try {
+        const savedSettings = await upsertMySettings(update);
+        setSettings(savedSettings);
+        setTheme(savedSettings.appearance.theme);
+        return savedSettings;
+      } catch (settingsError) {
+        setError(getErrorMessage(settingsError, "Could not save settings."));
+        throw settingsError;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [setTheme, user],
+  );
+
+  const saveSettingsSection = useCallback(
+    <Key extends keyof UserSettingsSections>(
+      section: Key,
+      values: Partial<UserSettingsSections[Key]>,
+    ) => saveSettings(buildSectionUpdate(section, values)),
+    [saveSettings],
+  );
+
+  const value = useMemo<UserSettingsContextValue>(
+    () => ({
+      settings,
+      loading,
+      saving,
+      error,
+      refreshSettings,
+      saveSettings,
+      saveSettingsSection,
+    }),
+    [
+      settings,
+      loading,
+      saving,
+      error,
+      refreshSettings,
+      saveSettings,
+      saveSettingsSection,
+    ],
+  );
+
+  return (
+    <UserSettingsContext.Provider value={value}>
+      {children}
+    </UserSettingsContext.Provider>
+  );
+}
+
+export function useUserSettings(): UserSettingsContextValue {
+  const context = useContext(UserSettingsContext);
+  if (!context) {
+    throw new Error("useUserSettings must be used within <UserSettingsProvider>");
+  }
+  return context;
+}

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -3,3 +3,4 @@ export { BooksProvider, useBooksContext } from "./BooksContext";
 export { ProfileProvider, useProfile } from "./ProfileContext";
 export { ThemeProvider, useTheme } from "./ThemeContext";
 export type { Theme } from "./ThemeContext";
+export { UserSettingsProvider, useUserSettings } from "./UserSettingsContext";

--- a/src/lib/profileForm.ts
+++ b/src/lib/profileForm.ts
@@ -1,7 +1,9 @@
 import type { Profile } from "@/types";
 import type { ProfilePayload } from "@/lib/profiles";
 
-export type ProfileForm = Required<ProfilePayload>;
+export type ProfileForm = Required<
+  Pick<ProfilePayload, "first_name" | "last_name" | "avatar_url" | "bio" | "timezone" | "language">
+>;
 
 export const emptyProfileForm: ProfileForm = {
   first_name: "",

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -6,7 +6,19 @@ import type {
   Profile,
 } from "@/types";
 
-type NullableProfileRow = Omit<Profile, "first_name" | "last_name" | "avatar_url" | "bio" | "timezone" | "language"> & {
+type NullableProfileRow = Omit<
+  Profile,
+  | "display_name"
+  | "username"
+  | "first_name"
+  | "last_name"
+  | "avatar_url"
+  | "bio"
+  | "timezone"
+  | "language"
+> & {
+  display_name: string | null;
+  username: string | null;
   first_name: string | null;
   last_name: string | null;
   avatar_url: string | null;
@@ -21,7 +33,17 @@ type NullableGroupRow = Omit<Group, "description" | "avatar_url"> & {
 };
 
 export type ProfilePayload = Partial<
-  Pick<Profile, "first_name" | "last_name" | "avatar_url" | "bio" | "timezone" | "language">
+  Pick<
+    Profile,
+    | "display_name"
+    | "username"
+    | "first_name"
+    | "last_name"
+    | "avatar_url"
+    | "bio"
+    | "timezone"
+    | "language"
+  >
 >;
 
 export type GroupPayload = Pick<Group, "name"> &
@@ -38,6 +60,8 @@ export function getErrorMessage(error: unknown, fallback: string): string {
 function normalizeProfile(row: NullableProfileRow): Profile {
   return {
     id: row.id,
+    display_name: row.display_name ?? undefined,
+    username: row.username ?? undefined,
     first_name: row.first_name ?? undefined,
     last_name: row.last_name ?? undefined,
     avatar_url: row.avatar_url ?? undefined,

--- a/src/lib/userSettings.ts
+++ b/src/lib/userSettings.ts
@@ -1,0 +1,218 @@
+import { supabase } from "./supabase";
+import type {
+  AppearanceSettings,
+  BackupSettings,
+  CollectionSettings,
+  LibrarySettings,
+  NotificationSettings,
+  PrivacySettings,
+  ReadingSettings,
+  UserSettings,
+  UserSettingsSections,
+  UserSettingsUpdate,
+} from "@/types";
+
+type SettingsSectionKey = keyof UserSettingsSections;
+
+type UserSettingsRow = {
+  user_id: string;
+  appearance: unknown;
+  reading: unknown;
+  library: unknown;
+  collections: unknown;
+  notifications: unknown;
+  privacy: unknown;
+  backup: unknown;
+  created_at: string;
+  updated_at: string;
+};
+
+export const DEFAULT_APPEARANCE_SETTINGS: AppearanceSettings = {
+  theme: "system",
+  accent_color: "default",
+  compact_mode: false,
+  reduced_animations: false,
+  book_cover_style: "rounded",
+  corner_radius: "medium",
+  font_size: "medium",
+  density: "comfortable",
+};
+
+export const DEFAULT_READING_SETTINGS: ReadingSettings = {
+  default_reading_status: "Wishlist",
+  reading_pace_calculation: "recent_logs",
+  progress_display: "percentage",
+  reading_streak_enabled: true,
+  reading_streak_goal_days: 7,
+  auto_finish_books: true,
+  estimated_completion_dates: true,
+};
+
+export const DEFAULT_LIBRARY_SETTINGS: LibrarySettings = {
+  default_sorting: "recently_added",
+  default_view: "grid",
+  default_filters: {},
+  show_unfinished_series_first: true,
+  hide_completed_books: false,
+  show_reading_statistics: true,
+};
+
+export const DEFAULT_COLLECTION_SETTINGS: CollectionSettings = {
+  collection_visibility: "private",
+  automatic_collections: true,
+  smart_collections: true,
+  collection_behavior: "manual_and_smart",
+};
+
+export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
+  reading_reminders: false,
+  weekly_summary: false,
+  daily_goal_reminders: false,
+  goal_completion_notifications: true,
+  friend_activity_notifications: false,
+  new_follower_notifications: false,
+};
+
+export const DEFAULT_PRIVACY_SETTINGS: PrivacySettings = {
+  private_account: true,
+  show_reading_activity: false,
+  show_reading_statistics_publicly: false,
+  show_reading_goals_publicly: false,
+  allow_followers: false,
+  blocked_users: [],
+};
+
+export const DEFAULT_BACKUP_SETTINGS: BackupSettings = {
+  automatic_backups: false,
+  backup_frequency: "manual",
+  last_backup_at: null,
+};
+
+export const DEFAULT_SETTINGS_SECTIONS: UserSettingsSections = {
+  appearance: DEFAULT_APPEARANCE_SETTINGS,
+  reading: DEFAULT_READING_SETTINGS,
+  library: DEFAULT_LIBRARY_SETTINGS,
+  collections: DEFAULT_COLLECTION_SETTINGS,
+  notifications: DEFAULT_NOTIFICATION_SETTINGS,
+  privacy: DEFAULT_PRIVACY_SETTINGS,
+  backup: DEFAULT_BACKUP_SETTINGS,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeSection<TSection extends object>(
+  defaults: TSection,
+  stored: unknown,
+  update?: Partial<TSection>,
+): TSection {
+  const storedValues = isRecord(stored) ? stored : {};
+  return {
+    ...defaults,
+    ...storedValues,
+    ...update,
+  } as TSection;
+}
+
+async function getCurrentUserId(): Promise<string> {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error) throw error;
+  if (!user) throw new Error("You must be signed in.");
+  return user.id;
+}
+
+function normalizeSettings(row: UserSettingsRow): UserSettings {
+  return {
+    user_id: row.user_id,
+    appearance: mergeSection(DEFAULT_APPEARANCE_SETTINGS, row.appearance),
+    reading: mergeSection(DEFAULT_READING_SETTINGS, row.reading),
+    library: mergeSection(DEFAULT_LIBRARY_SETTINGS, row.library),
+    collections: mergeSection(DEFAULT_COLLECTION_SETTINGS, row.collections),
+    notifications: mergeSection(DEFAULT_NOTIFICATION_SETTINGS, row.notifications),
+    privacy: mergeSection(DEFAULT_PRIVACY_SETTINGS, row.privacy),
+    backup: mergeSection(DEFAULT_BACKUP_SETTINGS, row.backup),
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+function toSettingsPayload(settings: UserSettings): UserSettingsSections & { user_id: string } {
+  return {
+    user_id: settings.user_id,
+    appearance: settings.appearance,
+    reading: settings.reading,
+    library: settings.library,
+    collections: settings.collections,
+    notifications: settings.notifications,
+    privacy: settings.privacy,
+    backup: settings.backup,
+  };
+}
+
+export function mergeUserSettings(
+  settings: UserSettings,
+  update: UserSettingsUpdate,
+): UserSettings {
+  return {
+    ...settings,
+    appearance: mergeSection(DEFAULT_APPEARANCE_SETTINGS, settings.appearance, update.appearance),
+    reading: mergeSection(DEFAULT_READING_SETTINGS, settings.reading, update.reading),
+    library: mergeSection(DEFAULT_LIBRARY_SETTINGS, settings.library, update.library),
+    collections: mergeSection(DEFAULT_COLLECTION_SETTINGS, settings.collections, update.collections),
+    notifications: mergeSection(
+      DEFAULT_NOTIFICATION_SETTINGS,
+      settings.notifications,
+      update.notifications,
+    ),
+    privacy: mergeSection(DEFAULT_PRIVACY_SETTINGS, settings.privacy, update.privacy),
+    backup: mergeSection(DEFAULT_BACKUP_SETTINGS, settings.backup, update.backup),
+  };
+}
+
+export async function getMySettings(): Promise<UserSettings> {
+  const userId = await getCurrentUserId();
+  const { data, error } = await supabase
+    .from("user_settings")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (data) return normalizeSettings(data as UserSettingsRow);
+
+  const { data: insertedData, error: insertError } = await supabase
+    .from("user_settings")
+    .insert({ user_id: userId })
+    .select("*")
+    .single();
+
+  if (insertError) throw insertError;
+  return normalizeSettings(insertedData as UserSettingsRow);
+}
+
+export async function upsertMySettings(update: UserSettingsUpdate): Promise<UserSettings> {
+  const currentSettings = await getMySettings();
+  const nextSettings = mergeUserSettings(currentSettings, update);
+  const { data, error } = await supabase
+    .from("user_settings")
+    .upsert(toSettingsPayload(nextSettings), { onConflict: "user_id" })
+    .select("*")
+    .single();
+
+  if (error) throw error;
+  return normalizeSettings(data as UserSettingsRow);
+}
+
+export function buildSectionUpdate<Key extends SettingsSectionKey>(
+  section: Key,
+  values: Partial<UserSettingsSections[Key]>,
+): UserSettingsUpdate {
+  return {
+    [section]: values,
+  } as UserSettingsUpdate;
+}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -9,6 +9,8 @@ function getDisplayName(
   profile: ReturnType<typeof useProfile>["profile"],
   email?: string | null,
 ): string {
+  if (profile?.display_name?.trim()) return profile.display_name.trim();
+
   const name = [profile?.first_name, profile?.last_name]
     .map((part) => part?.trim())
     .filter(Boolean)
@@ -22,6 +24,7 @@ export default function Profile() {
   const { profile, loading, error } = useProfile();
   const displayName = getDisplayName(profile, user?.email);
   const details = [
+    profile?.username ? { label: "Username", value: `@${profile.username}` } : null,
     profile?.bio ? { label: "Bio", value: profile.bio } : null,
     profile?.timezone ? { label: "Timezone", value: profile.timezone } : null,
     profile?.language ? { label: "Language", value: profile.language } : null,

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,52 +1,424 @@
-import { useEffect, useState, type FormEvent } from "react";
-import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
-import { Bell, Check, ChevronLeft, ChevronRight, KeyRound, Monitor, Shield, UserRound } from "lucide-react";
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { Link, Navigate, useParams } from "react-router-dom";
+import {
+  Bell,
+  BookOpen,
+  Database,
+  Download,
+  Info,
+  KeyRound,
+  Lock,
+  LogOut,
+  Monitor,
+  Save,
+  Shield,
+  Trash2,
+  Upload,
+  UserRound,
+  type LucideIcon,
+} from "lucide-react";
 import SetPasswordDialog from "@/components/SetPasswordDialog";
-import { ProfileForm } from "@/components/profile/ProfileForm";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { useProfile, useTheme, type Theme } from "@/context";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useAuth, useProfile, useTheme, useUserSettings } from "@/context";
 import { getErrorMessage } from "@/lib/profiles";
-import { cleanProfilePayload, emptyProfileForm, profileToForm, type ProfileForm as ProfileFormValues } from "@/lib/profileForm";
+import { supabase } from "@/lib/supabase";
+import {
+  DEFAULT_APPEARANCE_SETTINGS,
+  DEFAULT_BACKUP_SETTINGS,
+  DEFAULT_COLLECTION_SETTINGS,
+  DEFAULT_LIBRARY_SETTINGS,
+  DEFAULT_NOTIFICATION_SETTINGS,
+  DEFAULT_PRIVACY_SETTINGS,
+  DEFAULT_READING_SETTINGS,
+} from "@/lib/userSettings";
 import { cn } from "@/lib/utils";
+import type {
+  AccentColor,
+  AppearanceSettings as AppearanceSettingsValues,
+  BackupFrequency,
+  BookCoverStyle,
+  BookStatus,
+  CollectionBehavior,
+  CollectionSettings as CollectionSettingsValues,
+  CollectionVisibility,
+  CornerRadiusStyle,
+  DensityPreference,
+  FontSizePreference,
+  LibrarySettings as LibrarySettingsValues,
+  LibrarySorting,
+  LibraryView,
+  NotificationSettings as NotificationSettingsValues,
+  PrivacySettings as PrivacySettingsValues,
+  ProgressDisplay,
+  ReadingPaceCalculation,
+  ReadingSettings as ReadingSettingsValues,
+} from "@/types";
 
-type SettingsTab = "profile" | "account" | "notification" | "appearance";
+type SettingsTab =
+  | "profile"
+  | "appearance"
+  | "reading"
+  | "notifications"
+  | "account"
+  | "about";
+
+type ProfileSettingsForm = {
+  display_name: string;
+  username: string;
+  avatar_url: string;
+  bio: string;
+};
+
+type SelectOption<TValue extends string> = {
+  value: TValue;
+  label: string;
+};
+
+const APP_VERSION = "0.0.0";
 
 const settingsTabs: Array<{
   value: SettingsTab;
   label: string;
-  icon: typeof UserRound;
+  icon: LucideIcon;
 }> = [
   { value: "profile", label: "Profile", icon: UserRound },
-  { value: "account", label: "Account", icon: Shield },
-  { value: "notification", label: "Notification", icon: Bell },
   { value: "appearance", label: "Appearance", icon: Monitor },
+  { value: "reading", label: "Reading", icon: BookOpen },
+  { value: "notifications", label: "Notifications", icon: Bell },
+  { value: "account", label: "Account", icon: Shield },
+  { value: "about", label: "About", icon: Info },
 ];
+
+const legacyTabRedirects: Record<string, SettingsTab> = {
+  notification: "notifications",
+};
+
+const themeOptions = [
+  { value: "system", label: "System" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+] satisfies Array<SelectOption<AppearanceSettingsValues["theme"]>>;
+
+const accentColorOptions = [
+  { value: "default", label: "Default" },
+  { value: "rose", label: "Rose" },
+  { value: "orange", label: "Orange" },
+  { value: "green", label: "Green" },
+  { value: "blue", label: "Blue" },
+  { value: "violet", label: "Violet" },
+] satisfies Array<SelectOption<AccentColor>>;
+
+const bookCoverStyleOptions = [
+  { value: "rounded", label: "Rounded" },
+  { value: "square", label: "Square" },
+  { value: "soft", label: "Soft" },
+] satisfies Array<SelectOption<BookCoverStyle>>;
+
+const cornerRadiusOptions = [
+  { value: "none", label: "None" },
+  { value: "small", label: "Small" },
+  { value: "medium", label: "Medium" },
+  { value: "large", label: "Large" },
+] satisfies Array<SelectOption<CornerRadiusStyle>>;
+
+const fontSizeOptions = [
+  { value: "small", label: "Small" },
+  { value: "medium", label: "Medium" },
+  { value: "large", label: "Large" },
+] satisfies Array<SelectOption<FontSizePreference>>;
+
+const densityOptions = [
+  { value: "comfortable", label: "Comfortable" },
+  { value: "compact", label: "Compact" },
+  { value: "spacious", label: "Spacious" },
+] satisfies Array<SelectOption<DensityPreference>>;
+
+const statusOptions = [
+  { value: "Wishlist", label: "Wishlist" },
+  { value: "Not Started", label: "Not Started" },
+  { value: "Up Next", label: "Up Next" },
+  { value: "Reading", label: "Reading" },
+  { value: "Finished", label: "Finished" },
+  { value: "DNF", label: "DNF" },
+] satisfies Array<SelectOption<BookStatus>>;
+
+const paceOptions = [
+  { value: "recent_logs", label: "Recent logs" },
+  { value: "all_logs", label: "All logs" },
+  { value: "manual", label: "Manual" },
+] satisfies Array<SelectOption<ReadingPaceCalculation>>;
+
+const progressDisplayOptions = [
+  { value: "percentage", label: "Percentage" },
+  { value: "pages", label: "Pages" },
+  { value: "both", label: "Both" },
+] satisfies Array<SelectOption<ProgressDisplay>>;
+
+const librarySortingOptions = [
+  { value: "recently_added", label: "Recently added" },
+  { value: "title", label: "Title" },
+  { value: "author", label: "Author" },
+  { value: "rating", label: "Rating" },
+  { value: "status", label: "Status" },
+] satisfies Array<SelectOption<LibrarySorting>>;
+
+const libraryViewOptions = [
+  { value: "grid", label: "Grid" },
+  { value: "list", label: "List" },
+  { value: "compact", label: "Compact" },
+] satisfies Array<SelectOption<LibraryView>>;
+
+const collectionVisibilityOptions = [
+  { value: "private", label: "Private" },
+  { value: "followers", label: "Followers" },
+  { value: "public", label: "Public" },
+] satisfies Array<SelectOption<CollectionVisibility>>;
+
+const collectionBehaviorOptions = [
+  { value: "manual", label: "Manual" },
+  { value: "smart", label: "Smart" },
+  { value: "manual_and_smart", label: "Manual and smart" },
+] satisfies Array<SelectOption<CollectionBehavior>>;
+
+const backupFrequencyOptions = [
+  { value: "manual", label: "Manual" },
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+] satisfies Array<SelectOption<BackupFrequency>>;
 
 function isSettingsTab(value: string | undefined): value is SettingsTab {
   return settingsTabs.some((tab) => tab.value === value);
 }
 
+function getSettingsTab(value: string | undefined): SettingsTab | null {
+  if (!value) return "profile";
+  if (isSettingsTab(value)) return value;
+  return legacyTabRedirects[value] ?? null;
+}
+
+function profileToSettingsForm(profile: ReturnType<typeof useProfile>["profile"]): ProfileSettingsForm {
+  const fallbackName = [profile?.first_name, profile?.last_name]
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(" ");
+
+  return {
+    display_name: profile?.display_name ?? fallbackName,
+    username: profile?.username ?? "",
+    avatar_url: profile?.avatar_url ?? "",
+    bio: profile?.bio ?? "",
+  };
+}
+
+function cleanProfileSettingsForm(form: ProfileSettingsForm) {
+  const username = form.username.trim().toLowerCase();
+
+  return {
+    display_name: form.display_name.trim() || undefined,
+    username: username || undefined,
+    avatar_url: form.avatar_url.trim() || undefined,
+    bio: form.bio.trim() || undefined,
+  };
+}
+
+function isValidUsername(username: string): boolean {
+  return username === "" || /^[a-z0-9_]{3,30}$/.test(username);
+}
+
+function SettingsSection({
+  title,
+  description,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  description?: string;
+  icon?: LucideIcon;
+  children: ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start gap-3">
+          {Icon && (
+            <div className="mt-0.5 rounded-md bg-muted p-2 text-muted-foreground">
+              <Icon className="h-4 w-4" aria-hidden="true" />
+            </div>
+          )}
+          <div className="min-w-0">
+            <CardTitle>{title}</CardTitle>
+            {description && <CardDescription>{description}</CardDescription>}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+function SettingsRows({ children }: { children: ReactNode }) {
+  return <div className="divide-y divide-border rounded-lg border">{children}</div>;
+}
+
+function SettingRow({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="grid gap-3 px-3 py-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{title}</p>
+        {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+      </div>
+      <div className="sm:justify-self-end">{children}</div>
+    </div>
+  );
+}
+
+function SelectSetting<TValue extends string>({
+  value,
+  options,
+  onChange,
+  disabled,
+}: {
+  value: TValue;
+  options: Array<SelectOption<TValue>>;
+  onChange: (value: TValue) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Select value={value} onValueChange={(nextValue) => onChange(nextValue as TValue)} disabled={disabled}>
+      <SelectTrigger className="w-full sm:w-52">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function ToggleSetting({
+  checked,
+  onChange,
+  disabled,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Button
+      type="button"
+      variant={checked ? "default" : "outline"}
+      size="sm"
+      onClick={() => onChange(!checked)}
+      disabled={disabled}
+      aria-pressed={checked}
+      className="w-full sm:w-28"
+    >
+      {checked ? "On" : "Off"}
+    </Button>
+  );
+}
+
+function NumberSetting({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: number;
+  onChange: (value: number) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Input
+      type="number"
+      min={1}
+      max={365}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => {
+        const nextValue = Number(event.target.value);
+        if (Number.isFinite(nextValue) && nextValue >= 1) {
+          onChange(Math.min(nextValue, 365));
+        }
+      }}
+      className="w-full sm:w-28"
+    />
+  );
+}
+
+function DisabledActionButton({
+  icon: Icon,
+  children,
+}: {
+  icon?: LucideIcon;
+  children: ReactNode;
+}) {
+  return (
+    <Button type="button" variant="outline" disabled className="justify-start">
+      {Icon && <Icon className="mr-2 h-4 w-4" />}
+      {children}
+    </Button>
+  );
+}
+
 function ProfileSettings() {
   const { profile, loading, error: profileError, saveProfile } = useProfile();
-  const [form, setForm] = useState<ProfileFormValues>(emptyProfileForm);
+  const [form, setForm] = useState<ProfileSettingsForm>(() => profileToSettingsForm(profile));
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    setForm(profileToForm(profile));
+    setForm(profileToSettingsForm(profile));
   }, [profile]);
 
   async function submitProfile(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    const cleanForm = cleanProfileSettingsForm(form);
+
     setSaving(true);
     setMessage(null);
     setError(null);
 
+    if (!isValidUsername(cleanForm.username ?? "")) {
+      setSaving(false);
+      setError("Username must be 3-30 characters and use lowercase letters, numbers, or underscores.");
+      return;
+    }
+
     try {
-      const savedProfile = await saveProfile(cleanProfilePayload(form));
-      setForm(profileToForm(savedProfile));
+      const savedProfile = await saveProfile(cleanForm);
+      setForm(profileToSettingsForm(savedProfile));
       setMessage("Profile saved.");
     } catch (saveError) {
       setError(getErrorMessage(saveError, "Could not save profile."));
@@ -56,181 +428,720 @@ function ProfileSettings() {
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Profile</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          {profileError && <p className="text-sm text-destructive">{profileError}</p>}
-          {error && <p className="text-sm text-destructive">{error}</p>}
-          {message && <p className="text-sm text-muted-foreground">{message}</p>}
-          <ProfileForm
-            form={form}
+    <SettingsSection
+      title="Profile"
+      description="Personal information shown around your reading journal."
+      icon={UserRound}
+    >
+      <form className="space-y-4" onSubmit={submitProfile}>
+        {profileError && <p className="text-sm text-destructive">{profileError}</p>}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {message && <p className="text-sm text-muted-foreground">{message}</p>}
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="display-name">Display name</Label>
+            <Input
+              id="display-name"
+              value={form.display_name}
+              disabled={loading}
+              onChange={(event) => setForm({ ...form, display_name: event.target.value })}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="username">Username</Label>
+            <Input
+              id="username"
+              value={form.username}
+              disabled={loading}
+              placeholder="martina_reads"
+              onChange={(event) => setForm({ ...form, username: event.target.value.toLowerCase() })}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="avatar-url">Avatar URL</Label>
+          <Input
+            id="avatar-url"
+            value={form.avatar_url}
             disabled={loading}
-            saving={saving}
-            onSubmit={submitProfile}
-            onChange={setForm}
+            onChange={(event) => setForm({ ...form, avatar_url: event.target.value })}
           />
         </div>
-      </CardContent>
-    </Card>
+
+        <div className="space-y-2">
+          <Label htmlFor="bio">Bio</Label>
+          <Textarea
+            id="bio"
+            value={form.bio}
+            disabled={loading}
+            onChange={(event) => setForm({ ...form, bio: event.target.value })}
+          />
+        </div>
+
+        <Button type="submit" disabled={saving || loading}>
+          <Save className="mr-2 h-4 w-4" />
+          {saving ? "Saving..." : "Save profile"}
+        </Button>
+      </form>
+    </SettingsSection>
   );
 }
 
-function AccountSettings() {
-  const [passwordOpen, setPasswordOpen] = useState(false);
+function AppearanceSettings() {
+  const { setTheme } = useTheme();
+  const { settings, loading, saving, error, saveSettingsSection } = useUserSettings();
+  const appearance = settings?.appearance ?? DEFAULT_APPEARANCE_SETTINGS;
+  const disabled = loading || saving;
+
+  async function saveAppearance(update: Partial<AppearanceSettingsValues>) {
+    if (update.theme) setTheme(update.theme);
+    await saveSettingsSection("appearance", update);
+  }
 
   return (
-    <>
-      <Card>
-        <CardHeader>
-          <CardTitle>Account</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Button type="button" onClick={() => setPasswordOpen(true)}>
-            <KeyRound className="mr-2 h-4 w-4" />
-            Set password
-          </Button>
-        </CardContent>
-      </Card>
-      <SetPasswordDialog open={passwordOpen} onOpenChange={setPasswordOpen} />
-    </>
+    <SettingsSection
+      title="Appearance"
+      description="Controls for how the app looks and feels."
+      icon={Monitor}
+    >
+      <div className="space-y-4">
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <SettingsRows>
+          <SettingRow title="Theme">
+            <SelectSetting
+              value={appearance.theme}
+              options={themeOptions}
+              disabled={disabled}
+              onChange={(theme) => void saveAppearance({ theme })}
+            />
+          </SettingRow>
+          <SettingRow title="Accent color">
+            <SelectSetting
+              value={appearance.accent_color}
+              options={accentColorOptions}
+              disabled={disabled}
+              onChange={(accent_color) => void saveAppearance({ accent_color })}
+            />
+          </SettingRow>
+          <SettingRow title="Compact mode">
+            <ToggleSetting
+              checked={appearance.compact_mode}
+              disabled={disabled}
+              onChange={(compact_mode) => void saveAppearance({ compact_mode })}
+            />
+          </SettingRow>
+          <SettingRow title="Reduced animations">
+            <ToggleSetting
+              checked={appearance.reduced_animations}
+              disabled={disabled}
+              onChange={(reduced_animations) => void saveAppearance({ reduced_animations })}
+            />
+          </SettingRow>
+          <SettingRow title="Book cover style">
+            <SelectSetting
+              value={appearance.book_cover_style}
+              options={bookCoverStyleOptions}
+              disabled={disabled}
+              onChange={(book_cover_style) => void saveAppearance({ book_cover_style })}
+            />
+          </SettingRow>
+          <SettingRow title="Corner radius style">
+            <SelectSetting
+              value={appearance.corner_radius}
+              options={cornerRadiusOptions}
+              disabled={disabled}
+              onChange={(corner_radius) => void saveAppearance({ corner_radius })}
+            />
+          </SettingRow>
+          <SettingRow title="Font size">
+            <SelectSetting
+              value={appearance.font_size}
+              options={fontSizeOptions}
+              disabled={disabled}
+              onChange={(font_size) => void saveAppearance({ font_size })}
+            />
+          </SettingRow>
+          <SettingRow title="Density">
+            <SelectSetting
+              value={appearance.density}
+              options={densityOptions}
+              disabled={disabled}
+              onChange={(density) => void saveAppearance({ density })}
+            />
+          </SettingRow>
+        </SettingsRows>
+      </div>
+    </SettingsSection>
+  );
+}
+
+function ReadingSettings() {
+  const { settings, loading, saving, error, saveSettingsSection } = useUserSettings();
+  const reading = settings?.reading ?? DEFAULT_READING_SETTINGS;
+  const library = settings?.library ?? DEFAULT_LIBRARY_SETTINGS;
+  const collections = settings?.collections ?? DEFAULT_COLLECTION_SETTINGS;
+  const disabled = loading || saving;
+
+  const saveReading = (update: Partial<ReadingSettingsValues>) =>
+    saveSettingsSection("reading", update);
+  const saveLibrary = (update: Partial<LibrarySettingsValues>) =>
+    saveSettingsSection("library", update);
+  const saveCollections = (update: Partial<CollectionSettingsValues>) =>
+    saveSettingsSection("collections", update);
+
+  return (
+    <div className="space-y-4">
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <SettingsSection
+        title="Reading"
+        description="Preferences for how you track reading progress."
+        icon={BookOpen}
+      >
+        <SettingsRows>
+          <SettingRow title="Default reading status">
+            <SelectSetting
+              value={reading.default_reading_status}
+              options={statusOptions}
+              disabled={disabled}
+              onChange={(default_reading_status) => void saveReading({ default_reading_status })}
+            />
+          </SettingRow>
+          <SettingRow title="Reading pace calculation">
+            <SelectSetting
+              value={reading.reading_pace_calculation}
+              options={paceOptions}
+              disabled={disabled}
+              onChange={(reading_pace_calculation) =>
+                void saveReading({ reading_pace_calculation })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="Progress display">
+            <SelectSetting
+              value={reading.progress_display}
+              options={progressDisplayOptions}
+              disabled={disabled}
+              onChange={(progress_display) => void saveReading({ progress_display })}
+            />
+          </SettingRow>
+          <SettingRow title="Reading streak settings" description="Goal length in days.">
+            <div className="flex gap-2">
+              <ToggleSetting
+                checked={reading.reading_streak_enabled}
+                disabled={disabled}
+                onChange={(reading_streak_enabled) =>
+                  void saveReading({ reading_streak_enabled })
+                }
+              />
+              <NumberSetting
+                value={reading.reading_streak_goal_days}
+                disabled={disabled || !reading.reading_streak_enabled}
+                onChange={(reading_streak_goal_days) =>
+                  void saveReading({ reading_streak_goal_days })
+                }
+              />
+            </div>
+          </SettingRow>
+          <SettingRow title="Auto-finish books">
+            <ToggleSetting
+              checked={reading.auto_finish_books}
+              disabled={disabled}
+              onChange={(auto_finish_books) => void saveReading({ auto_finish_books })}
+            />
+          </SettingRow>
+          <SettingRow title="Estimated completion dates">
+            <ToggleSetting
+              checked={reading.estimated_completion_dates}
+              disabled={disabled}
+              onChange={(estimated_completion_dates) =>
+                void saveReading({ estimated_completion_dates })
+              }
+            />
+          </SettingRow>
+        </SettingsRows>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Library"
+        description="Defaults for sorting, filtering, and viewing your books."
+      >
+        <SettingsRows>
+          <SettingRow title="Default sorting">
+            <SelectSetting
+              value={library.default_sorting}
+              options={librarySortingOptions}
+              disabled={disabled}
+              onChange={(default_sorting) => void saveLibrary({ default_sorting })}
+            />
+          </SettingRow>
+          <SettingRow title="Default view">
+            <SelectSetting
+              value={library.default_view}
+              options={libraryViewOptions}
+              disabled={disabled}
+              onChange={(default_view) => void saveLibrary({ default_view })}
+            />
+          </SettingRow>
+          <SettingRow title="Default filters" description="Reserved for saved filter presets.">
+            <span className="text-xs text-muted-foreground">No filters selected</span>
+          </SettingRow>
+          <SettingRow title="Show unfinished series first">
+            <ToggleSetting
+              checked={library.show_unfinished_series_first}
+              disabled={disabled}
+              onChange={(show_unfinished_series_first) =>
+                void saveLibrary({ show_unfinished_series_first })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="Hide completed books">
+            <ToggleSetting
+              checked={library.hide_completed_books}
+              disabled={disabled}
+              onChange={(hide_completed_books) => void saveLibrary({ hide_completed_books })}
+            />
+          </SettingRow>
+          <SettingRow title="Show reading statistics">
+            <ToggleSetting
+              checked={library.show_reading_statistics}
+              disabled={disabled}
+              onChange={(show_reading_statistics) =>
+                void saveLibrary({ show_reading_statistics })
+              }
+            />
+          </SettingRow>
+        </SettingsRows>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Collections"
+        description="How shelves and smart collections should behave."
+      >
+        <SettingsRows>
+          <SettingRow title="Collection visibility">
+            <SelectSetting
+              value={collections.collection_visibility}
+              options={collectionVisibilityOptions}
+              disabled={disabled}
+              onChange={(collection_visibility) =>
+                void saveCollections({ collection_visibility })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="Automatic collections">
+            <ToggleSetting
+              checked={collections.automatic_collections}
+              disabled={disabled}
+              onChange={(automatic_collections) =>
+                void saveCollections({ automatic_collections })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="Smart collections">
+            <ToggleSetting
+              checked={collections.smart_collections}
+              disabled={disabled}
+              onChange={(smart_collections) => void saveCollections({ smart_collections })}
+            />
+          </SettingRow>
+          <SettingRow title="Collection behavior">
+            <SelectSetting
+              value={collections.collection_behavior}
+              options={collectionBehaviorOptions}
+              disabled={disabled}
+              onChange={(collection_behavior) =>
+                void saveCollections({ collection_behavior })
+              }
+            />
+          </SettingRow>
+        </SettingsRows>
+      </SettingsSection>
+    </div>
   );
 }
 
 function NotificationSettings() {
+  const { settings, loading, saving, error, saveSettingsSection } = useUserSettings();
+  const notifications = settings?.notifications ?? DEFAULT_NOTIFICATION_SETTINGS;
+  const disabled = loading || saving;
+
+  function saveNotifications(update: Partial<NotificationSettingsValues>) {
+    return saveSettingsSection("notifications", update);
+  }
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Notification</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <p className="text-sm text-muted-foreground">Notification settings will be added here.</p>
-      </CardContent>
-    </Card>
+    <SettingsSection
+      title="Notifications"
+      description="Reminders and social updates for your reading activity."
+      icon={Bell}
+    >
+      <div className="space-y-4">
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <SettingsRows>
+          <SettingRow title="Reading reminders">
+            <ToggleSetting
+              checked={notifications.reading_reminders}
+              disabled={disabled}
+              onChange={(reading_reminders) =>
+                void saveNotifications({ reading_reminders })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="Weekly summary">
+            <ToggleSetting
+              checked={notifications.weekly_summary}
+              disabled={disabled}
+              onChange={(weekly_summary) => void saveNotifications({ weekly_summary })}
+            />
+          </SettingRow>
+          <SettingRow title="Daily goal reminders">
+            <ToggleSetting
+              checked={notifications.daily_goal_reminders}
+              disabled={disabled}
+              onChange={(daily_goal_reminders) =>
+                void saveNotifications({ daily_goal_reminders })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="Goal completion notifications">
+            <ToggleSetting
+              checked={notifications.goal_completion_notifications}
+              disabled={disabled}
+              onChange={(goal_completion_notifications) =>
+                void saveNotifications({ goal_completion_notifications })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="Friend activity notifications">
+            <ToggleSetting
+              checked={notifications.friend_activity_notifications}
+              disabled={disabled}
+              onChange={(friend_activity_notifications) =>
+                void saveNotifications({ friend_activity_notifications })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="New follower notifications">
+            <ToggleSetting
+              checked={notifications.new_follower_notifications}
+              disabled={disabled}
+              onChange={(new_follower_notifications) =>
+                void saveNotifications({ new_follower_notifications })
+              }
+            />
+          </SettingRow>
+        </SettingsRows>
+      </div>
+    </SettingsSection>
   );
 }
 
-const themeOptions: Array<{ value: Theme; label: string }> = [
-  { value: "system", label: "System" },
-  { value: "light", label: "Light" },
-  { value: "dark", label: "Dark" },
-];
+function AccountSettings() {
+  const { user, signOut } = useAuth();
+  const { settings, loading, saving, error, saveSettingsSection } = useUserSettings();
+  const [passwordOpen, setPasswordOpen] = useState(false);
+  const [email, setEmail] = useState(user?.email ?? "");
+  const [emailSaving, setEmailSaving] = useState(false);
+  const [emailMessage, setEmailMessage] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const privacy = settings?.privacy ?? DEFAULT_PRIVACY_SETTINGS;
+  const backup = settings?.backup ?? DEFAULT_BACKUP_SETTINGS;
+  const disabled = loading || saving;
 
-function AppearanceSettings() {
-  const { theme, setTheme } = useTheme();
+  useEffect(() => {
+    setEmail(user?.email ?? "");
+  }, [user?.email]);
+
+  function savePrivacy(update: Partial<PrivacySettingsValues>) {
+    return saveSettingsSection("privacy", update);
+  }
+
+  function saveBackup(update: Partial<typeof backup>) {
+    return saveSettingsSection("backup", update);
+  }
+
+  async function submitEmail(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setEmailSaving(true);
+    setEmailMessage(null);
+    setEmailError(null);
+
+    try {
+      const nextEmail = email.trim();
+      if (!nextEmail) throw new Error("Email is required.");
+      const { error: updateError } = await supabase.auth.updateUser({ email: nextEmail });
+      if (updateError) throw updateError;
+      setEmailMessage("Check your inbox to confirm the email change.");
+    } catch (updateError) {
+      setEmailError(getErrorMessage(updateError, "Could not update email."));
+    } finally {
+      setEmailSaving(false);
+    }
+  }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Appearance</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="grid gap-2 sm:grid-cols-3">
-          {themeOptions.map((option) => {
-            const active = option.value === theme;
+    <div className="space-y-4">
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <SettingsSection
+        title="Security"
+        description="Sign-in details for your account."
+        icon={KeyRound}
+      >
+        <div className="space-y-4">
+          <form className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto]" onSubmit={submitEmail}>
+            <div className="space-y-2">
+              <Label htmlFor="account-email">Email</Label>
+              <Input
+                id="account-email"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+              {emailMessage && <p className="text-sm text-muted-foreground">{emailMessage}</p>}
+              {emailError && <p className="text-sm text-destructive">{emailError}</p>}
+            </div>
+            <Button
+              type="submit"
+              variant="outline"
+              disabled={emailSaving || email.trim() === (user?.email ?? "")}
+              className="self-end"
+            >
+              {emailSaving ? "Saving..." : "Change email"}
+            </Button>
+          </form>
 
-            return (
-              <Button
-                key={option.value}
-                type="button"
-                variant={active ? "default" : "outline"}
-                onClick={() => setTheme(option.value)}
-                aria-pressed={active}
-                className="justify-start"
-              >
-                {active && <Check className="mr-2 h-4 w-4" />}
-                {!active && <span className="mr-2 h-4 w-4" aria-hidden="true" />}
-                {option.label}
-              </Button>
-            );
-          })}
+          <Button type="button" variant="outline" onClick={() => setPasswordOpen(true)}>
+            <KeyRound className="mr-2 h-4 w-4" />
+            Change password
+          </Button>
         </div>
-      </CardContent>
-    </Card>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Privacy"
+        description="Control what other readers can see."
+        icon={Lock}
+      >
+        <SettingsRows>
+          <SettingRow title="Private account">
+            <ToggleSetting
+              checked={privacy.private_account}
+              disabled={disabled}
+              onChange={(private_account) => void savePrivacy({ private_account })}
+            />
+          </SettingRow>
+          <SettingRow title="Show reading activity">
+            <ToggleSetting
+              checked={privacy.show_reading_activity}
+              disabled={disabled}
+              onChange={(show_reading_activity) =>
+                void savePrivacy({ show_reading_activity })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="Show reading statistics publicly">
+            <ToggleSetting
+              checked={privacy.show_reading_statistics_publicly}
+              disabled={disabled}
+              onChange={(show_reading_statistics_publicly) =>
+                void savePrivacy({ show_reading_statistics_publicly })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="Show reading goals publicly">
+            <ToggleSetting
+              checked={privacy.show_reading_goals_publicly}
+              disabled={disabled}
+              onChange={(show_reading_goals_publicly) =>
+                void savePrivacy({ show_reading_goals_publicly })
+              }
+            />
+          </SettingRow>
+          <SettingRow title="Allow followers">
+            <ToggleSetting
+              checked={privacy.allow_followers}
+              disabled={disabled}
+              onChange={(allow_followers) => void savePrivacy({ allow_followers })}
+            />
+          </SettingRow>
+          <SettingRow title="Blocked users" description="Blocking management will come with social features.">
+            <span className="text-xs text-muted-foreground">
+              {privacy.blocked_users.length} blocked
+            </span>
+          </SettingRow>
+        </SettingsRows>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Data & Backup"
+        description="Exports, imports, and restore options."
+        icon={Database}
+      >
+        <div className="space-y-4">
+          <SettingsRows>
+            <SettingRow title="Backup settings">
+              <ToggleSetting
+                checked={backup.automatic_backups}
+                disabled={disabled}
+                onChange={(automatic_backups) => void saveBackup({ automatic_backups })}
+              />
+            </SettingRow>
+            <SettingRow title="Backup frequency">
+              <SelectSetting
+                value={backup.backup_frequency}
+                options={backupFrequencyOptions}
+                disabled={disabled || !backup.automatic_backups}
+                onChange={(backup_frequency) => void saveBackup({ backup_frequency })}
+              />
+            </SettingRow>
+          </SettingsRows>
+
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            <DisabledActionButton icon={Download}>Export library</DisabledActionButton>
+            <DisabledActionButton icon={Download}>Export notes</DisabledActionButton>
+            <DisabledActionButton icon={Download}>Export quotes</DisabledActionButton>
+            <DisabledActionButton icon={Upload}>Import data</DisabledActionButton>
+            <DisabledActionButton>Restore backup</DisabledActionButton>
+          </div>
+        </div>
+      </SettingsSection>
+
+      <SettingsSection title="Danger Zone" description="Account exit and deletion actions.">
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="outline" onClick={() => void signOut()}>
+            <LogOut className="mr-2 h-4 w-4" />
+            Log out
+          </Button>
+          <Button type="button" variant="destructive" disabled>
+            <Trash2 className="mr-2 h-4 w-4" />
+            Delete account
+          </Button>
+        </div>
+      </SettingsSection>
+
+      <SetPasswordDialog open={passwordOpen} onOpenChange={setPasswordOpen} />
+    </div>
+  );
+}
+
+function AboutSettings() {
+  return (
+    <SettingsSection
+      title="About"
+      description="Project information and support links."
+      icon={Info}
+    >
+      <SettingsRows>
+        <SettingRow title="App version">
+          <span className="text-sm text-muted-foreground">{APP_VERSION}</span>
+        </SettingRow>
+        <SettingRow title="Changelog">
+          <Button type="button" variant="outline" size="sm" disabled>
+            View changelog
+          </Button>
+        </SettingRow>
+        <SettingRow title="Documentation">
+          <Button type="button" variant="outline" size="sm" disabled>
+            Open docs
+          </Button>
+        </SettingRow>
+        <SettingRow title="GitHub">
+          <Button type="button" variant="outline" size="sm" disabled>
+            Open GitHub
+          </Button>
+        </SettingRow>
+        <SettingRow title="Report bug">
+          <Button type="button" variant="outline" size="sm" disabled>
+            Report bug
+          </Button>
+        </SettingRow>
+        <SettingRow title="Feature requests">
+          <Button type="button" variant="outline" size="sm" disabled>
+            Request feature
+          </Button>
+        </SettingRow>
+        <SettingRow title="Licenses">
+          <Button type="button" variant="outline" size="sm" disabled>
+            View licenses
+          </Button>
+        </SettingRow>
+      </SettingsRows>
+    </SettingsSection>
   );
 }
 
 function SettingsTabContent({ tab }: { tab: SettingsTab }) {
   if (tab === "profile") return <ProfileSettings />;
+  if (tab === "appearance") return <AppearanceSettings />;
+  if (tab === "reading") return <ReadingSettings />;
+  if (tab === "notifications") return <NotificationSettings />;
   if (tab === "account") return <AccountSettings />;
-  if (tab === "notification") return <NotificationSettings />;
-  return <AppearanceSettings />;
+  return <AboutSettings />;
 }
 
-function SettingsList({ activeTab }: { activeTab?: SettingsTab }) {
+function SettingsTabs({ activeTab }: { activeTab: SettingsTab }) {
   return (
-    <nav className="space-y-1">
-      {settingsTabs.map(({ value, label, icon: Icon }) => {
-        const active = value === activeTab;
+    <nav
+      className="-mx-4 overflow-x-auto px-4 sm:-mx-6 sm:px-6 md:mx-0 md:px-0"
+      aria-label="Settings sections"
+    >
+      <div className="flex min-w-max gap-1 rounded-lg bg-muted p-1 md:min-w-0">
+        {settingsTabs.map(({ value, label, icon: Icon }) => {
+          const active = value === activeTab;
 
-        return (
-          <Link
-            key={value}
-            to={`/settings/${value}`}
-            className={cn(
-              "flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors",
-              active
-                ? "bg-muted font-medium text-foreground"
-                : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
-            )}
-          >
-            <Icon className="h-4 w-4" aria-hidden="true" />
-            <span className="min-w-0 flex-1">{label}</span>
-            <ChevronRight className="h-4 w-4 md:hidden" aria-hidden="true" />
-          </Link>
-        );
-      })}
+          return (
+            <Button
+              key={value}
+              type="button"
+              variant={active ? "secondary" : "ghost"}
+              size="sm"
+              asChild
+              className={cn(
+                "flex-1 justify-center",
+                active && "bg-background shadow-sm hover:bg-background",
+              )}
+            >
+              <Link to={`/settings/${value}`} aria-current={active ? "page" : undefined}>
+                <Icon className="h-4 w-4" aria-hidden="true" />
+                {label}
+              </Link>
+            </Button>
+          );
+        })}
+      </div>
     </nav>
   );
 }
 
 export default function Settings() {
   const { tab } = useParams();
-  const navigate = useNavigate();
-  const activeTab = isSettingsTab(tab) ? tab : undefined;
+  const activeTab = getSettingsTab(tab);
 
-  useEffect(() => {
-    if (tab) return;
-    const desktopQuery = window.matchMedia("(min-width: 768px)");
-    if (desktopQuery.matches) {
-      navigate("/settings/profile", { replace: true });
-    }
-  }, [navigate, tab]);
-
-  if (tab && !activeTab) {
+  if (!activeTab) {
     return <Navigate to="/settings/profile" replace />;
   }
 
+  if (tab !== activeTab) {
+    return <Navigate to={`/settings/${activeTab}`} replace />;
+  }
+
   return (
-    <div className="space-y-4">
-      <div className="hidden md:block">
+    <div className="mx-auto max-w-5xl space-y-5">
+      <div className="space-y-2">
         <h1 className="text-2xl font-heading leading-snug font-medium">Settings</h1>
+        <p className="max-w-2xl text-sm text-muted-foreground">
+          Manage your profile, app preferences, reading defaults, notifications, and account.
+        </p>
       </div>
 
-      <div className="md:hidden">
-        {!activeTab ? (
-          <h1 className="text-2xl font-heading leading-snug font-medium">Settings</h1>
-        ) : (
-          <Button variant="ghost" size="sm" asChild>
-            <Link to="/settings">
-              <ChevronLeft className="mr-2 h-4 w-4" />
-              Settings
-            </Link>
-          </Button>
-        )}
-      </div>
+      <SettingsTabs activeTab={activeTab} />
 
-      <div className="grid gap-4 md:grid-cols-[13rem_minmax(0,1fr)]">
-        <aside className={cn(activeTab && "hidden md:block")}>
-          <SettingsList activeTab={activeTab} />
-        </aside>
-
-        <section className={cn(!activeTab && "hidden md:block")}>
-          {activeTab && <SettingsTabContent tab={activeTab} />}
-        </section>
-      </div>
+      <section>
+        <SettingsTabContent tab={activeTab} />
+      </section>
     </div>
   );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,6 +77,8 @@ export interface ReadingLog {
 
 export interface Profile {
   id: string;
+  display_name?: string;
+  username?: string;
   first_name?: string;
   last_name?: string;
   avatar_url?: string;
@@ -85,6 +87,115 @@ export interface Profile {
   language?: string;
   created_at: string;
 }
+
+export type SettingsTheme = "light" | "dark" | "system";
+
+export type AccentColor = "default" | "rose" | "orange" | "green" | "blue" | "violet";
+
+export type BookCoverStyle = "rounded" | "square" | "soft";
+
+export type CornerRadiusStyle = "none" | "small" | "medium" | "large";
+
+export type FontSizePreference = "small" | "medium" | "large";
+
+export type DensityPreference = "comfortable" | "compact" | "spacious";
+
+export interface AppearanceSettings {
+  theme: SettingsTheme;
+  accent_color: AccentColor;
+  compact_mode: boolean;
+  reduced_animations: boolean;
+  book_cover_style: BookCoverStyle;
+  corner_radius: CornerRadiusStyle;
+  font_size: FontSizePreference;
+  density: DensityPreference;
+}
+
+export type ReadingPaceCalculation = "recent_logs" | "all_logs" | "manual";
+
+export type ProgressDisplay = "percentage" | "pages" | "both";
+
+export interface ReadingSettings {
+  default_reading_status: BookStatus;
+  reading_pace_calculation: ReadingPaceCalculation;
+  progress_display: ProgressDisplay;
+  reading_streak_enabled: boolean;
+  reading_streak_goal_days: number;
+  auto_finish_books: boolean;
+  estimated_completion_dates: boolean;
+}
+
+export type LibrarySorting = "recently_added" | "title" | "author" | "rating" | "status";
+
+export type LibraryView = "grid" | "list" | "compact";
+
+export interface LibrarySettings {
+  default_sorting: LibrarySorting;
+  default_view: LibraryView;
+  default_filters: Record<string, string>;
+  show_unfinished_series_first: boolean;
+  hide_completed_books: boolean;
+  show_reading_statistics: boolean;
+}
+
+export type CollectionVisibility = "private" | "followers" | "public";
+
+export type CollectionBehavior = "manual" | "smart" | "manual_and_smart";
+
+export interface CollectionSettings {
+  collection_visibility: CollectionVisibility;
+  automatic_collections: boolean;
+  smart_collections: boolean;
+  collection_behavior: CollectionBehavior;
+}
+
+export interface NotificationSettings {
+  reading_reminders: boolean;
+  weekly_summary: boolean;
+  daily_goal_reminders: boolean;
+  goal_completion_notifications: boolean;
+  friend_activity_notifications: boolean;
+  new_follower_notifications: boolean;
+}
+
+export interface PrivacySettings {
+  private_account: boolean;
+  show_reading_activity: boolean;
+  show_reading_statistics_publicly: boolean;
+  show_reading_goals_publicly: boolean;
+  allow_followers: boolean;
+  blocked_users: string[];
+}
+
+export type BackupFrequency = "manual" | "daily" | "weekly" | "monthly";
+
+export interface BackupSettings {
+  automatic_backups: boolean;
+  backup_frequency: BackupFrequency;
+  last_backup_at: string | null;
+}
+
+export interface UserSettings {
+  user_id: string;
+  appearance: AppearanceSettings;
+  reading: ReadingSettings;
+  library: LibrarySettings;
+  collections: CollectionSettings;
+  notifications: NotificationSettings;
+  privacy: PrivacySettings;
+  backup: BackupSettings;
+  created_at: string;
+  updated_at: string;
+}
+
+export type UserSettingsSections = Pick<
+  UserSettings,
+  "appearance" | "reading" | "library" | "collections" | "notifications" | "privacy" | "backup"
+>;
+
+export type UserSettingsUpdate = {
+  [Key in keyof UserSettingsSections]?: Partial<UserSettingsSections[Key]>;
+};
 
 export interface Group {
   id: string;

--- a/supabase/migrations/20260530_user_settings.sql
+++ b/supabase/migrations/20260530_user_settings.sql
@@ -1,0 +1,144 @@
+-- User-facing settings for profile identity, appearance, reading behavior, and privacy.
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS display_name text,
+  ADD COLUMN IF NOT EXISTS username text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'profiles_username_format_check'
+      AND conrelid = 'profiles'::regclass
+  ) THEN
+    ALTER TABLE profiles
+      ADD CONSTRAINT profiles_username_format_check
+      CHECK (
+        username IS NULL
+        OR (
+          username = lower(username)
+          AND username ~ '^[a-z0-9_]{3,30}$'
+        )
+      );
+  END IF;
+END;
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_username_unique_idx
+  ON profiles (lower(username))
+  WHERE username IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS user_settings (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  appearance jsonb NOT NULL DEFAULT '{
+    "theme": "system",
+    "accent_color": "default",
+    "compact_mode": false,
+    "reduced_animations": false,
+    "book_cover_style": "rounded",
+    "corner_radius": "medium",
+    "font_size": "medium",
+    "density": "comfortable"
+  }'::jsonb,
+  reading jsonb NOT NULL DEFAULT '{
+    "default_reading_status": "Wishlist",
+    "reading_pace_calculation": "recent_logs",
+    "progress_display": "percentage",
+    "reading_streak_enabled": true,
+    "reading_streak_goal_days": 7,
+    "auto_finish_books": true,
+    "estimated_completion_dates": true
+  }'::jsonb,
+  library jsonb NOT NULL DEFAULT '{
+    "default_sorting": "recently_added",
+    "default_view": "grid",
+    "default_filters": {},
+    "show_unfinished_series_first": true,
+    "hide_completed_books": false,
+    "show_reading_statistics": true
+  }'::jsonb,
+  collections jsonb NOT NULL DEFAULT '{
+    "collection_visibility": "private",
+    "automatic_collections": true,
+    "smart_collections": true,
+    "collection_behavior": "manual_and_smart"
+  }'::jsonb,
+  notifications jsonb NOT NULL DEFAULT '{
+    "reading_reminders": false,
+    "weekly_summary": false,
+    "daily_goal_reminders": false,
+    "goal_completion_notifications": true,
+    "friend_activity_notifications": false,
+    "new_follower_notifications": false
+  }'::jsonb,
+  privacy jsonb NOT NULL DEFAULT '{
+    "private_account": true,
+    "show_reading_activity": false,
+    "show_reading_statistics_publicly": false,
+    "show_reading_goals_publicly": false,
+    "allow_followers": false,
+    "blocked_users": []
+  }'::jsonb,
+  backup jsonb NOT NULL DEFAULT '{
+    "automatic_backups": false,
+    "backup_frequency": "manual",
+    "last_backup_at": null
+  }'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (jsonb_typeof(appearance) = 'object'),
+  CHECK (jsonb_typeof(reading) = 'object'),
+  CHECK (jsonb_typeof(library) = 'object'),
+  CHECK (jsonb_typeof(collections) = 'object'),
+  CHECK (jsonb_typeof(notifications) = 'object'),
+  CHECK (jsonb_typeof(privacy) = 'object'),
+  CHECK (jsonb_typeof(backup) = 'object')
+);
+
+INSERT INTO user_settings (user_id)
+SELECT users.id
+FROM auth.users AS users
+ON CONFLICT (user_id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS user_settings_set_updated_at ON user_settings;
+
+CREATE TRIGGER user_settings_set_updated_at
+  BEFORE UPDATE ON user_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();
+
+ALTER TABLE user_settings ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "user_settings: owner select" ON user_settings;
+DROP POLICY IF EXISTS "user_settings: owner insert" ON user_settings;
+DROP POLICY IF EXISTS "user_settings: owner update" ON user_settings;
+DROP POLICY IF EXISTS "user_settings: owner delete" ON user_settings;
+
+CREATE POLICY "user_settings: owner select"
+  ON user_settings FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "user_settings: owner insert"
+  ON user_settings FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "user_settings: owner update"
+  ON user_settings FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "user_settings: owner delete"
+  ON user_settings FOR DELETE
+  USING (auth.uid() = user_id);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -70,6 +70,8 @@ CREATE TABLE IF NOT EXISTS book_notes (
 -- ── PROFILES ──────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS profiles (
   id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name text,
+  username text,
   first_name text,
   last_name text,
   avatar_url text,
@@ -78,6 +80,27 @@ CREATE TABLE IF NOT EXISTS profiles (
   language text,
   created_at timestamptz NOT NULL DEFAULT now()
 );
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'profiles_username_format_check'
+      AND conrelid = 'profiles'::regclass
+  ) THEN
+    ALTER TABLE profiles
+      ADD CONSTRAINT profiles_username_format_check
+      CHECK (
+        username IS NULL
+        OR (
+          username = lower(username)
+          AND username ~ '^[a-z0-9_]{3,30}$'
+        )
+      );
+  END IF;
+END;
+$$;
 
 INSERT INTO profiles (id)
 SELECT users.id
@@ -105,6 +128,97 @@ CREATE TRIGGER on_auth_user_created_create_profile
   AFTER INSERT ON auth.users
   FOR EACH ROW
   EXECUTE FUNCTION handle_new_auth_user_profile();
+
+-- ── USER SETTINGS ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS user_settings (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  appearance jsonb NOT NULL DEFAULT '{
+    "theme": "system",
+    "accent_color": "default",
+    "compact_mode": false,
+    "reduced_animations": false,
+    "book_cover_style": "rounded",
+    "corner_radius": "medium",
+    "font_size": "medium",
+    "density": "comfortable"
+  }'::jsonb,
+  reading jsonb NOT NULL DEFAULT '{
+    "default_reading_status": "Wishlist",
+    "reading_pace_calculation": "recent_logs",
+    "progress_display": "percentage",
+    "reading_streak_enabled": true,
+    "reading_streak_goal_days": 7,
+    "auto_finish_books": true,
+    "estimated_completion_dates": true
+  }'::jsonb,
+  library jsonb NOT NULL DEFAULT '{
+    "default_sorting": "recently_added",
+    "default_view": "grid",
+    "default_filters": {},
+    "show_unfinished_series_first": true,
+    "hide_completed_books": false,
+    "show_reading_statistics": true
+  }'::jsonb,
+  collections jsonb NOT NULL DEFAULT '{
+    "collection_visibility": "private",
+    "automatic_collections": true,
+    "smart_collections": true,
+    "collection_behavior": "manual_and_smart"
+  }'::jsonb,
+  notifications jsonb NOT NULL DEFAULT '{
+    "reading_reminders": false,
+    "weekly_summary": false,
+    "daily_goal_reminders": false,
+    "goal_completion_notifications": true,
+    "friend_activity_notifications": false,
+    "new_follower_notifications": false
+  }'::jsonb,
+  privacy jsonb NOT NULL DEFAULT '{
+    "private_account": true,
+    "show_reading_activity": false,
+    "show_reading_statistics_publicly": false,
+    "show_reading_goals_publicly": false,
+    "allow_followers": false,
+    "blocked_users": []
+  }'::jsonb,
+  backup jsonb NOT NULL DEFAULT '{
+    "automatic_backups": false,
+    "backup_frequency": "manual",
+    "last_backup_at": null
+  }'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (jsonb_typeof(appearance) = 'object'),
+  CHECK (jsonb_typeof(reading) = 'object'),
+  CHECK (jsonb_typeof(library) = 'object'),
+  CHECK (jsonb_typeof(collections) = 'object'),
+  CHECK (jsonb_typeof(notifications) = 'object'),
+  CHECK (jsonb_typeof(privacy) = 'object'),
+  CHECK (jsonb_typeof(backup) = 'object')
+);
+
+INSERT INTO user_settings (user_id)
+SELECT users.id
+FROM auth.users AS users
+ON CONFLICT (user_id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS user_settings_set_updated_at ON user_settings;
+
+CREATE TRIGGER user_settings_set_updated_at
+  BEFORE UPDATE ON user_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION set_updated_at();
 
 -- ── GROUPS ────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS groups (
@@ -140,6 +254,7 @@ CREATE INDEX IF NOT EXISTS book_notes_book_id_idx ON book_notes(book_id);
 CREATE INDEX IF NOT EXISTS book_notes_book_created_at_idx ON book_notes(book_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS book_notes_book_note_date_idx ON book_notes(book_id, note_date DESC, created_at DESC);
 CREATE INDEX IF NOT EXISTS profiles_created_at_idx ON profiles(created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS profiles_username_unique_idx ON profiles (lower(username)) WHERE username IS NOT NULL;
 CREATE INDEX IF NOT EXISTS groups_created_by_idx ON groups(created_by);
 CREATE INDEX IF NOT EXISTS group_memberships_user_id_idx ON group_memberships(user_id);
 CREATE INDEX IF NOT EXISTS group_memberships_group_id_idx ON group_memberships(group_id);
@@ -150,6 +265,7 @@ ALTER TABLE books        ENABLE ROW LEVEL SECURITY;
 ALTER TABLE reading_logs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE book_notes ENABLE ROW LEVEL SECURITY;
 ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_settings ENABLE ROW LEVEL SECURITY;
 ALTER TABLE groups ENABLE ROW LEVEL SECURITY;
 ALTER TABLE group_memberships ENABLE ROW LEVEL SECURITY;
 
@@ -321,6 +437,12 @@ CREATE POLICY "book_notes: owner delete"
 CREATE POLICY "profiles: owner select" ON profiles FOR SELECT USING (auth.uid() = id);
 CREATE POLICY "profiles: owner insert" ON profiles FOR INSERT WITH CHECK (auth.uid() = id);
 CREATE POLICY "profiles: owner update" ON profiles FOR UPDATE USING (auth.uid() = id) WITH CHECK (auth.uid() = id);
+
+-- user_settings
+CREATE POLICY "user_settings: owner select" ON user_settings FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "user_settings: owner insert" ON user_settings FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "user_settings: owner update" ON user_settings FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "user_settings: owner delete" ON user_settings FOR DELETE USING (auth.uid() = user_id);
 
 -- groups
 CREATE POLICY "groups: member select" ON groups FOR SELECT USING (is_active_group_member(id, auth.uid()));


### PR DESCRIPTION
## Summary

Implements the Settings page structure and v1 settings persistence for the reading journal app.

## What changed

- Added a Supabase migration for profiles.display_name, profiles.username, and a new user_settings table with owner-only RLS policies.
- Added TypeScript settings types, defaults, Supabase helpers, and UserSettingsProvider / useUserSettings.
- Rebuilt Settings into route-backed tabs for Profile, Appearance, Reading, Notifications, Account, and About.
- Added working controls for profile, appearance, reading/library/collections preferences, notification toggles, privacy preferences, backup preferences, email change, password change, and log out.
- Kept export/import/restore/delete-account/About link actions as disabled v1 placeholders where backend or link support is not ready yet.
- Updated the sidebar and Profile page to prefer the new display_name field and show username.

## Developer impact

Most settings are now saved and available through useUserSettings(). Only theme, profile display, auth actions, and log out currently affect behavior immediately; other saved preferences are ready for follow-up work that applies them across Library, Add Book, layout density, animations, and related UI.

## Validation

- Ran the Supabase migration manually in the Supabase SQL Editor.
- npm run build
- git diff --check