### PR TITLE
[codex] add notes to progress updates

### DIFF
--- a/src/components/ReadingProgressPanel.tsx
+++ b/src/components/ReadingProgressPanel.tsx
@@ -4,6 +4,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollWheelPicker } from "@/components/ui/scroll-wheel-picker";
+import { Textarea } from "@/components/ui/textarea";
+import { createBookNote, getProgressNoteDate } from "@/lib/bookNotes";
 import { createReadingLog, fetchLastReadingLog } from "@/lib/books";
 import { useAuth } from "@/context/AuthContext";
 import type { Book, ReadingLog } from "@/types";
@@ -66,6 +68,8 @@ export default function ReadingProgressPanel({
   const [selectedLoggedAt, setSelectedLoggedAt] = useState(() =>
     toDateTimeLocalValue(new Date())
   );
+  const [showNoteEditor, setShowNoteEditor] = useState(false);
+  const [noteContent, setNoteContent] = useState("");
 
   // Fetch last reading log on mount
   useEffect(() => {
@@ -93,6 +97,8 @@ export default function ReadingProgressPanel({
       setSelectedMinutes(0);
       setShowLoggedAtEditor(false);
       setSelectedLoggedAt(toDateTimeLocalValue(new Date()));
+      setShowNoteEditor(false);
+      setNoteContent("");
       setErrorMsg(null);
     }
   }, [expanded, lastLog, book.current_page, totalPages]);
@@ -125,6 +131,19 @@ export default function ReadingProgressPanel({
         timeMinutes > 0 ? timeMinutes : undefined,
         loggedAtIso
       );
+
+      const trimmedNoteContent = noteContent.trim();
+      if (trimmedNoteContent) {
+        await createBookNote({
+          bookId: book.id,
+          userId: user.id,
+          label: "note",
+          content: trimmedNoteContent,
+          pageStart: selectedPage,
+          noteDate: getProgressNoteDate(showLoggedAtEditor, selectedLoggedAt),
+        });
+      }
+
       await onProgressSaved(selectedPage);
       // Update lastLog locally so the min page updates
       setLastLog({
@@ -134,6 +153,8 @@ export default function ReadingProgressPanel({
         current_page: selectedPage,
         logged_at: loggedAtIso ?? new Date().toISOString(),
       });
+      setShowNoteEditor(false);
+      setNoteContent("");
       setExpanded(false);
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : "Failed to save progress");
@@ -220,6 +241,34 @@ export default function ReadingProgressPanel({
                   type="datetime-local"
                   value={selectedLoggedAt}
                   onChange={(event) => setSelectedLoggedAt(event.target.value)}
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            {!showNoteEditor && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setShowNoteEditor(true)}
+              >
+                Add Note
+              </Button>
+            )}
+
+            {showNoteEditor && (
+              <div className="space-y-1.5">
+                <Label htmlFor="progress-note" className="text-xs text-muted-foreground">
+                  Note for this progress update (optional)
+                </Label>
+                <Textarea
+                  id="progress-note"
+                  value={noteContent}
+                  onChange={(event) => setNoteContent(event.target.value)}
+                  placeholder="Write a note about what you read..."
+                  className="min-h-28"
                 />
               </div>
             )}

--- a/src/lib/bookNotes.ts
+++ b/src/lib/bookNotes.ts
@@ -48,6 +48,16 @@ export interface UpdateBookNoteInput extends BookNoteFieldsInput {
   noteId: string;
 }
 
+export function getProgressNoteDate(
+  showLoggedAtEditor: boolean,
+  selectedLoggedAt: string,
+): string | null {
+  if (!showLoggedAtEditor || !selectedLoggedAt) return null;
+
+  const noteDate = selectedLoggedAt.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(noteDate) ? noteDate : null;
+}
+
 function normalizePageValue(
   value: string | number | null | undefined,
   fieldLabel: string,

--- a/tests/bookNotes.test.ts
+++ b/tests/bookNotes.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   formatBookNotePageRange,
+  getProgressNoteDate,
   normalizeBookNoteFields,
   normalizeBookNoteInput,
   sortBookNotes,
@@ -159,6 +160,15 @@ test("stores quote speaker only for quote entries", () => {
 test("formats source page labels", () => {
   assert.equal(formatBookNotePageRange({ page_start: null }), null);
   assert.equal(formatBookNotePageRange({ page_start: 42 }), "p. 42");
+});
+
+test("uses the selected progress date for notes created from progress updates", () => {
+  assert.equal(getProgressNoteDate(true, "2026-05-05T23:45"), "2026-05-05");
+});
+
+test("lets progress notes default to today when no progress date is edited", () => {
+  assert.equal(getProgressNoteDate(false, "2026-05-05T23:45"), null);
+  assert.equal(getProgressNoteDate(true, ""), null);
 });
 
 test("sorts notes by visible note date newest first", () => {


### PR DESCRIPTION
## Summary
- Adds an optional note field to the shared progress update dialog.
- Saves non-empty progress notes as regular book notes tied to the selected page.
- Uses the edited progress date for the note date when the finished time is changed.

## Validation
- npm test
- npm run typecheck
- npm run build