### PR TITLE
[codex] add genre discovery pages

### DIFF
--- a/src/lib/genreMetadata.ts
+++ b/src/lib/genreMetadata.ts
@@ -1,0 +1,184 @@
+export type GenreMetadata = {
+  name: string;
+  description: string;
+  accentClassName?: string;
+};
+
+export const genreMetadataBySlug: Record<string, GenreMetadata> = {
+  fiction: {
+    name: "Fiction",
+    description: "Stories shaped by character, setting, conflict, and imagination.",
+    accentClassName: "from-rose-500/25 via-amber-500/15 to-sky-500/20",
+  },
+  "non-fiction": {
+    name: "Non-Fiction",
+    description: "Books rooted in real people, events, ideas, research, and practical knowledge.",
+    accentClassName: "from-emerald-500/25 via-cyan-500/15 to-slate-500/20",
+  },
+  "age-target": {
+    name: "Age Target",
+    description: "Reading age and audience labels that help you browse across genres.",
+    accentClassName: "from-fuchsia-500/20 via-orange-500/15 to-lime-500/20",
+  },
+  fantasy: {
+    name: "Fantasy",
+    description: "Stories where magic, myth, invented worlds, or supernatural forces shape the plot.",
+    accentClassName: "from-emerald-500/25 via-indigo-500/15 to-rose-500/20",
+  },
+  "high-fantasy": {
+    name: "High Fantasy",
+    description: "Fantasy set in secondary worlds, often with large stakes, deep lore, and heroic arcs.",
+  },
+  "epic-fantasy": {
+    name: "Epic Fantasy",
+    description: "Broad fantasy stories with sweeping conflicts, ensemble casts, and long-form journeys.",
+  },
+  "urban-fantasy": {
+    name: "Urban Fantasy",
+    description: "Magic and supernatural elements woven into modern city life.",
+  },
+  "science-fiction": {
+    name: "Science Fiction",
+    description: "Speculative stories built around science, technology, space, time, or future societies.",
+    accentClassName: "from-cyan-500/25 via-violet-500/15 to-amber-500/20",
+  },
+  "space-opera": {
+    name: "Space Opera",
+    description: "Large-scale science fiction with star-spanning adventure, politics, and drama.",
+  },
+  dystopian: {
+    name: "Dystopian",
+    description: "Speculative societies shaped by oppression, collapse, control, or survival.",
+  },
+  "hard-sci-fi": {
+    name: "Hard Sci-Fi",
+    description: "Science fiction that leans on technical plausibility and scientific detail.",
+  },
+  romance: {
+    name: "Romance",
+    description: "Stories centered on relationships, emotional stakes, and a romantic arc.",
+  },
+  "mystery-crime": {
+    name: "Mystery & Crime",
+    description: "Investigations, puzzles, criminal cases, and the search for truth.",
+  },
+  "thriller-suspense": {
+    name: "Thriller & Suspense",
+    description: "Fast-moving stories built around danger, tension, secrets, and high stakes.",
+  },
+  horror: {
+    name: "Horror",
+    description: "Stories designed around fear, dread, monsters, the uncanny, or psychological unease.",
+  },
+  "historical-fiction": {
+    name: "Historical Fiction",
+    description: "Fiction set in the past, blending invented lives with historical context.",
+  },
+  "literary-fiction": {
+    name: "Literary Fiction",
+    description: "Character-focused fiction with strong attention to style, theme, and interior life.",
+  },
+  "contemporary-fiction": {
+    name: "Contemporary Fiction",
+    description: "Fiction set close to the present day, often focused on modern relationships and society.",
+  },
+  "action-adventure": {
+    name: "Action & Adventure",
+    description: "Plot-driven stories with quests, danger, movement, and physical stakes.",
+  },
+  "humor-satire": {
+    name: "Humor & Satire",
+    description: "Books that use wit, comedy, irony, or exaggeration to entertain or critique.",
+  },
+  "biography-memoir": {
+    name: "Biography & Memoir",
+    description: "Life stories, personal histories, and accounts of real people.",
+  },
+  history: {
+    name: "History",
+    description: "Books about past events, cultures, movements, and the forces that shaped them.",
+  },
+  "true-crime": {
+    name: "True Crime",
+    description: "Real criminal cases, investigations, legal stories, and social context.",
+  },
+  "politics-current-events": {
+    name: "Politics & Current Events",
+    description: "Books about power, policy, public life, institutions, and recent events.",
+  },
+  "self-help-personal-development": {
+    name: "Self-Help & Personal Development",
+    description: "Practical books for habits, growth, productivity, reflection, and life skills.",
+  },
+  "business-economics": {
+    name: "Business & Economics",
+    description: "Markets, organizations, money, work, leadership, and economic systems.",
+  },
+  "science-technology": {
+    name: "Science & Technology",
+    description: "Books explaining scientific fields, technical change, and how the world works.",
+  },
+  "popular-science": {
+    name: "Popular Science",
+    description: "Accessible science writing for curious readers outside specialist fields.",
+  },
+  "nature-environment": {
+    name: "Nature & Environment",
+    description: "Books about ecosystems, climate, natural history, conservation, and our planet.",
+  },
+  "philosophy-spirituality": {
+    name: "Philosophy & Spirituality",
+    description: "Questions of meaning, ethics, belief, consciousness, and how to live.",
+  },
+  "health-wellness": {
+    name: "Health & Wellness",
+    description: "Physical health, mental wellbeing, fitness, medicine, and sustainable care.",
+  },
+  travel: {
+    name: "Travel",
+    description: "Places, journeys, cultures, travel writing, and ways of seeing the world.",
+  },
+  "cookbooks-food": {
+    name: "Cookbooks & Food",
+    description: "Recipes, food culture, cooking skills, ingredients, and culinary history.",
+  },
+  "art-photography-design": {
+    name: "Art, Photography & Design",
+    description: "Visual culture, creative practice, images, objects, spaces, and design thinking.",
+  },
+  "essays-anthologies": {
+    name: "Essays & Anthologies",
+    description: "Collected shorter works, themed selections, and reflective nonfiction pieces.",
+  },
+  childrens: {
+    name: "Children's",
+    description: "Books created for younger readers, from early stories to chapter books.",
+  },
+  "middle-grade": {
+    name: "Middle Grade",
+    description: "Books often written for readers roughly 8 to 12, with age-appropriate adventure and themes.",
+  },
+  "young-adult": {
+    name: "Young Adult",
+    description: "Books centered on teen perspectives, coming-of-age stakes, and identity.",
+  },
+  "new-adult": {
+    name: "New Adult",
+    description: "Books focused on early adulthood, independence, relationships, and transition.",
+  },
+  adult: {
+    name: "Adult",
+    description: "Books written primarily for adult readers.",
+  },
+};
+
+export function getGenreMetadata(slug: string, name: string, isSystem: boolean): GenreMetadata {
+  return (
+    genreMetadataBySlug[slug] ?? {
+      name,
+      description: isSystem
+        ? `Browse books filed under ${name} and any of its subgenres.`
+        : `${name} is a custom genre in your library. Books from this genre and its subgenres are grouped here.`,
+    }
+  );
+}

--- a/src/lib/genreTree.ts
+++ b/src/lib/genreTree.ts
@@ -1,4 +1,4 @@
-import type { Genre, GenreTreeNode } from "@/types";
+import type { Book, Genre, GenreTreeNode } from "@/types";
 
 export const GENRE_ROOT_NAMES = new Set([
   "Fiction",
@@ -19,6 +19,17 @@ export type GenreSearchResult = {
   pathLabel: string;
 };
 
+export type GenreSlugLookup = {
+  slugById: Map<string, string>;
+  genreBySlug: Map<string, Genre>;
+};
+
+export type GenreBookCount = {
+  direct: number;
+  descendant: number;
+  total: number;
+};
+
 function compareGenres(a: Genre, b: Genre): number {
   const rootOrderA = !a.parent_id ? GENRE_ROOT_ORDER.get(a.name) : undefined;
   const rootOrderB = !b.parent_id ? GENRE_ROOT_ORDER.get(b.name) : undefined;
@@ -33,6 +44,19 @@ function compareGenres(a: Genre, b: Genre): number {
 
 export function normalizeGenreName(name: string): string {
   return name.trim().replace(/\s+/g, " ");
+}
+
+export function slugifyGenreName(name: string): string {
+  const normalized = name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/&/g, " ")
+    .replace(/['’]/g, "")
+    .toLocaleLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return normalized || "genre";
 }
 
 export function isGenreRoot(genre: Pick<Genre, "name" | "parent_id">): boolean {
@@ -57,8 +81,7 @@ export function buildGenreMaps(genres: Genre[]) {
   return { byId, childrenByParentId };
 }
 
-export function getGenrePath(genreId: string, genres: Genre[]): Genre[] {
-  const { byId } = buildGenreMaps(genres);
+function getGenrePathFromMap(genreId: string, byId: Map<string, Genre>): Genre[] {
   const path: Genre[] = [];
   const visited = new Set<string>();
   let current = byId.get(genreId);
@@ -70,6 +93,53 @@ export function getGenrePath(genreId: string, genres: Genre[]): Genre[] {
   }
 
   return path;
+}
+
+export function buildGenreSlugLookup(genres: Genre[]): GenreSlugLookup {
+  const { byId } = buildGenreMaps(genres);
+  const slugById = new Map<string, string>();
+  const genreBySlug = new Map<string, Genre>();
+  const usedSlugs = new Set<string>();
+  const sortedGenres = [...genres].sort((a, b) => {
+    const pathA = getGenrePathFromMap(a.id, byId).map((item) => item.name).join(" -> ");
+    const pathB = getGenrePathFromMap(b.id, byId).map((item) => item.name).join(" -> ");
+    return pathA.localeCompare(pathB, undefined, { sensitivity: "base", numeric: true });
+  });
+
+  for (const genre of sortedGenres) {
+    const path = getGenrePathFromMap(genre.id, byId);
+    const parent = path.length > 1 ? path[path.length - 2] : null;
+    const candidates = [
+      slugifyGenreName(genre.name),
+      parent ? `${slugifyGenreName(parent.name)}-${slugifyGenreName(genre.name)}` : "",
+      path.map((item) => slugifyGenreName(item.name)).join("-"),
+      `${path.map((item) => slugifyGenreName(item.name)).join("-")}-${genre.id.slice(0, 8)}`,
+    ].filter(Boolean);
+
+    let slug = candidates.find((candidate) => !usedSlugs.has(candidate));
+    if (!slug) slug = `${slugifyGenreName(genre.name)}-${genre.id.slice(0, 8)}`;
+
+    usedSlugs.add(slug);
+    slugById.set(genre.id, slug);
+    genreBySlug.set(slug, genre);
+  }
+
+  return { slugById, genreBySlug };
+}
+
+export function getGenreSlug(genreId: string, genres: Genre[]): string | null {
+  return buildGenreSlugLookup(genres).slugById.get(genreId) ?? null;
+}
+
+export function resolveGenreSlug(slugOrId: string, genres: Genre[]): Genre | null {
+  const { byId } = buildGenreMaps(genres);
+  if (byId.has(slugOrId)) return byId.get(slugOrId) ?? null;
+  return buildGenreSlugLookup(genres).genreBySlug.get(slugOrId) ?? null;
+}
+
+export function getGenrePath(genreId: string, genres: Genre[]): Genre[] {
+  const { byId } = buildGenreMaps(genres);
+  return getGenrePathFromMap(genreId, byId);
 }
 
 export function getGenrePathLabel(genreId: string, genres: Genre[]): string {
@@ -115,6 +185,86 @@ export function buildGenreTree(genres: Genre[]): GenreTreeNode[] {
 
 export function flattenGenreTree(nodes: GenreTreeNode[]): GenreTreeNode[] {
   return nodes.flatMap((node) => [node, ...flattenGenreTree(node.children)]);
+}
+
+export function getDescendantGenreIds(genreId: string, genres: Genre[]): string[] {
+  const { childrenByParentId } = buildGenreMaps(genres);
+  const ids: string[] = [];
+  const stack = [...(childrenByParentId.get(genreId) ?? [])];
+  const visited = new Set<string>();
+
+  while (stack.length > 0) {
+    const current = stack.shift();
+    if (!current || visited.has(current.id)) continue;
+
+    visited.add(current.id);
+    ids.push(current.id);
+    stack.push(...(childrenByParentId.get(current.id) ?? []));
+  }
+
+  return ids;
+}
+
+export function getGenreSubtreeIds(genreId: string, genres: Genre[]): string[] {
+  const { byId } = buildGenreMaps(genres);
+  const genre = byId.get(genreId);
+  const descendantIds = getDescendantGenreIds(genreId, genres);
+
+  if (genre && isGenreRoot(genre)) {
+    return descendantIds;
+  }
+
+  return [genreId, ...descendantIds];
+}
+
+export function bookMatchesGenreSubtree(book: Pick<Book, "genre_ids">, genreId: string, genres: Genre[]): boolean {
+  const subtreeIds = new Set(getGenreSubtreeIds(genreId, genres));
+  return book.genre_ids?.some((bookGenreId) => subtreeIds.has(bookGenreId)) ?? false;
+}
+
+export function getBooksForGenreSubtree<T extends Pick<Book, "genre_ids">>(
+  books: T[],
+  genreId: string,
+  genres: Genre[],
+): T[] {
+  const subtreeIds = new Set(getGenreSubtreeIds(genreId, genres));
+  return books.filter((book) => book.genre_ids?.some((bookGenreId) => subtreeIds.has(bookGenreId)));
+}
+
+export function getGenreBookCount(
+  genreId: string,
+  books: Array<Pick<Book, "genre_ids">>,
+  genres: Genre[],
+): GenreBookCount {
+  const { byId } = buildGenreMaps(genres);
+  const genre = byId.get(genreId);
+  const countDirectAssignments = !genre || !isGenreRoot(genre);
+  const descendantIds = new Set(getDescendantGenreIds(genreId, genres));
+  let direct = 0;
+  let descendant = 0;
+  let total = 0;
+
+  for (const book of books) {
+    const genreIds = new Set(book.genre_ids ?? []);
+    const hasDirectMatch = countDirectAssignments && genreIds.has(genreId);
+    const hasDescendantMatch = [...genreIds].some((id) => descendantIds.has(id));
+    if (hasDirectMatch) direct += 1;
+    if (hasDescendantMatch) descendant += 1;
+    if (hasDirectMatch || hasDescendantMatch) total += 1;
+  }
+
+  return {
+    direct,
+    descendant,
+    total,
+  };
+}
+
+export function getGenreBookCounts(
+  genres: Genre[],
+  books: Array<Pick<Book, "genre_ids">>,
+): Map<string, GenreBookCount> {
+  return new Map(genres.map((genre) => [genre.id, getGenreBookCount(genre.id, books, genres)]));
 }
 
 export function searchGenres(genres: Genre[], query: string): GenreSearchResult[] {

--- a/src/lib/router.tsx
+++ b/src/lib/router.tsx
@@ -13,6 +13,7 @@ const Authors = lazy(() => import("@/pages/Authors"));
 const AuthorDetails = lazy(() => import("@/pages/AuthorDetails"));
 const Search = lazy(() => import("@/pages/Search"));
 const Analytics = lazy(() => import("@/pages/Analytics"));
+const Genres = lazy(() => import("@/pages/Genres"));
 const GenreDetails = lazy(() => import("@/pages/GenreDetails"));
 const BookDetails = lazy(() => import("@/pages/BookDetails"));
 const BookAnalytics = lazy(() => import("@/pages/BookAnalytics"));
@@ -56,6 +57,7 @@ export const router = createBrowserRouter([
           { path: "/authors", element: lazyRoute(<Authors />) },
           { path: "/authors/:authorName", element: lazyRoute(<AuthorDetails />) },
           { path: "/search", element: lazyRoute(<Search />) },
+          { path: "/genres", element: lazyRoute(<Genres />) },
           { path: "/genres/:genreId", element: lazyRoute(<GenreDetails />) },
           { path: "/books/:bookId", element: lazyRoute(<BookDetails />) },
           { path: "/books/:bookId/analytics", element: lazyRoute(<BookAnalytics />) },

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import { RefreshCw } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -217,8 +218,15 @@ export default function Analytics() {
 
       <Card>
         <CardHeader>
-          <CardTitle>Genre distribution</CardTitle>
-          <CardDescription>See how your library is split across genres.</CardDescription>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <CardTitle>Genre distribution</CardTitle>
+              <CardDescription>See how your library is split across genres.</CardDescription>
+            </div>
+            <Button asChild variant="outline" size="sm">
+              <Link to="/genres">Browse genres</Link>
+            </Button>
+          </div>
         </CardHeader>
         <CardContent>
           <GenreDistributionChart books={books} loading={booksLoading} error={booksError} />

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -39,6 +39,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { useBooksContext } from "@/context/BooksContext";
+import { useGenresContext } from "@/context/GenresContext";
 import { useSeries } from "@/hooks/useSeries";
 import {
   formatCalendarSpan,
@@ -51,7 +52,7 @@ import {
 } from "@/lib/bookAnalytics";
 import { fetchBookNotes, sortBookNotes } from "@/lib/bookNotes";
 import { fetchReadingLogsForBook } from "@/lib/books";
-import { formatGenrePathForDisplay } from "@/lib/genreTree";
+import { buildGenreSlugLookup, formatGenrePathForDisplay, getSelectedGenreTags } from "@/lib/genreTree";
 import {
   formatPublicationDateForDisplay,
   formatPublicationDateInput,
@@ -174,9 +175,18 @@ export default function BookDetails() {
   const { bookId } = useParams<{ bookId: string }>();
   const navigate = useNavigate();
   const { books, loading, error, updateBook, updateCover, deleteBook, reload } = useBooksContext();
+  const { genres } = useGenresContext();
   const { series } = useSeries();
 
   const book = bookId ? books.find((item) => item.id === bookId) ?? null : null;
+  const { slugById } = useMemo(() => buildGenreSlugLookup(genres), [genres]);
+  const linkedGenres = useMemo(() => {
+    if (!book?.selected_genres?.length) return [];
+    return getSelectedGenreTags(book.selected_genres).map((genre) => ({
+      genre,
+      slug: slugById.get(genre.id) ?? genre.id,
+    }));
+  }, [book?.selected_genres, slugById]);
   const seriesName = book?.series_id
     ? series.find((item) => item.id === book.series_id)?.name
     : undefined;
@@ -919,7 +929,15 @@ export default function BookDetails() {
             <div className="rounded-xl border bg-card p-5">
               <div className="space-y-5">
                 <MetadataGroup title="Genres">
-                  {book.genre_paths?.length ? (
+                  {linkedGenres.length > 0 ? (
+                    <div className="flex flex-wrap gap-1.5">
+                      {linkedGenres.map(({ genre, slug }) => (
+                        <Badge key={genre.id} variant="outline" className="max-w-full font-normal" asChild>
+                          <Link to={`/genres/${slug}`}>{genre.name}</Link>
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : book.genre_paths?.length ? (
                     <div className="flex flex-wrap gap-1.5">
                       {book.genre_paths.map((path) => (
                         <Badge key={path} variant="outline" className="max-w-full font-normal">

--- a/src/pages/GenreDetails.tsx
+++ b/src/pages/GenreDetails.tsx
@@ -1,28 +1,61 @@
-import { Link, useParams } from "react-router-dom";
-import { ArrowLeft, BookOpen, ChevronRight, ListTree } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { useMemo } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  ArrowLeft,
+  ChevronRight,
+  ListTree,
+} from "lucide-react";
+import BookCard from "@/components/BookCard";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { useBooksContext } from "@/context/BooksContext";
 import { useGenresContext } from "@/context/GenresContext";
-import { getGenrePath } from "@/lib/genres";
+import { buildGenreSlugLookup, getBooksForGenreSubtree, getGenreBookCount, getGenrePath, resolveGenreSlug } from "@/lib/genres";
+import { getGenreMetadata } from "@/lib/genreMetadata";
+import { cn } from "@/lib/utils";
+import type { Book } from "@/types";
+
+function compareText(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { sensitivity: "base", numeric: true });
+}
+
+function sortBooksByTitle(books: Book[]): Book[] {
+  return [...books].sort((a, b) => {
+    return compareText(a.title, b.title);
+  });
+}
+
+function BooksGrid({ books, onBook }: { books: Book[]; onBook: (book: Book) => void }) {
+  return (
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(108px,1fr))] gap-3 sm:grid-cols-[repeat(auto-fill,minmax(132px,1fr))] lg:grid-cols-[repeat(auto-fill,minmax(150px,1fr))]">
+      {books.map((book) => (
+        <BookCard key={book.id} book={book} onClick={onBook} textSize="compact" />
+      ))}
+    </div>
+  );
+}
 
 export default function GenreDetails() {
   const { genreId } = useParams<{ genreId: string }>();
+  const navigate = useNavigate();
   const { genres, loading: genresLoading, error: genresError } = useGenresContext();
   const { books, loading: booksLoading } = useBooksContext();
-  const genre = genreId ? genres.find((item) => item.id === genreId) ?? null : null;
+
+  const { slugById } = useMemo(() => buildGenreSlugLookup(genres), [genres]);
+  const genre = genreId ? resolveGenreSlug(genreId, genres) : null;
+  const slug = genre ? slugById.get(genre.id) ?? genre.id : "";
   const path = genre ? getGenrePath(genre.id, genres) : [];
-  const parent = genre?.parent_id ? genres.find((item) => item.id === genre.parent_id) ?? null : null;
+  const metadata = genre ? getGenreMetadata(slug, genre.name, genre.is_system) : null;
   const subgenres = genre ? genres.filter((item) => item.parent_id === genre.id) : [];
-  const matchingBooks = genre
-    ? books.filter((book) => book.genre_ids?.includes(genre.id))
-    : [];
+  const matchingBooks = genre ? sortBooksByTitle(getBooksForGenreSubtree(books, genre.id, genres)) : [];
+  const genreCount = genre ? getGenreBookCount(genre.id, books, genres) : null;
 
   if (genresLoading || booksLoading) {
     return (
       <div className="space-y-5">
         <div className="h-9 w-28 animate-pulse rounded-md bg-muted" />
-        <div className="h-40 animate-pulse rounded-xl bg-muted" />
+        <div className="h-56 animate-pulse rounded-xl bg-muted" />
+        <div className="h-64 animate-pulse rounded-xl bg-muted" />
       </div>
     );
   }
@@ -31,110 +64,116 @@ export default function GenreDetails() {
     return <p className="text-sm text-destructive">{genresError}</p>;
   }
 
-  if (!genre) {
+  if (!genre || !metadata || !genreCount) {
     return (
       <div className="flex flex-col items-center gap-3 py-16 text-center">
         <ListTree className="h-10 w-10 text-muted-foreground/40" />
         <h1 className="text-lg font-heading leading-snug font-medium">Genre not found</h1>
         <Button asChild size="sm" variant="outline">
-          <Link to="/library">Back to Library</Link>
+          <Link to="/genres">Back to Genres</Link>
         </Button>
       </div>
     );
   }
 
   return (
-    <div className="mx-auto max-w-5xl space-y-6">
-      <Button asChild variant="ghost" size="sm" className="px-2">
-        <Link to="/library">
-          <ArrowLeft className="mr-1.5 h-4 w-4" />
-          Back
-        </Link>
+    <div className="mx-auto max-w-6xl space-y-7">
+      <Button variant="ghost" size="sm" className="px-2" onClick={() => navigate(-1)}>
+        <ArrowLeft className="mr-1.5 h-4 w-4" />
+        Back
       </Button>
 
-      <section className="space-y-3">
-        <div className="flex flex-wrap items-center gap-1 text-sm text-muted-foreground">
-          {path.map((item, index) => (
-            <span key={item.id} className="inline-flex items-center gap-1">
-              {index > 0 && <ChevronRight className="h-3.5 w-3.5" />}
-              {item.id === genre.id ? (
-                <span>{item.name}</span>
-              ) : (
-                <Link to={`/genres/${item.id}`} className="hover:text-foreground">
-                  {item.name}
-                </Link>
-              )}
-            </span>
-          ))}
-        </div>
-        <div className="flex flex-wrap items-center gap-3">
-          <h1 className="text-3xl font-heading leading-tight font-medium">{genre.name}</h1>
-          <Badge variant={genre.is_system ? "secondary" : "outline"}>
-            {genre.is_system ? "System" : "Custom"}
-          </Badge>
-        </div>
-      </section>
+      <section className={cn("overflow-hidden rounded-xl border bg-card", metadata.accentClassName)}>
+        <div className={cn("bg-gradient-to-br p-5", metadata.accentClassName ?? "from-primary/10 via-accent/10 to-muted/20")}>
+          <div className="space-y-5">
+            <nav className="flex flex-wrap items-center gap-1 text-sm text-muted-foreground" aria-label="Breadcrumb">
+              <Link to="/genres" className="hover:text-foreground">Genres</Link>
+              {path.map((item) => {
+                const itemSlug = slugById.get(item.id) ?? item.id;
+                return (
+                  <span key={item.id} className="inline-flex items-center gap-1">
+                    <ChevronRight className="h-3.5 w-3.5" />
+                    {item.id === genre.id ? (
+                      <span>{item.name}</span>
+                    ) : (
+                      <Link to={`/genres/${itemSlug}`} className="hover:text-foreground">
+                        {item.name}
+                      </Link>
+                    )}
+                  </span>
+                );
+              })}
+            </nav>
 
-      <section className="grid gap-4 md:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
-        <div className="rounded-xl border bg-card p-5">
-          <h2 className="text-sm font-medium">Parent</h2>
-          <div className="mt-3">
-            {parent ? (
-              <Button asChild variant="link" className="h-auto px-0">
-                <Link to={`/genres/${parent.id}`}>{parent.name}</Link>
-              </Button>
-            ) : (
-              <p className="text-sm text-muted-foreground">No parent</p>
-            )}
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-3">
+                <h1 className="text-4xl font-heading leading-tight font-medium">{genre.name}</h1>
+                <Badge variant={genre.is_system ? "secondary" : "outline"}>
+                  {genre.is_system ? "System" : "Custom"}
+                </Badge>
+              </div>
+              <p className="max-w-2xl text-sm leading-6 text-muted-foreground">{metadata.description}</p>
+            </div>
+
+            <div className="grid max-w-xl grid-cols-3 overflow-hidden rounded-xl border bg-background/75">
+              <div className="border-r p-4">
+                <p className="text-xs text-muted-foreground">Total books</p>
+                <p className="mt-1 text-2xl font-semibold">{genreCount.total}</p>
+              </div>
+              <div className="border-r p-4">
+                <p className="text-xs text-muted-foreground">Tagged here</p>
+                <p className="mt-1 text-2xl font-semibold">{genreCount.direct}</p>
+              </div>
+              <div className="p-4">
+                <p className="text-xs text-muted-foreground">Subgenres</p>
+                <p className="mt-1 text-2xl font-semibold">{subgenres.length}</p>
+              </div>
+            </div>
           </div>
         </div>
-
-        <div className="rounded-xl border bg-card p-5">
-          <h2 className="text-sm font-medium">Subgenres</h2>
-          {subgenres.length > 0 ? (
-            <div className="mt-3 flex flex-wrap gap-2">
-              {subgenres.map((item) => (
-                <Button key={item.id} asChild size="sm" variant="outline">
-                  <Link to={`/genres/${item.id}`}>{item.name}</Link>
-                </Button>
-              ))}
-            </div>
-          ) : (
-            <p className="mt-3 text-sm text-muted-foreground">No subgenres yet.</p>
-          )}
-        </div>
       </section>
 
-      <section className="rounded-xl border bg-card p-5">
-        <h2 className="text-sm font-medium">Books</h2>
-        {matchingBooks.length > 0 ? (
-          <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {matchingBooks.map((book) => (
-              <Link
-                key={book.id}
-                to={`/books/${book.id}`}
-                className="flex min-w-0 gap-3 rounded-lg border bg-background p-3 transition-colors hover:bg-muted/30"
-              >
-                <div className="h-20 w-14 shrink-0 overflow-hidden rounded-md bg-muted">
-                  {book.cover_url ? (
-                    <img src={book.cover_url} alt={book.title} className="h-full w-full object-cover" />
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center">
-                      <BookOpen className="h-5 w-5 text-muted-foreground/40" />
-                    </div>
-                  )}
-                </div>
-                <div className="min-w-0">
-                  <p className="line-clamp-2 text-sm font-medium">{book.title}</p>
-                  <p className="mt-1 truncate text-xs text-muted-foreground">
-                    {book.authors.join(", ")}
+      {subgenres.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-xl font-heading leading-snug font-medium">Subgenres</h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {subgenres.map((subgenre) => {
+              const count = getGenreBookCount(subgenre.id, books, genres).total;
+              const subgenreSlug = slugById.get(subgenre.id) ?? subgenre.id;
+              return (
+                <Link
+                  key={subgenre.id}
+                  to={`/genres/${subgenreSlug}`}
+                  className="rounded-lg border bg-card p-4 transition-colors hover:bg-muted/40"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="font-medium">{subgenre.name}</p>
+                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  </div>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {count} book{count === 1 ? "" : "s"}
                   </p>
-                </div>
-              </Link>
-            ))}
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-heading leading-snug font-medium">Books</h2>
+          <p className="text-sm text-muted-foreground">
+            {matchingBooks.length} matching book{matchingBooks.length === 1 ? "" : "s"}.
+          </p>
+        </div>
+
+        {matchingBooks.length === 0 ? (
+          <div className="flex h-40 items-center justify-center rounded-xl border border-dashed text-sm text-muted-foreground">
+            No books assigned to this genre yet.
           </div>
         ) : (
-          <p className="mt-3 text-sm text-muted-foreground">No books assigned to this genre yet.</p>
+          <BooksGrid books={matchingBooks} onBook={(book) => navigate(`/books/${book.id}`)} />
         )}
       </section>
     </div>

--- a/src/pages/Genres.tsx
+++ b/src/pages/Genres.tsx
@@ -1,0 +1,168 @@
+import { Link } from "react-router-dom";
+import { BookOpen, ChevronRight, ListTree } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useBooksContext } from "@/context/BooksContext";
+import { useGenresContext } from "@/context/GenresContext";
+import {
+  buildGenreSlugLookup,
+  getGenreBookCounts,
+  isGenreRoot,
+} from "@/lib/genres";
+import type { GenreTreeNode } from "@/types";
+
+function formatBookCount(count: number): string {
+  return `${count} book${count === 1 ? "" : "s"}`;
+}
+
+function GenreTreeRow({
+  node,
+  slugById,
+  countsById,
+}: {
+  node: GenreTreeNode;
+  slugById: Map<string, string>;
+  countsById: ReturnType<typeof getGenreBookCounts>;
+}) {
+  const count = countsById.get(node.id)?.total ?? 0;
+  const slug = slugById.get(node.id) ?? node.id;
+
+  return (
+    <li>
+      <Link
+        to={`/genres/${slug}`}
+        className="group grid min-h-11 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        style={{ paddingLeft: `${12 + Math.max(0, node.depth - 1) * 18}px` }}
+      >
+        <span className="min-w-0">
+          <span className="block truncate font-medium">{node.name}</span>
+          {node.children.length > 0 && (
+            <span className="block text-xs text-muted-foreground">
+              {node.children.length} subgenre{node.children.length === 1 ? "" : "s"}
+            </span>
+          )}
+        </span>
+        <Badge variant="secondary" className="justify-self-end whitespace-nowrap">
+          {formatBookCount(count)}
+        </Badge>
+        <ChevronRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+      </Link>
+      {node.children.length > 0 && (
+        <ul className="mt-1 space-y-1">
+          {node.children.map((child) => (
+            <GenreTreeRow
+              key={child.id}
+              node={child}
+              slugById={slugById}
+              countsById={countsById}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export default function Genres() {
+  const { genres, tree, loading: genresLoading, error: genresError } = useGenresContext();
+  const { books, loading: booksLoading } = useBooksContext();
+  const { slugById } = buildGenreSlugLookup(genres);
+  const countsById = getGenreBookCounts(genres, books);
+  const loading = genresLoading || booksLoading;
+  const rootSections = tree.filter((node) => isGenreRoot(node));
+  const customRoots = tree.filter((node) => !isGenreRoot(node));
+
+  if (loading) {
+    return (
+      <div className="space-y-5">
+        <div className="h-9 w-44 animate-pulse rounded-md bg-muted" />
+        <div className="h-48 animate-pulse rounded-xl bg-muted" />
+        <div className="h-48 animate-pulse rounded-xl bg-muted" />
+      </div>
+    );
+  }
+
+  if (genresError) {
+    return <p className="text-sm text-destructive">{genresError}</p>;
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-7">
+      <section className="space-y-2">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <ListTree className="h-4 w-4" />
+          Genre discovery
+        </div>
+        <h1 className="text-3xl font-heading leading-tight font-medium">Browse Genres</h1>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          Explore your genre tree from broad categories down to specific subgenres. Counts include books tagged directly on a genre and books tagged on any of its descendants.
+        </p>
+      </section>
+
+      {tree.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed py-16 text-center">
+          <BookOpen className="h-10 w-10 text-muted-foreground/40" />
+          <p className="text-sm text-muted-foreground">No genres are available yet.</p>
+          <Button asChild size="sm" variant="outline">
+            <Link to="/library">Back to Library</Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {rootSections.map((section) => {
+            const sectionSlug = slugById.get(section.id) ?? section.id;
+
+            return (
+              <section key={section.id} className="rounded-xl border bg-card p-4">
+                <Link
+                  to={`/genres/${sectionSlug}`}
+                  className="group mb-3 grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-3 rounded-md border-b px-3 pb-3 pt-1 transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <div className="min-w-0">
+                    <h2 className="truncate text-lg font-heading leading-snug font-medium">{section.name}</h2>
+                    <p className="text-xs text-muted-foreground">
+                      {section.children.length} top-level genre{section.children.length === 1 ? "" : "s"}
+                    </p>
+                  </div>
+                  <Badge variant="outline" className="justify-self-end whitespace-nowrap">
+                    {formatBookCount(countsById.get(section.id)?.total ?? 0)}
+                  </Badge>
+                  <ChevronRight className="h-4 w-4 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                </Link>
+                <ul className="space-y-1">
+                  {section.children.map((child) => (
+                    <GenreTreeRow
+                      key={child.id}
+                      node={child}
+                      slugById={slugById}
+                      countsById={countsById}
+                    />
+                  ))}
+                </ul>
+              </section>
+            );
+          })}
+
+          {customRoots.length > 0 && (
+            <section className="rounded-xl border bg-card p-4">
+              <div className="mb-3 border-b pb-3">
+                <h2 className="text-lg font-heading leading-snug font-medium">Custom Genres</h2>
+                <p className="text-xs text-muted-foreground">Genres you created outside the system sections.</p>
+              </div>
+              <ul className="space-y-1">
+                {customRoots.map((node) => (
+                  <GenreTreeRow
+                    key={node.id}
+                    node={node}
+                    slugById={slugById}
+                    countsById={countsById}
+                  />
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/genres.test.ts
+++ b/tests/genres.test.ts
@@ -2,14 +2,19 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildGenreTree,
+  buildGenreSlugLookup,
   formatGenrePathForDisplay,
+  getBooksForGenreSubtree,
+  getDescendantGenreIds,
+  getGenreBookCount,
   getGenrePathLabel,
   getMostSpecificGenres,
   getSelectedGenreTags,
+  slugifyGenreName,
   mapGenreLabelsToIds,
   searchGenres,
 } from "../src/lib/genreTree";
-import type { Genre } from "../src/types";
+import type { Book, Genre } from "../src/types";
 
 function makeGenre(overrides: Partial<Genre> & Pick<Genre, "id" | "name">): Genre {
   return {
@@ -26,12 +31,24 @@ const genres = [
   makeGenre({ id: "fiction", name: "Fiction" }),
   makeGenre({ id: "fantasy", name: "Fantasy", parent_id: "fiction" }),
   makeGenre({ id: "epic", name: "Epic Fantasy", parent_id: "fantasy" }),
+  makeGenre({ id: "high", name: "High Fantasy", parent_id: "fantasy" }),
   makeGenre({ id: "dark", name: "Dark Fantasy", parent_id: "fantasy" }),
   makeGenre({ id: "nonfiction", name: "Non-Fiction" }),
   makeGenre({ id: "history", name: "History", parent_id: "nonfiction" }),
   makeGenre({ id: "age", name: "Age Target" }),
   makeGenre({ id: "ya", name: "Young Adult", parent_id: "age" }),
 ];
+
+function makeBook(overrides: Partial<Book> & Pick<Book, "id" | "title" | "genre_ids">): Book {
+  return {
+    authors: ["Unknown"],
+    status: "Not Started",
+    is_favorite: false,
+    user_id: "user-1",
+    created_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
 
 test("builds an unlimited-depth genre tree", () => {
   const tree = buildGenreTree(genres);
@@ -80,4 +97,74 @@ test("maps external genre labels and age labels to known genre ids case-insensit
     "history",
     "ya",
   ]);
+});
+
+test("slugifies genre names for readable urls", () => {
+  assert.equal(slugifyGenreName("Science Fiction"), "science-fiction");
+  assert.equal(slugifyGenreName("Mystery & Crime"), "mystery-crime");
+  assert.equal(slugifyGenreName("Children's"), "childrens");
+});
+
+test("builds duplicate-safe genre slugs with readable parent fallback", () => {
+  const duplicateGenres = [
+    ...genres,
+    makeGenre({ id: "nonfiction-fantasy", name: "Fantasy", parent_id: "nonfiction" }),
+  ];
+  const { slugById, genreBySlug } = buildGenreSlugLookup(duplicateGenres);
+
+  assert.equal(slugById.get("fantasy"), "fantasy");
+  assert.equal(slugById.get("nonfiction-fantasy"), "non-fiction-fantasy");
+  assert.equal(genreBySlug.get("non-fiction-fantasy")?.id, "nonfiction-fantasy");
+});
+
+test("collects descendant genre ids for nested trees", () => {
+  assert.deepEqual(getDescendantGenreIds("fantasy", genres), ["dark", "epic", "high"]);
+});
+
+test("counts parent genre books from direct and descendant assignments", () => {
+  const books = [
+    makeBook({ id: "direct", title: "Direct Fantasy", genre_ids: ["fantasy"] }),
+    makeBook({ id: "child", title: "Epic Fantasy", genre_ids: ["epic"] }),
+    makeBook({ id: "both", title: "Both", genre_ids: ["fantasy", "epic"] }),
+    makeBook({ id: "other", title: "History", genre_ids: ["history"] }),
+  ];
+
+  assert.deepEqual(getGenreBookCount("fantasy", books, genres), {
+    direct: 2,
+    descendant: 2,
+    total: 3,
+  });
+});
+
+test("ignores direct assignments on root organizer genres", () => {
+  const books = [
+    makeBook({ id: "root-only", title: "Root Fiction", genre_ids: ["fiction"] }),
+    makeBook({ id: "child", title: "Fantasy Book", genre_ids: ["fantasy"] }),
+  ];
+
+  assert.deepEqual(getGenreBookCount("fiction", books, genres), {
+    direct: 0,
+    descendant: 1,
+    total: 1,
+  });
+  assert.deepEqual(
+    getBooksForGenreSubtree(books, "fiction", genres).map((book) => book.id),
+    ["child"],
+  );
+});
+
+test("includes child genre books on both child and parent genre pages", () => {
+  const books = [
+    makeBook({ id: "high-fantasy-book", title: "High Fantasy Book", genre_ids: ["high"] }),
+    makeBook({ id: "history-book", title: "History Book", genre_ids: ["history"] }),
+  ];
+
+  assert.deepEqual(
+    getBooksForGenreSubtree(books, "high", genres).map((book) => book.id),
+    ["high-fantasy-book"],
+  );
+  assert.deepEqual(
+    getBooksForGenreSubtree(books, "fantasy", genres).map((book) => book.id),
+    ["high-fantasy-book"],
+  );
 });


### PR DESCRIPTION
## Summary

Adds a genre discovery flow for browsing the genre hierarchy and opening detail pages for individual genres.

## What changed

- Added a protected `/genres` page that displays the full genre tree grouped by root sections.
- Made root sections like Fiction, Non-Fiction, and Age Target clickable so they open their own genre pages.
- Reworked genre detail pages to use readable slug URLs while keeping UUID-based URLs compatible.
- Added genre metadata descriptions in code rather than adding new database columns.
- Added genre helpers for slug generation, duplicate slug fallback, descendant lookup, subtree book matching, and book counts.
- Updated genre counts so root organizer genres ignore direct root assignments and only count descendant genre books.
- Linked genre badges on book detail pages to the matching genre pages.
- Added a Browse genres link from Analytics/Discover.

## Validation

- `npm test`
- `npm run build`
