### PR TITLE
[codex] chat replies, reactions, and attachments

### DIFF
--- a/src/components/groups/GroupsManager.tsx
+++ b/src/components/groups/GroupsManager.tsx
@@ -47,6 +47,7 @@ import {
   buildAuthorAttachment,
   buildBookAttachment,
   buildNoteAttachment,
+  buildSeriesAttachment,
   noteSnapshotToCreateInput,
   MAX_INCLUDED_ATTACHMENT_NOTES,
 } from "@/lib/chatAttachments";
@@ -74,6 +75,7 @@ import {
 import { supabase } from "@/lib/supabase";
 import { buildAuthorSummaries } from "@/lib/authorShelf";
 import { createBookNote, fetchAllBookNotes } from "@/lib/bookNotes";
+import { useSeries } from "@/hooks/useSeries";
 import { cn } from "@/lib/utils";
 import type {
   Book,
@@ -85,10 +87,11 @@ import type {
   GroupMessage,
   PublicProfile,
   GroupMembershipRole,
+  Series,
 } from "@/types";
 
 type ComposeMode = "direct" | "group";
-type AttachmentPickerMode = "book" | "note" | "author";
+type AttachmentPickerMode = "book" | "note" | "author" | "series";
 
 type ConfirmAction =
   | { type: "message"; messageId: string }
@@ -181,7 +184,14 @@ function noteLabel(label: ChatSharedNoteSnapshot["label"]): string {
 function attachmentTypeLabel(attachment: ChatAttachmentPayload): string {
   if (attachment.type === "book") return "Book";
   if (attachment.type === "note") return noteLabel(attachment.note.label);
-  return "Author";
+  if (attachment.type === "author") return "Author";
+  return "Series";
+}
+
+function sortSeriesByName(series: Series[]): Series[] {
+  return [...series].sort((first, second) =>
+    first.name.localeCompare(second.name, undefined, { sensitivity: "base", numeric: true }),
+  );
 }
 
 function sortBooksByTitle(books: Book[]): Book[] {
@@ -407,6 +417,49 @@ function AttachmentCard({
           )}
         </div>
       )}
+
+      {attachment.type === "series" && (
+        <div className="space-y-3">
+          <div>
+            <p className="font-medium">{attachment.series.name}</p>
+            <p className="text-xs text-muted-foreground">
+              {attachment.series.books.length} book{attachment.series.books.length === 1 ? "" : "s"} shared
+            </p>
+          </div>
+          {attachment.series.books.length > 0 && (
+            <div className="space-y-2">
+              {attachment.series.books.map((book, index) => (
+                <div
+                  key={`${book.id ?? book.title}-${index}`}
+                  className="flex items-center gap-3 rounded-md border bg-muted/20 p-2"
+                >
+                  {book.cover_url ? (
+                    <img src={book.cover_url} alt="" className="h-14 w-10 shrink-0 rounded object-cover" />
+                  ) : (
+                    <div className="flex h-14 w-10 shrink-0 items-center justify-center rounded bg-muted">
+                      <BookOpen className="h-4 w-4 text-muted-foreground" />
+                    </div>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{book.title}</p>
+                    <p className="truncate text-xs text-muted-foreground">{book.authors.join(", ")}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          {attachment.series.included_quotes && attachment.series.included_quotes.length > 0 && (
+            <div className="space-y-1">
+              {attachment.series.included_quotes.map((quote, index) => (
+                <p key={`${quote.id ?? index}-${quote.content}`} className="rounded-md bg-muted/50 px-2 py-1 text-xs">
+                  {quote.content}
+                  {quote.book_title && <span className="text-muted-foreground"> - {quote.book_title}</span>}
+                </p>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -414,6 +467,7 @@ function AttachmentCard({
 export function GroupsManager() {
   const { user } = useAuth();
   const { books, addBook } = useBooksContext();
+  const { series } = useSeries();
   const [threads, setThreads] = useState<ChatThread[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>("");
   const [messages, setMessages] = useState<GroupMessage[]>([]);
@@ -437,6 +491,7 @@ export function GroupsManager() {
   const [selectedBookId, setSelectedBookId] = useState("");
   const [selectedNoteId, setSelectedNoteId] = useState("");
   const [selectedAuthorName, setSelectedAuthorName] = useState("");
+  const [selectedSeriesId, setSelectedSeriesId] = useState("");
   const [selectedIncludedNoteIds, setSelectedIncludedNoteIds] = useState<string[]>([]);
   const [selectedAttachment, setSelectedAttachment] = useState<ChatAttachmentPayload | null>(null);
   const [selectedReply, setSelectedReply] = useState<ChatReplySnapshot | null>(null);
@@ -485,6 +540,26 @@ export function GroupsManager() {
   }, [notes]);
 
   const authorSummaries = useMemo(() => buildAuthorSummaries(books, notes), [books, notes]);
+  const seriesById = useMemo(() => new Map(series.map((item) => [item.id, item])), [series]);
+  const seriesBooksById = useMemo(() => {
+    const map = new Map<string, Book[]>();
+    books.forEach((book) => {
+      if (!book.series_id) return;
+      map.set(book.series_id, [...(map.get(book.series_id) ?? []), book]);
+    });
+    return map;
+  }, [books]);
+  const seriesQuoteNotesById = useMemo(() => {
+    const map = new Map<string, BookNote[]>();
+    books.forEach((book) => {
+      if (!book.series_id) return;
+      const bookNotes = notesByBookId.get(book.id) ?? [];
+      const quoteNotes = bookNotes.filter((note) => note.label === "quote");
+      if (quoteNotes.length === 0) return;
+      map.set(book.series_id, [...(map.get(book.series_id) ?? []), ...quoteNotes]);
+    });
+    return map;
+  }, [books, notesByBookId]);
 
   const filteredBooks = useMemo(() => {
     const query = attachmentSearch.trim().toLowerCase();
@@ -513,14 +588,24 @@ export function GroupsManager() {
     return authorSummaries.filter((author) => author.name.toLowerCase().includes(query));
   }, [attachmentSearch, authorSummaries]);
 
+  const filteredSeries = useMemo(() => {
+    const query = attachmentSearch.trim().toLowerCase();
+    const sorted = sortSeriesByName(series);
+    if (!query) return sorted;
+    return sorted.filter((item) => item.name.toLowerCase().includes(query));
+  }, [attachmentSearch, series]);
+
   const selectedBook = selectedBookId ? booksById.get(selectedBookId) ?? null : null;
   const selectedNote = selectedNoteId ? notes.find((note) => note.id === selectedNoteId) ?? null : null;
   const selectedAuthor = selectedAuthorName
     ? authorSummaries.find((author) => author.name === selectedAuthorName) ?? null
     : null;
+  const selectedSeries = selectedSeriesId ? seriesById.get(selectedSeriesId) ?? null : null;
 
   const selectedBookNotes = selectedBook ? sortNotesForPicker(notesByBookId.get(selectedBook.id) ?? []) : [];
   const selectedAuthorQuotes = selectedAuthor ? sortNotesForPicker(selectedAuthor.quotes) : [];
+  const selectedSeriesBooks = selectedSeries ? sortBooksByTitle(seriesBooksById.get(selectedSeries.id) ?? []) : [];
+  const selectedSeriesQuotes = selectedSeries ? sortNotesForPicker(seriesQuoteNotesById.get(selectedSeries.id) ?? []) : [];
 
   useEffect(() => {
     let cancelled = false;
@@ -807,6 +892,7 @@ export function GroupsManager() {
     setSelectedBookId("");
     setSelectedNoteId("");
     setSelectedAuthorName("");
+    setSelectedSeriesId("");
     setSelectedIncludedNoteIds([]);
   }
 
@@ -838,6 +924,19 @@ export function GroupsManager() {
         buildAuthorAttachment({
           authorName: selectedAuthor.name,
           books: selectedAuthor.books,
+          includedQuotes,
+        }),
+      );
+    }
+
+    if (attachmentPicker === "series" && selectedSeries) {
+      const includedQuotes = selectedIncludedNoteIds
+        .map((noteId) => notes.find((note) => note.id === noteId))
+        .filter((note): note is BookNote => Boolean(note));
+      setSelectedAttachment(
+        buildSeriesAttachment({
+          seriesName: selectedSeries.name,
+          books: selectedSeriesBooks,
           includedQuotes,
         }),
       );
@@ -1527,6 +1626,14 @@ export function GroupsManager() {
                               <UserRound className="h-4 w-4" />
                               Attach Author
                             </button>
+                            <button
+                              type="button"
+                              className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+                              onClick={() => openAttachmentPicker("series")}
+                            >
+                              <Users className="h-4 w-4" />
+                              Attach Series
+                            </button>
                           </div>
                         )}
                       </div>
@@ -1674,7 +1781,9 @@ export function GroupsManager() {
                 ? "Attach Book"
                 : attachmentPicker === "note"
                   ? "Attach Notes"
-                  : "Attach Author"}
+                  : attachmentPicker === "author"
+                    ? "Attach Author"
+                    : "Attach Series"}
             </DialogTitle>
             <DialogDescription>
               Select what you want to send in this chat.
@@ -1827,6 +1936,61 @@ export function GroupsManager() {
                 </div>
               </div>
             )}
+
+            {attachmentPicker === "series" && (
+              <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                <div className="max-h-72 space-y-1 overflow-y-auto">
+                  {filteredSeries.map((item) => {
+                    const booksInSeries = seriesBooksById.get(item.id) ?? [];
+                    const quotesInSeries = seriesQuoteNotesById.get(item.id) ?? [];
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        className={cn(
+                          "w-full rounded-md p-3 text-left hover:bg-muted",
+                          selectedSeriesId === item.id && "bg-muted",
+                        )}
+                        onClick={() => {
+                          setSelectedSeriesId(item.id);
+                          setSelectedIncludedNoteIds([]);
+                        }}
+                      >
+                        <span className="block truncate text-sm font-medium">{item.name}</span>
+                        <span className="block text-xs text-muted-foreground">
+                          {booksInSeries.length} book{booksInSeries.length === 1 ? "" : "s"} · {quotesInSeries.length} quote
+                          {quotesInSeries.length === 1 ? "" : "s"}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+
+                <div className="max-h-72 space-y-2 overflow-y-auto rounded-md border p-3">
+                  <p className="text-sm font-medium">Include quotes</p>
+                  {!selectedSeries ? (
+                    <p className="text-sm text-muted-foreground">Select a series first.</p>
+                  ) : selectedSeriesQuotes.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No quotes for this series yet.</p>
+                  ) : (
+                    selectedSeriesQuotes.map((quote) => (
+                      <label key={quote.id} className="flex gap-2 rounded-md p-2 text-sm hover:bg-muted">
+                        <input
+                          type="checkbox"
+                          checked={selectedIncludedNoteIds.includes(quote.id)}
+                          disabled={
+                            !selectedIncludedNoteIds.includes(quote.id) &&
+                            selectedIncludedNoteIds.length >= MAX_INCLUDED_ATTACHMENT_NOTES
+                          }
+                          onChange={() => toggleIncludedNote(quote.id)}
+                        />
+                        <span className="line-clamp-2">{quote.content}</span>
+                      </label>
+                    ))
+                  )}
+                </div>
+              </div>
+            )}
           </div>
 
           <DialogFooter>
@@ -1839,7 +2003,8 @@ export function GroupsManager() {
               disabled={
                 (attachmentPicker === "book" && !selectedBook) ||
                 (attachmentPicker === "note" && !selectedNote) ||
-                (attachmentPicker === "author" && !selectedAuthor)
+                (attachmentPicker === "author" && !selectedAuthor) ||
+                (attachmentPicker === "series" && !selectedSeries)
               }
             >
               Attach

--- a/src/components/groups/GroupsManager.tsx
+++ b/src/components/groups/GroupsManager.tsx
@@ -1,7 +1,34 @@
-import { useEffect, useMemo, useState, type FormEvent } from "react";
-import { UserPlus, Users } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import {
+  ArrowLeft,
+  BookOpen,
+  Copy,
+  Heart,
+  MessageCircle,
+  Paperclip,
+  Pencil,
+  Plus,
+  Reply,
+  Search,
+  Send,
+  Settings,
+  StickyNote,
+  Trash2,
+  UserPlus,
+  UserRound,
+  Users,
+  X,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -13,308 +40,1813 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "@/context";
+import { useBooksContext } from "@/context/BooksContext";
 import {
-  addGroupMember,
-  createGroup,
-  getErrorMessage,
-  getGroupMembers,
-  getMyGroups,
-  removeGroupMember,
-  updateGroupMemberRole,
-  type GroupPayload,
-} from "@/lib/profiles";
-import type { Group, GroupMembership, GroupMembershipRole } from "@/types";
+  attachmentTitle,
+  bookSnapshotToAddBookPayload,
+  buildAuthorAttachment,
+  buildBookAttachment,
+  buildNoteAttachment,
+  noteSnapshotToCreateInput,
+  MAX_INCLUDED_ATTACHMENT_NOTES,
+} from "@/lib/chatAttachments";
+import {
+  addGroupMemberByUsername,
+  changeGroupMemberRole,
+  createGroupChat,
+  createOrGetDirectChat,
+  deleteChatMessage,
+  editChatMessage,
+  buildReplySnapshot,
+  getChatMembers,
+  getChatMessages,
+  getChatThreads,
+  getMessagePreview,
+  markChatRead,
+  removeChatMember,
+  searchPublicProfiles,
+  sendChatMessage,
+  toggleHeartReaction,
+  toChatErrorMessage,
+  type ChatMember,
+  type ChatThread,
+} from "@/lib/chat";
+import { supabase } from "@/lib/supabase";
+import { buildAuthorSummaries } from "@/lib/authorShelf";
+import { createBookNote, fetchAllBookNotes } from "@/lib/bookNotes";
+import { cn } from "@/lib/utils";
+import type {
+  Book,
+  BookNote,
+  ChatAttachmentPayload,
+  ChatReplySnapshot,
+  ChatSharedBookSnapshot,
+  ChatSharedNoteSnapshot,
+  GroupMessage,
+  PublicProfile,
+  GroupMembershipRole,
+} from "@/types";
 
-const UUID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+type ComposeMode = "direct" | "group";
+type AttachmentPickerMode = "book" | "note" | "author";
 
-function getAddMemberErrorMessage(error: unknown): string {
-  const message = getErrorMessage(error, "Could not add member.");
+type ConfirmAction =
+  | { type: "message"; messageId: string }
+  | { type: "member"; userId: string }
+  | { type: "leave"; userId: string };
 
-  if (
-    message.includes("group_memberships_user_id_fkey") ||
-    message.includes("violates foreign key constraint")
-  ) {
-    return "No app user exists for that UUID. Make sure the user has accepted their invite.";
-  }
+type MessageActionMenu = {
+  messageId: string;
+  x: number;
+  y: number;
+};
 
-  return message;
+function formatMessageTime(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function profileLabel(profile?: PublicProfile): string {
+  if (!profile) return "Unknown user";
+  return profile.display_name?.trim() || profile.username?.trim() || "Unknown user";
+}
+
+function profileSubLabel(profile?: PublicProfile): string {
+  if (profile?.username) return `@${profile.username}`;
+  return "No username";
+}
+
+function initialsFor(profile?: PublicProfile, fallback = "?"): string {
+  const label = profileLabel(profile);
+  if (label !== "Unknown user") return label.trim().charAt(0).toUpperCase();
+  return fallback.trim().charAt(0).toUpperCase() || "?";
+}
+
+function MessageAvatar({ profile, fallback }: { profile?: PublicProfile; fallback?: string }) {
+  const [imageFailed, setImageFailed] = useState(false);
+  const avatarUrl = profile?.avatar_url?.trim() || "";
+
+  useEffect(() => {
+    setImageFailed(false);
+  }, [avatarUrl]);
+
+  return (
+    <span className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted text-sm font-medium text-muted-foreground">
+      {avatarUrl && !imageFailed ? (
+        <img src={avatarUrl} alt="" className="h-full w-full object-cover" onError={() => setImageFailed(true)} />
+      ) : (
+        <span aria-hidden="true">{initialsFor(profile, fallback)}</span>
+      )}
+    </span>
+  );
+}
+
+function messageFromPayload(payload: unknown): GroupMessage {
+  const row = payload as GroupMessage;
+  return {
+    id: row.id,
+    group_id: row.group_id,
+    sender_id: row.sender_id,
+    content: row.content,
+    attachment_type: row.attachment_type ?? null,
+    attachment_payload: row.attachment_payload ?? null,
+    reply_to_message_id: row.reply_to_message_id ?? null,
+    reply_snapshot: row.reply_snapshot ?? null,
+    reactions: row.reactions ?? [],
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    edited_at: row.edited_at ?? null,
+    deleted_at: row.deleted_at ?? null,
+  };
+}
+
+function upsertMessage(messages: GroupMessage[], nextMessage: GroupMessage): GroupMessage[] {
+  const withoutExisting = messages.filter((message) => message.id !== nextMessage.id);
+  return [...withoutExisting, nextMessage].sort(
+    (first, second) =>
+      new Date(first.created_at).getTime() - new Date(second.created_at).getTime(),
+  );
+}
+
+function noteLabel(label: ChatSharedNoteSnapshot["label"]): string {
+  if (label === "quote") return "Quote";
+  if (label === "review") return "Review";
+  return "Note";
+}
+
+function attachmentTypeLabel(attachment: ChatAttachmentPayload): string {
+  if (attachment.type === "book") return "Book";
+  if (attachment.type === "note") return noteLabel(attachment.note.label);
+  return "Author";
+}
+
+function sortBooksByTitle(books: Book[]): Book[] {
+  return [...books].sort((first, second) =>
+    first.title.localeCompare(second.title, undefined, { sensitivity: "base", numeric: true }),
+  );
+}
+
+function sortNotesForPicker(notes: BookNote[]): BookNote[] {
+  return [...notes].sort((first, second) => {
+    const dateCompare = (second.note_date ?? second.created_at).localeCompare(first.note_date ?? first.created_at);
+    if (dateCompare !== 0) return dateCompare;
+    return second.created_at.localeCompare(first.created_at);
+  });
+}
+
+function AttachmentSummary({ attachment }: { attachment: ChatAttachmentPayload }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border bg-muted/35 px-3 py-2 text-sm">
+      <Badge variant="outline">{attachmentTypeLabel(attachment)}</Badge>
+      <span className="min-w-0 flex-1 truncate">{attachmentTitle(attachment)}</span>
+    </div>
+  );
+}
+
+function ReplyPreview({
+  reply,
+  compact = false,
+  onCancel,
+}: {
+  reply: ChatReplySnapshot;
+  compact?: boolean;
+  onCancel?: () => void;
+}) {
+  return (
+    <div className={cn("flex gap-2 rounded-md border-l-4 border-primary/70 bg-background/70 px-3 py-2", compact && "py-1.5")}>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium text-primary">Reply to {reply.sender_name}</p>
+        <p className="line-clamp-1 text-xs text-muted-foreground">
+          {reply.attachment_title ? `${reply.attachment_title}: ` : ""}
+          {reply.text}
+        </p>
+      </div>
+      {onCancel && (
+        <Button type="button" size="icon" variant="ghost" className="h-7 w-7 shrink-0" onClick={onCancel}>
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function reactionNames(reaction: NonNullable<GroupMessage["reactions"]>[number]): string {
+  return reaction.participants.map((participant) => participant.display_name).join(", ");
+}
+
+function AttachmentCard({
+  message,
+  mine,
+  books,
+  noteImportOpen,
+  noteImportTargetBookId,
+  onImportBook,
+  onOpenNoteImport,
+  onCancelNoteImport,
+  onNoteTargetChange,
+  onImportNote,
+}: {
+  message: GroupMessage;
+  mine: boolean;
+  books: Book[];
+  noteImportOpen: boolean;
+  noteImportTargetBookId: string;
+  onImportBook: (book: ChatSharedBookSnapshot) => void;
+  onOpenNoteImport: () => void;
+  onCancelNoteImport: () => void;
+  onNoteTargetChange: (bookId: string) => void;
+  onImportNote: () => void;
+}) {
+  const attachment = message.attachment_payload;
+  if (!attachment) return null;
+
+  return (
+    <div className="mt-2 space-y-3 rounded-lg border bg-background p-3 text-foreground shadow-sm">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline">{attachmentTypeLabel(attachment)}</Badge>
+        <span className="min-w-0 truncate text-sm font-medium">{attachmentTitle(attachment)}</span>
+      </div>
+
+      {attachment.type === "book" && (
+        <div className="flex gap-3">
+          {attachment.book.cover_url ? (
+            <img
+              src={attachment.book.cover_url}
+              alt=""
+              className="h-24 w-16 shrink-0 rounded-md object-cover"
+            />
+          ) : (
+            <div className="flex h-24 w-16 shrink-0 items-center justify-center rounded-md bg-muted">
+              <BookOpen className="h-5 w-5 text-muted-foreground" />
+            </div>
+          )}
+          <div className="min-w-0 flex-1 space-y-2">
+            <div>
+              <p className="font-medium leading-snug">{attachment.book.title}</p>
+              <p className="text-xs text-muted-foreground">{attachment.book.authors.join(", ")}</p>
+            </div>
+            {attachment.book.description && (
+              <p className="line-clamp-3 text-xs text-muted-foreground">{attachment.book.description}</p>
+            )}
+            {attachment.book.included_notes && attachment.book.included_notes.length > 0 && (
+              <div className="space-y-1">
+                {attachment.book.included_notes.map((note, index) => (
+                  <p key={`${note.id ?? index}-${note.label}`} className="rounded-md bg-muted/50 px-2 py-1 text-xs">
+                    <span className="font-medium">{noteLabel(note.label)}:</span> {note.content}
+                  </p>
+                ))}
+              </div>
+            )}
+            {!mine && (
+              <Button type="button" size="sm" variant="outline" onClick={() => onImportBook(attachment.book)}>
+                Save to own library
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {attachment.type === "note" && (
+        <div className="space-y-3">
+          <div className="rounded-md bg-muted/50 px-3 py-2">
+            <p className="text-xs font-medium uppercase text-muted-foreground">{noteLabel(attachment.note.label)}</p>
+            {attachment.note.title && <p className="mt-1 text-sm font-medium">{attachment.note.title}</p>}
+            <p className="mt-1 text-sm">{attachment.note.content}</p>
+            {attachment.note.quote_speaker && (
+              <p className="mt-1 text-xs text-muted-foreground">- {attachment.note.quote_speaker}</p>
+            )}
+            {attachment.note.book_title && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                From {attachment.note.book_title}
+              </p>
+            )}
+          </div>
+
+          {!mine && !noteImportOpen && (
+            <Button type="button" size="sm" variant="outline" onClick={onOpenNoteImport}>
+              Save to own library
+            </Button>
+          )}
+
+          {!mine && noteImportOpen && (
+            <div className="space-y-2 rounded-md border p-3">
+              <Label>Choose a book</Label>
+              <Select value={noteImportTargetBookId} onValueChange={onNoteTargetChange}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a book" />
+                </SelectTrigger>
+                <SelectContent>
+                  {sortBooksByTitle(books).map((book) => (
+                    <SelectItem key={book.id} value={book.id}>
+                      {book.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <div className="flex justify-end gap-2">
+                <Button type="button" size="sm" variant="ghost" onClick={onCancelNoteImport}>
+                  Cancel
+                </Button>
+                <Button type="button" size="sm" disabled={!noteImportTargetBookId} onClick={onImportNote}>
+                  Save
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {attachment.type === "author" && (
+        <div className="space-y-3">
+          <div>
+            <p className="font-medium">{attachment.author.name}</p>
+            <p className="text-xs text-muted-foreground">
+              {attachment.author.books.length} book{attachment.author.books.length === 1 ? "" : "s"} shared
+            </p>
+          </div>
+          {attachment.author.books.length > 0 && (
+            <div className="space-y-2">
+              {attachment.author.books.map((book, index) => (
+                <div
+                  key={`${book.id ?? book.title}-${index}`}
+                  className="flex items-center gap-3 rounded-md border bg-muted/20 p-2"
+                >
+                  {book.cover_url ? (
+                    <img src={book.cover_url} alt="" className="h-14 w-10 shrink-0 rounded object-cover" />
+                  ) : (
+                    <div className="flex h-14 w-10 shrink-0 items-center justify-center rounded bg-muted">
+                      <BookOpen className="h-4 w-4 text-muted-foreground" />
+                    </div>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{book.title}</p>
+                    <p className="truncate text-xs text-muted-foreground">{book.authors.join(", ")}</p>
+                  </div>
+                  {!mine && (
+                    <Button type="button" size="sm" variant="outline" onClick={() => onImportBook(book)}>
+                      Save
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+          {attachment.author.included_quotes && attachment.author.included_quotes.length > 0 && (
+            <div className="space-y-1">
+              {attachment.author.included_quotes.map((quote, index) => (
+                <p key={`${quote.id ?? index}-${quote.content}`} className="rounded-md bg-muted/50 px-2 py-1 text-xs">
+                  {quote.content}
+                  {quote.book_title && <span className="text-muted-foreground"> - {quote.book_title}</span>}
+                </p>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function GroupsManager() {
   const { user } = useAuth();
-  const [groups, setGroups] = useState<Group[]>([]);
+  const { books, addBook } = useBooksContext();
+  const [threads, setThreads] = useState<ChatThread[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>("");
-  const [members, setMembers] = useState<GroupMembership[]>([]);
-  const [groupForm, setGroupForm] = useState<GroupPayload>({ name: "", description: "" });
-  const [memberUserId, setMemberUserId] = useState("");
-  const [creatingGroup, setCreatingGroup] = useState(false);
-  const [message, setMessage] = useState<string | null>(null);
+  const [messages, setMessages] = useState<GroupMessage[]>([]);
+  const [members, setMembers] = useState<ChatMember[]>([]);
+  const [notes, setNotes] = useState<BookNote[]>([]);
+  const [composeMode, setComposeMode] = useState<ComposeMode>("direct");
+  const [directSearch, setDirectSearch] = useState("");
+  const [profileResults, setProfileResults] = useState<PublicProfile[]>([]);
+  const [groupName, setGroupName] = useState("");
+  const [groupDescription, setGroupDescription] = useState("");
+  const [memberUsername, setMemberUsername] = useState("");
+  const [messageText, setMessageText] = useState("");
+  const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+  const [editingText, setEditingText] = useState("");
+  const [mobileThreadOpen, setMobileThreadOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+  const [attachMenuOpen, setAttachMenuOpen] = useState(false);
+  const [attachmentPicker, setAttachmentPicker] = useState<AttachmentPickerMode | null>(null);
+  const [attachmentSearch, setAttachmentSearch] = useState("");
+  const [selectedBookId, setSelectedBookId] = useState("");
+  const [selectedNoteId, setSelectedNoteId] = useState("");
+  const [selectedAuthorName, setSelectedAuthorName] = useState("");
+  const [selectedIncludedNoteIds, setSelectedIncludedNoteIds] = useState<string[]>([]);
+  const [selectedAttachment, setSelectedAttachment] = useState<ChatAttachmentPayload | null>(null);
+  const [selectedReply, setSelectedReply] = useState<ChatReplySnapshot | null>(null);
+  const [messageActionMenu, setMessageActionMenu] = useState<MessageActionMenu | null>(null);
+  const [reactionDetailsMessageId, setReactionDetailsMessageId] = useState<string | null>(null);
+  const [noteImportMessageId, setNoteImportMessageId] = useState<string | null>(null);
+  const [noteImportTargetBookId, setNoteImportTargetBookId] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [messagesLoading, setMessagesLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const longPressTimerRef = useRef<number | null>(null);
 
-  const selectedGroup = useMemo(
-    () => groups.find((group) => group.id === selectedGroupId) ?? null,
-    [groups, selectedGroupId],
+  const selectedThread = useMemo(
+    () => threads.find((thread) => thread.group.id === selectedGroupId) ?? null,
+    [threads, selectedGroupId],
   );
 
-  async function loadGroups() {
-    setError(null);
-    try {
-      const nextGroups = await getMyGroups();
-      setGroups(nextGroups);
-      setSelectedGroupId((current) =>
-        nextGroups.some((group) => group.id === current) ? current : nextGroups[0]?.id || "",
-      );
-    } catch (loadError) {
-      setError(getErrorMessage(loadError, "Could not load groups."));
-    }
-  }
+  const memberProfiles = useMemo(
+    () =>
+      new Map(
+        members.map((member) => [member.user_id, member.profile]).filter((entry): entry is [string, PublicProfile] =>
+          Boolean(entry[1]),
+        ),
+      ),
+    [members],
+  );
+
+  const canManageSelectedGroup =
+    selectedThread?.group.kind === "group" &&
+    ["owner", "admin"].includes(selectedThread.currentMembership.role);
+
+  const booksById = useMemo(
+    () => new Map(books.map((book) => [book.id, book])),
+    [books],
+  );
+
+  const notesByBookId = useMemo(() => {
+    const map = new Map<string, BookNote[]>();
+    notes.forEach((note) => {
+      map.set(note.book_id, [...(map.get(note.book_id) ?? []), note]);
+    });
+    return map;
+  }, [notes]);
+
+  const authorSummaries = useMemo(() => buildAuthorSummaries(books, notes), [books, notes]);
+
+  const filteredBooks = useMemo(() => {
+    const query = attachmentSearch.trim().toLowerCase();
+    const sorted = sortBooksByTitle(books);
+    if (!query) return sorted;
+    return sorted.filter((book) =>
+      [book.title, ...book.authors].some((value) => value.toLowerCase().includes(query)),
+    );
+  }, [attachmentSearch, books]);
+
+  const filteredNotes = useMemo(() => {
+    const query = attachmentSearch.trim().toLowerCase();
+    const sorted = sortNotesForPicker(notes);
+    if (!query) return sorted;
+    return sorted.filter((note) => {
+      const book = booksById.get(note.book_id);
+      return [note.title, note.content, note.quote_speaker, book?.title]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(query));
+    });
+  }, [attachmentSearch, booksById, notes]);
+
+  const filteredAuthors = useMemo(() => {
+    const query = attachmentSearch.trim().toLowerCase();
+    if (!query) return authorSummaries;
+    return authorSummaries.filter((author) => author.name.toLowerCase().includes(query));
+  }, [attachmentSearch, authorSummaries]);
+
+  const selectedBook = selectedBookId ? booksById.get(selectedBookId) ?? null : null;
+  const selectedNote = selectedNoteId ? notes.find((note) => note.id === selectedNoteId) ?? null : null;
+  const selectedAuthor = selectedAuthorName
+    ? authorSummaries.find((author) => author.name === selectedAuthorName) ?? null
+    : null;
+
+  const selectedBookNotes = selectedBook ? sortNotesForPicker(notesByBookId.get(selectedBook.id) ?? []) : [];
+  const selectedAuthorQuotes = selectedAuthor ? sortNotesForPicker(selectedAuthor.quotes) : [];
 
   useEffect(() => {
-    void loadGroups();
-  }, []);
-
-  useEffect(() => {
-    if (!selectedGroupId) {
-      setMembers([]);
-      return;
-    }
-
     let cancelled = false;
-    getGroupMembers(selectedGroupId)
-      .then((nextMembers) => {
-        if (!cancelled) setMembers(nextMembers);
+
+    fetchAllBookNotes()
+      .then((nextNotes) => {
+        if (!cancelled) setNotes(nextNotes);
       })
-      .catch((memberError) => {
-        if (!cancelled) {
-          setError(getErrorMessage(memberError, "Could not load group members."));
-        }
+      .catch(() => {
+        if (!cancelled) setNotes([]);
       });
 
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  async function loadThreads(preferredGroupId?: string) {
+    if (!user) return;
+
+    setError(null);
+    try {
+      const nextThreads = await getChatThreads(user.id);
+      setThreads(nextThreads);
+      setSelectedGroupId((current) => {
+        if (preferredGroupId && nextThreads.some((thread) => thread.group.id === preferredGroupId)) {
+          return preferredGroupId;
+        }
+        if (nextThreads.some((thread) => thread.group.id === current)) return current;
+        return nextThreads[0]?.group.id ?? "";
+      });
+    } catch (loadError) {
+      setError(toChatErrorMessage(loadError, "Could not load chats."));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadThreads();
+  }, [user?.id]);
+
+  useEffect(() => {
+    if (!selectedGroupId || !user) {
+      setMessages([]);
+      setMembers([]);
+      return;
+    }
+
+    let cancelled = false;
+    setMessagesLoading(true);
+    setError(null);
+
+    Promise.all([getChatMessages(selectedGroupId, user.id), getChatMembers(selectedGroupId)])
+      .then(async ([nextMessages, nextMembers]) => {
+        if (cancelled) return;
+        setMessages(nextMessages);
+        setMembers(nextMembers);
+        await markChatRead(selectedGroupId);
+        if (!cancelled) {
+          setThreads((current) =>
+            current.map((thread) =>
+              thread.group.id === selectedGroupId ? { ...thread, unreadCount: 0 } : thread,
+            ),
+          );
+        }
+      })
+      .catch((loadError) => {
+        if (!cancelled) setError(toChatErrorMessage(loadError, "Could not load this chat."));
+      })
+      .finally(() => {
+        if (!cancelled) setMessagesLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedGroupId, user?.id]);
+
+  useEffect(() => {
+    if (!selectedGroupId || !user) return;
+    const currentUserId = user.id;
+
+    const channel = supabase
+      .channel(`group-messages:${selectedGroupId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "group_messages",
+          filter: `group_id=eq.${selectedGroupId}`,
+        },
+        (payload) => {
+          if (payload.eventType === "DELETE") {
+            const oldMessage = messageFromPayload(payload.old);
+            setMessages((current) => current.filter((message) => message.id !== oldMessage.id));
+            return;
+          }
+
+          const nextMessage = messageFromPayload(payload.new);
+          void getChatMessages(selectedGroupId, currentUserId)
+            .then(setMessages)
+            .catch(() => setMessages((current) => upsertMessage(current, nextMessage)));
+          void loadThreads(selectedGroupId);
+
+          void markChatRead(selectedGroupId).catch(() => undefined);
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "group_message_reactions",
+        },
+        () => {
+          void getChatMessages(selectedGroupId, currentUserId)
+            .then(setMessages)
+            .catch(() => undefined);
+        },
+      )
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [selectedGroupId, user?.id]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ block: "end" });
+  }, [messages.length, selectedGroupId]);
+
+  useEffect(() => {
+    setSelectedReply(null);
+    setMessageActionMenu(null);
+    setReactionDetailsMessageId(null);
   }, [selectedGroupId]);
+
+  useEffect(() => {
+    function closeFloatingMenus() {
+      setMessageActionMenu(null);
+      setReactionDetailsMessageId(null);
+    }
+
+    window.addEventListener("click", closeFloatingMenus);
+    window.addEventListener("scroll", closeFloatingMenus, true);
+    return () => {
+      window.removeEventListener("click", closeFloatingMenus);
+      window.removeEventListener("scroll", closeFloatingMenus, true);
+    };
+  }, []);
+
+  function clearLongPressTimer() {
+    if (longPressTimerRef.current !== null) {
+      window.clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }
+
+  function openMessageActionMenu(message: GroupMessage, x: number, y: number) {
+    if (message.deleted_at) return;
+    setMessageActionMenu({ messageId: message.id, x, y });
+    setReactionDetailsMessageId(null);
+  }
+
+  function startReply(message: GroupMessage, senderProfile?: PublicProfile) {
+    setSelectedReply(
+      buildReplySnapshot({
+        message,
+        senderName: message.sender_id === user?.id ? "You" : profileLabel(senderProfile),
+      }),
+    );
+    setMessageActionMenu(null);
+  }
+
+  async function copyMessageText(message: GroupMessage) {
+    if (!message.content.trim()) return;
+    setMessageActionMenu(null);
+    try {
+      await navigator.clipboard.writeText(message.content);
+      setStatusMessage("Message copied.");
+    } catch {
+      setError("Could not copy message.");
+    }
+  }
+
+  async function toggleMessageHeart(message: GroupMessage) {
+    if (!user || message.deleted_at) return;
+    setError(null);
+    try {
+      await toggleHeartReaction(message, user.id);
+      setMessages(await getChatMessages(selectedGroupId, user.id));
+    } catch (reactionError) {
+      setError(toChatErrorMessage(reactionError, "Could not update reaction."));
+    }
+  }
 
   async function submitGroup(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const name = groupForm.name.trim();
-    if (!name) return;
+    if (!groupName.trim()) return;
 
-    setCreatingGroup(true);
+    setSaving(true);
     setError(null);
-    setMessage(null);
+    setStatusMessage(null);
 
     try {
-      const { group } = await createGroup({
-        name,
-        description: groupForm.description?.trim() || undefined,
-        avatar_url: groupForm.avatar_url?.trim() || undefined,
+      const group = await createGroupChat({
+        name: groupName.trim(),
+        description: groupDescription.trim() || undefined,
       });
-      setGroups((current) => [group, ...current]);
-      setSelectedGroupId(group.id);
-      setGroupForm({ name: "", description: "" });
-      setMessage("Group created.");
-    } catch (groupError) {
-      setError(getErrorMessage(groupError, "Could not create group."));
+      setGroupName("");
+      setGroupDescription("");
+      setStatusMessage("Group chat created.");
+      await loadThreads(group.id);
+      setMobileThreadOpen(true);
+    } catch (createError) {
+      setError(toChatErrorMessage(createError, "Could not create group chat."));
     } finally {
-      setCreatingGroup(false);
+      setSaving(false);
+    }
+  }
+
+  async function searchProfiles(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!user) return;
+
+    setError(null);
+    setStatusMessage(null);
+
+    try {
+      const results = await searchPublicProfiles(directSearch);
+      setProfileResults(results);
+      if (results.length === 0) setStatusMessage("No matching users found.");
+    } catch (searchError) {
+      setError(toChatErrorMessage(searchError, "Could not search users."));
+    }
+  }
+
+  async function startDirectChat(profileId: string) {
+    setSaving(true);
+    setError(null);
+    setStatusMessage(null);
+
+    try {
+      const group = await createOrGetDirectChat(profileId);
+      setDirectSearch("");
+      setProfileResults([]);
+      setStatusMessage("Direct chat ready.");
+      await loadThreads(group.id);
+      setMobileThreadOpen(true);
+    } catch (directError) {
+      setError(toChatErrorMessage(directError, "Could not start direct chat."));
+    } finally {
+      setSaving(false);
     }
   }
 
   async function submitMember(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const nextUserId = memberUserId.trim();
-    if (!selectedGroupId || !nextUserId) return;
+    if (!selectedThread || !memberUsername.trim()) return;
 
+    setSaving(true);
     setError(null);
-    setMessage(null);
-
-    if (!UUID_PATTERN.test(nextUserId)) {
-      setError("Enter a valid user UUID.");
-      return;
-    }
+    setStatusMessage(null);
 
     try {
-      const member = await addGroupMember(selectedGroupId, nextUserId);
-      setMembers((current) => [
-        ...current.filter((item) => item.user_id !== member.user_id),
-        member,
-      ]);
-      setMemberUserId("");
-      setMessage("Member added.");
+      await addGroupMemberByUsername(selectedThread.group.id, memberUsername);
+      setMemberUsername("");
+      setStatusMessage("Member added.");
+      setMembers(await getChatMembers(selectedThread.group.id));
+      await loadThreads(selectedThread.group.id);
     } catch (memberError) {
-      setError(getAddMemberErrorMessage(memberError));
+      setError(toChatErrorMessage(memberError, "Could not add member."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function openAttachmentPicker(mode: AttachmentPickerMode) {
+    setAttachmentPicker(mode);
+    setAttachMenuOpen(false);
+    setAttachmentSearch("");
+    setSelectedBookId("");
+    setSelectedNoteId("");
+    setSelectedAuthorName("");
+    setSelectedIncludedNoteIds([]);
+  }
+
+  function toggleIncludedNote(noteId: string) {
+    setSelectedIncludedNoteIds((current) => {
+      if (current.includes(noteId)) return current.filter((id) => id !== noteId);
+      if (current.length >= MAX_INCLUDED_ATTACHMENT_NOTES) return current;
+      return [...current, noteId];
+    });
+  }
+
+  function attachSelectedItem() {
+    if (attachmentPicker === "book" && selectedBook) {
+      const includedNotes = selectedIncludedNoteIds
+        .map((noteId) => notes.find((note) => note.id === noteId))
+        .filter((note): note is BookNote => Boolean(note));
+      setSelectedAttachment(buildBookAttachment(selectedBook, includedNotes));
+    }
+
+    if (attachmentPicker === "note" && selectedNote) {
+      setSelectedAttachment(buildNoteAttachment(selectedNote, booksById.get(selectedNote.book_id)));
+    }
+
+    if (attachmentPicker === "author" && selectedAuthor) {
+      const includedQuotes = selectedIncludedNoteIds
+        .map((noteId) => notes.find((note) => note.id === noteId))
+        .filter((note): note is BookNote => Boolean(note));
+      setSelectedAttachment(
+        buildAuthorAttachment({
+          authorName: selectedAuthor.name,
+          books: selectedAuthor.books,
+          includedQuotes,
+        }),
+      );
+    }
+
+    setAttachmentPicker(null);
+    setSelectedIncludedNoteIds([]);
+  }
+
+  async function submitMessage(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedThread || !user || (!messageText.trim() && !selectedAttachment)) return;
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const message = await sendChatMessage(
+        selectedThread.group.id,
+        user.id,
+        messageText,
+        selectedAttachment,
+        selectedReply,
+      );
+      setMessages((current) => upsertMessage(current, message));
+      setMessageText("");
+      setSelectedAttachment(null);
+      setSelectedReply(null);
+      await markChatRead(selectedThread.group.id);
+      await loadThreads(selectedThread.group.id);
+    } catch (sendError) {
+      setError(toChatErrorMessage(sendError, "Could not send message."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function importBookSnapshot(book: ChatSharedBookSnapshot) {
+    setSaving(true);
+    setError(null);
+    setStatusMessage(null);
+
+    try {
+      await addBook(bookSnapshotToAddBookPayload(book));
+      setStatusMessage("Book saved to your library.");
+    } catch (importError) {
+      setError(toChatErrorMessage(importError, "Could not save book."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function importNoteAttachment(message: GroupMessage) {
+    if (!user || message.attachment_payload?.type !== "note" || !noteImportTargetBookId) return;
+
+    setSaving(true);
+    setError(null);
+    setStatusMessage(null);
+
+    try {
+      const savedNote = await createBookNote(
+        noteSnapshotToCreateInput({
+          note: message.attachment_payload.note,
+          bookId: noteImportTargetBookId,
+          userId: user.id,
+        }),
+      );
+      setNotes((current) => [savedNote, ...current]);
+      setNoteImportMessageId(null);
+      setNoteImportTargetBookId("");
+      setStatusMessage("Note saved.");
+    } catch (importError) {
+      setError(toChatErrorMessage(importError, "Could not save note."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function saveEditedMessage(messageId: string) {
+    if (!editingText.trim()) return;
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const message = await editChatMessage(messageId, editingText);
+      setMessages((current) => upsertMessage(current, message));
+      setEditingMessageId(null);
+      setEditingText("");
+      await loadThreads(selectedGroupId);
+    } catch (editError) {
+      setError(toChatErrorMessage(editError, "Could not edit message."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function removeMessage(messageId: string) {
+    setSaving(true);
+    setError(null);
+
+    try {
+      const message = await deleteChatMessage(messageId);
+      setMessages((current) => upsertMessage(current, message));
+      await loadThreads(selectedGroupId);
+    } catch (deleteError) {
+      setError(toChatErrorMessage(deleteError, "Could not delete message."));
+    } finally {
+      setSaving(false);
     }
   }
 
   async function changeRole(userId: string, role: GroupMembershipRole) {
-    if (!selectedGroupId) return;
+    if (!selectedThread) return;
+
+    setSaving(true);
     setError(null);
-    setMessage(null);
+    setStatusMessage(null);
 
     try {
-      const member = await updateGroupMemberRole(selectedGroupId, userId, role);
-      setMembers((current) =>
-        current.map((item) => (item.user_id === userId ? member : item)),
-      );
-      setMessage("Member role updated.");
+      await changeGroupMemberRole(selectedThread.group.id, userId, role);
+      setMembers(await getChatMembers(selectedThread.group.id));
+      setStatusMessage("Member role updated.");
     } catch (roleError) {
-      setError(getErrorMessage(roleError, "Could not update member role."));
+      setError(toChatErrorMessage(roleError, "Could not update member role."));
+    } finally {
+      setSaving(false);
     }
   }
 
   async function removeMember(userId: string) {
-    if (!selectedGroupId) return;
+    if (!selectedThread || !user) return;
+
+    setSaving(true);
     setError(null);
-    setMessage(null);
+    setStatusMessage(null);
 
     try {
-      await removeGroupMember(selectedGroupId, userId);
-      setMembers((current) => current.filter((member) => member.user_id !== userId));
-      setMessage(userId === user?.id ? "You left the group." : "Member removed.");
-      if (userId === user?.id) {
-        const nextGroups = await getMyGroups();
-        setGroups(nextGroups);
-        setSelectedGroupId(nextGroups[0]?.id || "");
-      }
+      await removeChatMember(selectedThread.group.id, userId);
+      setStatusMessage(userId === user.id ? "You left the group." : "Member removed.");
+      await loadThreads(userId === user.id ? undefined : selectedThread.group.id);
     } catch (removeError) {
-      setError(getErrorMessage(removeError, "Could not remove member."));
+      setError(toChatErrorMessage(removeError, "Could not remove member."));
+    } finally {
+      setSaving(false);
     }
   }
 
+  async function confirmDelete() {
+    const action = confirmAction;
+    setConfirmAction(null);
+
+    if (!action) return;
+
+    if (action.type === "message") {
+      await removeMessage(action.messageId);
+      return;
+    }
+
+    await removeMember(action.userId);
+  }
+
+  const actionMenuMessage = messageActionMenu
+    ? messages.find((message) => message.id === messageActionMenu.messageId) ?? null
+    : null;
+  const actionMenuSenderProfile = actionMenuMessage ? memberProfiles.get(actionMenuMessage.sender_id) : undefined;
+  const actionMenuMine = actionMenuMessage?.sender_id === user?.id;
+
   return (
-    <div className="space-y-4">
-      {error && <p className="text-sm text-destructive">{error}</p>}
-      {message && <p className="text-sm text-muted-foreground">{message}</p>}
+    <div className="overflow-hidden rounded-lg border bg-background shadow-[var(--shadow-card)]">
+      {(error || statusMessage) && (
+        <div className="space-y-1 border-b px-4 py-3">
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {statusMessage && <p className="text-sm text-muted-foreground">{statusMessage}</p>}
+        </div>
+      )}
 
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Create Group</CardTitle>
-            <CardDescription>Private reading groups.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <form className="space-y-3" onSubmit={submitGroup}>
-              <div className="space-y-2">
-                <Label htmlFor="group-name">Name</Label>
-                <Input
-                  id="group-name"
-                  value={groupForm.name}
-                  onChange={(event) =>
-                    setGroupForm((current) => ({ ...current, name: event.target.value }))
-                  }
-                />
+      {messageActionMenu && actionMenuMessage && (
+        <div
+          className="fixed z-50 w-44 rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-popover)]"
+          style={{
+            left: Math.min(messageActionMenu.x, window.innerWidth - 190),
+            top: Math.min(messageActionMenu.y, window.innerHeight - 180),
+          }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+            onClick={() => startReply(actionMenuMessage, actionMenuSenderProfile)}
+          >
+            <Reply className="h-4 w-4" />
+            Reply
+          </button>
+          {actionMenuMessage.content.trim() && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+              onClick={() => copyMessageText(actionMenuMessage)}
+            >
+              <Copy className="h-4 w-4" />
+              Copy Text
+            </button>
+          )}
+          {actionMenuMine && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+              onClick={() => {
+                setEditingMessageId(actionMenuMessage.id);
+                setEditingText(actionMenuMessage.content);
+                setMessageActionMenu(null);
+              }}
+            >
+              <Pencil className="h-4 w-4" />
+              Edit
+            </button>
+          )}
+          {actionMenuMine && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm text-destructive hover:bg-muted"
+              onClick={() => {
+                setConfirmAction({ type: "message", messageId: actionMenuMessage.id });
+                setMessageActionMenu(null);
+              }}
+            >
+              <Trash2 className="h-4 w-4" />
+              Delete
+            </button>
+          )}
+        </div>
+      )}
+
+      <div className="grid h-[calc(100svh-8rem)] min-h-[38rem] lg:grid-cols-[22rem_minmax(0,1fr)]">
+        <aside className={cn("min-h-0 border-r bg-muted/20", mobileThreadOpen && "hidden lg:flex", "flex-col")}>
+          <div className="space-y-4 border-b p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="font-heading text-lg font-medium leading-snug">Start Chat</h2>
+                <p className="text-xs text-muted-foreground">Find a reader or create a group.</p>
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="group-description">Description</Label>
-                <Textarea
-                  id="group-description"
-                  value={groupForm.description ?? ""}
-                  onChange={(event) =>
-                    setGroupForm((current) => ({ ...current, description: event.target.value }))
-                  }
-                />
-              </div>
-              <Button type="submit" disabled={creatingGroup || !groupForm.name.trim()}>
-                <Users className="mr-2 h-4 w-4" />
-                {creatingGroup ? "Creating..." : "Create group"}
-              </Button>
-            </form>
-          </CardContent>
-        </Card>
+              <MessageCircle className="h-5 w-5 text-muted-foreground" />
+            </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>My Groups</CardTitle>
-            <CardDescription>
-              {groups.length === 0
-                ? "No groups yet."
-                : `${groups.length} group${groups.length === 1 ? "" : "s"}`}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {groups.length > 0 && (
-              <div className="space-y-2">
-                <Label htmlFor="selected-group">Group</Label>
-                <Select value={selectedGroupId} onValueChange={setSelectedGroupId}>
-                  <SelectTrigger id="selected-group" className="w-full">
-                    <SelectValue placeholder="Choose a group" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {groups.map((group) => (
-                      <SelectItem key={group.id} value={group.id}>
-                        {group.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
+            <Select value={composeMode} onValueChange={(value) => setComposeMode(value as ComposeMode)}>
+              <SelectTrigger aria-label="Chat type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="direct">Direct chat</SelectItem>
+                <SelectItem value="group">Group chat</SelectItem>
+              </SelectContent>
+            </Select>
 
-            {selectedGroup && (
-              <div className="space-y-4">
-                <div>
-                  <h2 className="font-heading leading-snug font-medium">{selectedGroup.name}</h2>
-                  {selectedGroup.description && (
-                    <p className="text-sm text-muted-foreground">{selectedGroup.description}</p>
-                  )}
-                </div>
-
-                <form className="flex flex-col gap-2 sm:flex-row" onSubmit={submitMember}>
+            {composeMode === "direct" ? (
+              <div className="space-y-3">
+                <form className="flex gap-2" onSubmit={searchProfiles}>
                   <Input
-                    aria-label="User ID"
-                    placeholder="User UUID"
-                    value={memberUserId}
-                    onChange={(event) => setMemberUserId(event.target.value)}
+                    aria-label="Search username"
+                    placeholder="Username or display name"
+                    value={directSearch}
+                    onChange={(event) => setDirectSearch(event.target.value)}
                   />
-                  <Button type="submit" variant="outline" disabled={!memberUserId.trim()}>
-                    <UserPlus className="mr-2 h-4 w-4" />
-                    Add
+                  <Button type="submit" size="icon" variant="outline" disabled={directSearch.trim().length < 2}>
+                    <Search className="h-4 w-4" />
                   </Button>
                 </form>
 
-                <div className="space-y-2">
-                  {members.map((member) => (
-                    <div
-                      key={member.user_id}
-                      className="flex flex-col gap-2 rounded-lg border p-3 sm:flex-row sm:items-center"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium">{member.user_id}</p>
-                        <p className="text-xs text-muted-foreground">{member.status}</p>
-                      </div>
-                      <Select
-                        value={member.role}
-                        onValueChange={(value) =>
-                          changeRole(member.user_id, value as GroupMembershipRole)
-                        }
-                      >
-                        <SelectTrigger className="w-full sm:w-32">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="owner">Owner</SelectItem>
-                          <SelectItem value="admin">Admin</SelectItem>
-                          <SelectItem value="member">Member</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <Button
+                {profileResults.length > 0 && (
+                  <div className="space-y-2">
+                    {profileResults.map((profile) => (
+                      <button
+                        key={profile.id}
                         type="button"
-                        variant="destructive"
-                        size="sm"
-                        onClick={() => removeMember(member.user_id)}
+                        className="flex w-full items-center gap-3 rounded-md p-2 text-left transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        onClick={() => startDirectChat(profile.id)}
+                        disabled={saving}
                       >
-                        Remove
+                        <MessageAvatar profile={profile} />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-sm font-medium">{profileLabel(profile)}</span>
+                          <span className="block truncate text-xs text-muted-foreground">{profileSubLabel(profile)}</span>
+                        </span>
+                        <MessageCircle className="h-4 w-4 text-muted-foreground" />
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <form className="space-y-3" onSubmit={submitGroup}>
+                <div className="space-y-2">
+                  <Label htmlFor="group-name">Name</Label>
+                  <Input id="group-name" value={groupName} onChange={(event) => setGroupName(event.target.value)} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="group-description">Description</Label>
+                  <Textarea
+                    id="group-description"
+                    value={groupDescription}
+                    onChange={(event) => setGroupDescription(event.target.value)}
+                    rows={3}
+                  />
+                </div>
+                <Button type="submit" disabled={saving || !groupName.trim()}>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Create group
+                </Button>
+              </form>
+            )}
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-2">
+            <div className="px-2 py-2">
+              <h2 className="font-heading text-lg font-medium leading-snug">Chats</h2>
+              <p className="text-xs text-muted-foreground">
+                {loading ? "Loading..." : `${threads.length} conversation${threads.length === 1 ? "" : "s"}`}
+              </p>
+            </div>
+
+            {threads.length === 0 && !loading ? (
+              <p className="px-2 py-6 text-sm text-muted-foreground">
+                Start a direct chat or create a group chat.
+              </p>
+            ) : (
+              <div className="space-y-1">
+                {threads.map((thread) => (
+                  <button
+                    key={thread.group.id}
+                    type="button"
+                    className={cn(
+                      "flex w-full items-start gap-3 rounded-lg p-3 text-left transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      thread.group.id === selectedGroupId && "bg-primary text-primary-foreground hover:bg-primary",
+                    )}
+                    onClick={() => {
+                      setSelectedGroupId(thread.group.id);
+                      setMobileThreadOpen(true);
+                      setSettingsOpen(false);
+                    }}
+                  >
+                    <MessageAvatar profile={thread.avatarProfile} fallback={thread.title} />
+                    <span className="min-w-0 flex-1">
+                      <span className="flex items-center gap-2">
+                        <span className="truncate text-sm font-medium">{thread.title}</span>
+                        {thread.group.kind === "group" && (
+                          <Users
+                            className={cn(
+                              "h-3.5 w-3.5 shrink-0",
+                              thread.group.id === selectedGroupId ? "text-primary-foreground/80" : "text-muted-foreground",
+                            )}
+                          />
+                        )}
+                      </span>
+                      <span
+                        className={cn(
+                          "mt-0.5 line-clamp-1 text-xs",
+                          thread.group.id === selectedGroupId ? "text-primary-foreground/80" : "text-muted-foreground",
+                        )}
+                      >
+                        {getMessagePreview(thread.latestMessage)}
+                      </span>
+                    </span>
+                    {thread.unreadCount > 0 && (
+                      <span
+                        className={cn(
+                          "flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full px-1.5 text-[0.68rem] font-semibold",
+                          thread.group.id === selectedGroupId
+                            ? "bg-primary-foreground text-primary"
+                            : "bg-primary text-primary-foreground",
+                        )}
+                      >
+                        {thread.unreadCount}
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </aside>
+
+        <section className={cn("min-h-0 min-w-0", !mobileThreadOpen && "hidden lg:block")}>
+          {selectedThread ? (
+            <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)]">
+              <div className="grid min-h-16 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 border-b bg-background px-3 sm:px-4">
+                <div className="flex min-w-0 items-center gap-2">
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="lg:hidden"
+                    onClick={() => setMobileThreadOpen(false)}
+                  >
+                    <ArrowLeft className="h-4 w-4" />
+                  </Button>
+                  <MessageAvatar profile={selectedThread.avatarProfile} fallback={selectedThread.title} />
+                </div>
+                <div className="min-w-0 text-center">
+                  <h1 className="truncate font-heading text-base font-medium leading-snug sm:text-lg">
+                    {selectedThread.title}
+                  </h1>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {selectedThread.group.kind === "direct"
+                      ? "Direct chat"
+                      : selectedThread.description || `${members.length} members`}
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant={settingsOpen ? "secondary" : "ghost"}
+                  aria-label="Chat settings"
+                  onClick={() => setSettingsOpen((current) => !current)}
+                >
+                  <Settings className="h-5 w-5" />
+                </Button>
+              </div>
+
+              <div
+                className={cn(
+                  "grid min-h-0",
+                  settingsOpen ? "lg:grid-cols-[minmax(0,1fr)_19rem]" : "lg:grid-cols-[minmax(0,1fr)]",
+                )}
+              >
+                <div className="flex min-h-[32rem] min-w-0 flex-col">
+                  <div className="min-h-0 flex-1 space-y-4 overflow-y-auto bg-background p-4 sm:p-6">
+                    {messagesLoading ? (
+                      <p className="text-sm text-muted-foreground">Loading messages...</p>
+                    ) : messages.length === 0 ? (
+                      <p className="text-sm text-muted-foreground">No messages yet.</p>
+                    ) : (
+                      messages.map((message) => {
+                        const mine = message.sender_id === user?.id;
+                        const senderProfile = memberProfiles.get(message.sender_id);
+                        const editing = editingMessageId === message.id;
+                        const heartReaction = message.reactions?.find((reaction) => reaction.reaction === "heart");
+                        const canUseActions = !message.deleted_at;
+
+                        return (
+                          <div key={message.id} className={cn("flex gap-3", mine && "justify-end")}>
+                            {!mine && <MessageAvatar profile={senderProfile} fallback={message.sender_id} />}
+                            <div className={cn("max-w-[min(34rem,80%)] space-y-1", mine && "items-end")}>
+                              {editing ? (
+                                <div className="space-y-2">
+                                  <Textarea
+                                    value={editingText}
+                                    onChange={(event) => setEditingText(event.target.value)}
+                                    rows={3}
+                                  />
+                                  <div className="flex justify-end gap-2">
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="sm"
+                                      onClick={() => {
+                                        setEditingMessageId(null);
+                                        setEditingText("");
+                                      }}
+                                    >
+                                      Cancel
+                                    </Button>
+                                    <Button
+                                      type="button"
+                                      size="sm"
+                                      disabled={saving || !editingText.trim()}
+                                      onClick={() => saveEditedMessage(message.id)}
+                                    >
+                                      Save
+                                    </Button>
+                                  </div>
+                                </div>
+                              ) : message.content.trim() || message.deleted_at || message.reply_snapshot ? (
+                                <div className={cn("relative", mine && "self-end")}>
+                                  <div
+                                    className={cn(
+                                      "space-y-2 rounded-2xl px-3 py-2 text-sm leading-relaxed",
+                                      mine
+                                        ? "rounded-br-sm bg-primary text-primary-foreground"
+                                        : "rounded-bl-sm bg-muted text-foreground",
+                                      message.deleted_at && "italic text-muted-foreground",
+                                    )}
+                                    onContextMenu={(event) => {
+                                      if (!canUseActions) return;
+                                      event.preventDefault();
+                                      openMessageActionMenu(message, event.clientX, event.clientY);
+                                    }}
+                                    onDoubleClick={() => toggleMessageHeart(message)}
+                                    onTouchStart={(event) => {
+                                      if (!canUseActions) return;
+                                      const touch = event.touches[0];
+                                      clearLongPressTimer();
+                                      longPressTimerRef.current = window.setTimeout(() => {
+                                        openMessageActionMenu(message, touch.clientX, touch.clientY);
+                                      }, 550);
+                                    }}
+                                    onTouchMove={clearLongPressTimer}
+                                    onTouchEnd={clearLongPressTimer}
+                                    onTouchCancel={clearLongPressTimer}
+                                  >
+                                    {message.reply_snapshot && <ReplyPreview reply={message.reply_snapshot} compact />}
+                                    {message.deleted_at ? "Message deleted" : message.content}
+                                  </div>
+                                  {heartReaction && heartReaction.count > 0 && (
+                                    <div
+                                      className={cn(
+                                        "relative mt-1 flex",
+                                        mine ? "justify-end pr-2" : "justify-start pl-2",
+                                      )}
+                                    >
+                                      <button
+                                        type="button"
+                                        className={cn(
+                                          "flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-xs shadow-sm",
+                                          heartReaction.reacted_by_current_user && "border-primary text-primary",
+                                        )}
+                                        onClick={(event) => {
+                                          event.stopPropagation();
+                                          setReactionDetailsMessageId((current) =>
+                                            current === message.id ? null : message.id,
+                                          );
+                                        }}
+                                        onMouseEnter={() => setReactionDetailsMessageId(message.id)}
+                                      >
+                                        <Heart className="h-3 w-3 fill-current" />
+                                        {heartReaction.count}
+                                      </button>
+                                      {reactionDetailsMessageId === message.id && (
+                                        <div className="absolute bottom-7 z-30 max-w-56 rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-[var(--shadow-popover)]">
+                                          {reactionNames(heartReaction)}
+                                        </div>
+                                      )}
+                                    </div>
+                                  )}
+                                </div>
+                              ) : null}
+
+                              {!message.deleted_at && (
+                                <div
+                                  onContextMenu={(event) => {
+                                    if (!canUseActions) return;
+                                    event.preventDefault();
+                                    openMessageActionMenu(message, event.clientX, event.clientY);
+                                  }}
+                                  onDoubleClick={() => toggleMessageHeart(message)}
+                                  onTouchStart={(event) => {
+                                    if (!canUseActions) return;
+                                    const touch = event.touches[0];
+                                    clearLongPressTimer();
+                                    longPressTimerRef.current = window.setTimeout(() => {
+                                      openMessageActionMenu(message, touch.clientX, touch.clientY);
+                                    }, 550);
+                                  }}
+                                  onTouchMove={clearLongPressTimer}
+                                  onTouchEnd={clearLongPressTimer}
+                                  onTouchCancel={clearLongPressTimer}
+                                >
+                                  <AttachmentCard
+                                    message={message}
+                                    mine={mine}
+                                    books={books}
+                                    noteImportOpen={noteImportMessageId === message.id}
+                                    noteImportTargetBookId={noteImportTargetBookId}
+                                    onImportBook={importBookSnapshot}
+                                    onOpenNoteImport={() => {
+                                      setNoteImportMessageId(message.id);
+                                      setNoteImportTargetBookId("");
+                                    }}
+                                    onCancelNoteImport={() => {
+                                      setNoteImportMessageId(null);
+                                      setNoteImportTargetBookId("");
+                                    }}
+                                    onNoteTargetChange={setNoteImportTargetBookId}
+                                    onImportNote={() => importNoteAttachment(message)}
+                                  />
+                                </div>
+                              )}
+
+                              {heartReaction &&
+                                heartReaction.count > 0 &&
+                                !message.content.trim() &&
+                                !message.reply_snapshot && (
+                                  <div
+                                    className={cn(
+                                      "relative flex",
+                                      mine ? "justify-end pr-2" : "justify-start pl-2",
+                                    )}
+                                  >
+                                    <button
+                                      type="button"
+                                      className={cn(
+                                        "flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-xs shadow-sm",
+                                        heartReaction.reacted_by_current_user && "border-primary text-primary",
+                                      )}
+                                      onClick={(event) => {
+                                        event.stopPropagation();
+                                        setReactionDetailsMessageId((current) =>
+                                          current === message.id ? null : message.id,
+                                        );
+                                      }}
+                                      onMouseEnter={() => setReactionDetailsMessageId(message.id)}
+                                    >
+                                      <Heart className="h-3 w-3 fill-current" />
+                                      {heartReaction.count}
+                                    </button>
+                                    {reactionDetailsMessageId === message.id && (
+                                      <div className="absolute bottom-7 z-30 max-w-56 rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-[var(--shadow-popover)]">
+                                        {reactionNames(heartReaction)}
+                                      </div>
+                                    )}
+                                  </div>
+                                )}
+
+                              <div className={cn("flex items-center gap-2", mine && "justify-end")}>
+                                <span className="truncate text-xs font-medium text-muted-foreground">
+                                  {mine ? "You" : profileLabel(senderProfile)}
+                                </span>
+                                <span className="text-xs text-muted-foreground">
+                                  {formatMessageTime(message.created_at)}
+                                  {message.edited_at && !message.deleted_at ? " · edited" : ""}
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })
+                    )}
+                    <div ref={messagesEndRef} />
+                  </div>
+
+                  <form className="space-y-2 border-t bg-background p-3" onSubmit={submitMessage}>
+                    {selectedReply && (
+                      <ReplyPreview reply={selectedReply} onCancel={() => setSelectedReply(null)} />
+                    )}
+
+                    {selectedAttachment && (
+                      <div className="flex items-center gap-2">
+                        <div className="min-w-0 flex-1">
+                          <AttachmentSummary attachment={selectedAttachment} />
+                        </div>
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          aria-label="Remove attachment"
+                          onClick={() => setSelectedAttachment(null)}
+                        >
+                          <X className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    )}
+
+                    <div className="flex items-end gap-2">
+                      <div className="relative">
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="outline"
+                          aria-label="Attach"
+                          onClick={() => setAttachMenuOpen((current) => !current)}
+                        >
+                          <Paperclip className="h-4 w-4" />
+                        </Button>
+                        {attachMenuOpen && (
+                          <div className="absolute bottom-12 left-0 z-20 w-48 rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-popover)]">
+                            <button
+                              type="button"
+                              className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+                              onClick={() => openAttachmentPicker("book")}
+                            >
+                              <BookOpen className="h-4 w-4" />
+                              Attach Book
+                            </button>
+                            <button
+                              type="button"
+                              className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+                              onClick={() => openAttachmentPicker("note")}
+                            >
+                              <StickyNote className="h-4 w-4" />
+                              Attach Notes
+                            </button>
+                            <button
+                              type="button"
+                              className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+                              onClick={() => openAttachmentPicker("author")}
+                            >
+                              <UserRound className="h-4 w-4" />
+                              Attach Author
+                            </button>
+                          </div>
+                        )}
+                      </div>
+
+                      <Textarea
+                        aria-label="Message"
+                        value={messageText}
+                        onChange={(event) => setMessageText(event.target.value)}
+                        placeholder="Write a message"
+                        rows={2}
+                        className="min-h-12 resize-none rounded-full px-4 py-3"
+                      />
+                      <Button type="submit" size="icon" disabled={saving || (!messageText.trim() && !selectedAttachment)}>
+                        <Send className="h-4 w-4" />
                       </Button>
                     </div>
+                  </form>
+                </div>
+
+                {settingsOpen && (
+                  <aside className="min-h-0 overflow-y-auto border-t bg-muted/20 p-4 lg:border-l lg:border-t-0">
+                  <div className="space-y-4">
+                    <div>
+                      <h2 className="font-heading text-base font-medium leading-snug">Chat Settings</h2>
+                      <p className="text-sm text-muted-foreground">
+                        {members.length} member{members.length === 1 ? "" : "s"}
+                      </p>
+                    </div>
+
+                    {canManageSelectedGroup && (
+                      <form className="flex gap-2" onSubmit={submitMember}>
+                        <Input
+                          aria-label="Member username"
+                          placeholder="username"
+                          value={memberUsername}
+                          onChange={(event) => setMemberUsername(event.target.value)}
+                        />
+                        <Button type="submit" size="icon" variant="outline" disabled={saving || !memberUsername.trim()}>
+                          <UserPlus className="h-4 w-4" />
+                        </Button>
+                      </form>
+                    )}
+
+                    <div className="space-y-2">
+                      {members.map((member) => {
+                        const canEditMember =
+                          canManageSelectedGroup && member.user_id !== user?.id && member.role !== "owner";
+                        return (
+                          <div key={member.user_id} className="space-y-2 rounded-md border p-3">
+                            <div className="flex items-center gap-2">
+                              <MessageAvatar profile={member.profile} fallback={member.user_id} />
+                              <div className="min-w-0 flex-1">
+                                <p className="truncate text-sm font-medium">
+                                  {member.user_id === user?.id ? "You" : profileLabel(member.profile)}
+                                </p>
+                                <p className="truncate text-xs text-muted-foreground">
+                                  {profileSubLabel(member.profile)} · {member.role}
+                                </p>
+                              </div>
+                            </div>
+
+                            {canEditMember && (
+                              <div className="flex gap-2">
+                                <Select
+                                  value={member.role}
+                                  onValueChange={(value) => changeRole(member.user_id, value as GroupMembershipRole)}
+                                >
+                                  <SelectTrigger className="h-8 flex-1">
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    <SelectItem value="admin">Admin</SelectItem>
+                                    <SelectItem value="member">Member</SelectItem>
+                                  </SelectContent>
+                                </Select>
+                                <Button
+                                  type="button"
+                                  variant="destructive"
+                                  size="sm"
+                                  onClick={() => setConfirmAction({ type: "member", userId: member.user_id })}
+                                >
+                                  Remove
+                                </Button>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+
+                    {selectedThread.group.kind === "group" && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full"
+                        onClick={() => user && setConfirmAction({ type: "leave", userId: user.id })}
+                        disabled={saving}
+                      >
+                        Leave group
+                      </Button>
+                    )}
+                  </div>
+                </aside>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="flex h-full min-h-[38rem] items-center justify-center">
+              <div className="p-6 text-center">
+                <MessageCircle className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+                <p className="font-medium">No chat selected</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Start a chat or choose a conversation from the list.
+                </p>
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+
+      <Dialog open={confirmAction !== null} onOpenChange={(open) => !open && setConfirmAction(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete this?</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete this? This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setConfirmAction(null)}>
+              Cancel
+            </Button>
+            <Button type="button" variant="destructive" onClick={confirmDelete} disabled={saving}>
+              Yes
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={attachmentPicker !== null} onOpenChange={(open) => !open && setAttachmentPicker(null)}>
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>
+              {attachmentPicker === "book"
+                ? "Attach Book"
+                : attachmentPicker === "note"
+                  ? "Attach Notes"
+                  : "Attach Author"}
+            </DialogTitle>
+            <DialogDescription>
+              Select what you want to send in this chat.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <Input
+              aria-label="Search attachments"
+              placeholder="Search"
+              value={attachmentSearch}
+              onChange={(event) => setAttachmentSearch(event.target.value)}
+            />
+
+            {attachmentPicker === "book" && (
+              <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                <div className="max-h-72 space-y-1 overflow-y-auto">
+                  {filteredBooks.map((book) => (
+                    <button
+                      key={book.id}
+                      type="button"
+                      className={cn(
+                        "flex w-full items-center gap-3 rounded-md p-2 text-left hover:bg-muted",
+                        selectedBookId === book.id && "bg-muted",
+                      )}
+                      onClick={() => {
+                        setSelectedBookId(book.id);
+                        setSelectedIncludedNoteIds([]);
+                      }}
+                    >
+                      {book.cover_url ? (
+                        <img src={book.cover_url} alt="" className="h-12 w-8 rounded object-cover" />
+                      ) : (
+                        <div className="flex h-12 w-8 items-center justify-center rounded bg-muted">
+                          <BookOpen className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                      )}
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm font-medium">{book.title}</span>
+                        <span className="block truncate text-xs text-muted-foreground">{book.authors.join(", ")}</span>
+                      </span>
+                    </button>
                   ))}
+                </div>
+
+                <div className="max-h-72 space-y-2 overflow-y-auto rounded-md border p-3">
+                  <p className="text-sm font-medium">Include notes, reviews, or quotes</p>
+                  {!selectedBook ? (
+                    <p className="text-sm text-muted-foreground">Select a book first.</p>
+                  ) : selectedBookNotes.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">This book has no notes yet.</p>
+                  ) : (
+                    selectedBookNotes.map((note) => (
+                      <label key={note.id} className="flex gap-2 rounded-md p-2 text-sm hover:bg-muted">
+                        <input
+                          type="checkbox"
+                          checked={selectedIncludedNoteIds.includes(note.id)}
+                          disabled={
+                            !selectedIncludedNoteIds.includes(note.id) &&
+                            selectedIncludedNoteIds.length >= MAX_INCLUDED_ATTACHMENT_NOTES
+                          }
+                          onChange={() => toggleIncludedNote(note.id)}
+                        />
+                        <span className="min-w-0">
+                          <span className="block text-xs font-medium uppercase text-muted-foreground">
+                            {noteLabel(note.label)}
+                          </span>
+                          <span className="line-clamp-2">{note.content}</span>
+                        </span>
+                      </label>
+                    ))
+                  )}
                 </div>
               </div>
             )}
-          </CardContent>
-        </Card>
-      </div>
+
+            {attachmentPicker === "note" && (
+              <div className="max-h-80 space-y-1 overflow-y-auto">
+                {filteredNotes.map((note) => {
+                  const book = booksById.get(note.book_id);
+                  return (
+                    <button
+                      key={note.id}
+                      type="button"
+                      className={cn(
+                        "w-full rounded-md p-3 text-left hover:bg-muted",
+                        selectedNoteId === note.id && "bg-muted",
+                      )}
+                      onClick={() => setSelectedNoteId(note.id)}
+                    >
+                      <span className="block text-xs font-medium uppercase text-muted-foreground">
+                        {noteLabel(note.label)}
+                      </span>
+                      <span className="mt-1 line-clamp-2 text-sm">{note.content}</span>
+                      <span className="mt-1 block truncate text-xs text-muted-foreground">
+                        {book?.title ?? "Unknown book"}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
+            {attachmentPicker === "author" && (
+              <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                <div className="max-h-72 space-y-1 overflow-y-auto">
+                  {filteredAuthors.map((author) => (
+                    <button
+                      key={author.name}
+                      type="button"
+                      className={cn(
+                        "w-full rounded-md p-3 text-left hover:bg-muted",
+                        selectedAuthorName === author.name && "bg-muted",
+                      )}
+                      onClick={() => {
+                        setSelectedAuthorName(author.name);
+                        setSelectedIncludedNoteIds([]);
+                      }}
+                    >
+                      <span className="block truncate text-sm font-medium">{author.name}</span>
+                      <span className="block text-xs text-muted-foreground">
+                        {author.bookCount} book{author.bookCount === 1 ? "" : "s"} · {author.quoteCount} quote{author.quoteCount === 1 ? "" : "s"}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+
+                <div className="max-h-72 space-y-2 overflow-y-auto rounded-md border p-3">
+                  <p className="text-sm font-medium">Include quotes</p>
+                  {!selectedAuthor ? (
+                    <p className="text-sm text-muted-foreground">Select an author first.</p>
+                  ) : selectedAuthorQuotes.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">No quotes for this author yet.</p>
+                  ) : (
+                    selectedAuthorQuotes.map((quote) => (
+                      <label key={quote.id} className="flex gap-2 rounded-md p-2 text-sm hover:bg-muted">
+                        <input
+                          type="checkbox"
+                          checked={selectedIncludedNoteIds.includes(quote.id)}
+                          disabled={
+                            !selectedIncludedNoteIds.includes(quote.id) &&
+                            selectedIncludedNoteIds.length >= MAX_INCLUDED_ATTACHMENT_NOTES
+                          }
+                          onChange={() => toggleIncludedNote(quote.id)}
+                        />
+                        <span className="line-clamp-2">{quote.content}</span>
+                      </label>
+                    ))
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setAttachmentPicker(null)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={attachSelectedItem}
+              disabled={
+                (attachmentPicker === "book" && !selectedBook) ||
+                (attachmentPicker === "note" && !selectedNote) ||
+                (attachmentPicker === "author" && !selectedAuthor)
+              }
+            >
+              Attach
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/groups/GroupsManager.tsx
+++ b/src/components/groups/GroupsManager.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { Link } from "react-router-dom";
 import {
   ArrowLeft,
   BookOpen,
@@ -188,6 +189,22 @@ function attachmentTypeLabel(attachment: ChatAttachmentPayload): string {
   return "Series";
 }
 
+function attachmentHref(attachment: ChatAttachmentPayload): string | null {
+  if (attachment.type === "book") return attachment.book.id ? `/books/${attachment.book.id}` : null;
+  if (attachment.type === "note") {
+    if (!attachment.note.book_id) return null;
+    return `/books/${attachment.note.book_id}/annotations`;
+  }
+  if (attachment.type === "author") return `/authors/${encodeURIComponent(attachment.author.name)}`;
+  if (attachment.series.id) return `/series/${attachment.series.id}`;
+  return null;
+}
+
+function quoteHref(note: ChatSharedNoteSnapshot): string | null {
+  if (!note.book_id) return null;
+  return `/books/${note.book_id}/annotations`;
+}
+
 function sortSeriesByName(series: Series[]): Series[] {
   return [...series].sort((first, second) =>
     first.name.localeCompare(second.name, undefined, { sensitivity: "base", numeric: true }),
@@ -255,6 +272,7 @@ function AttachmentCard({
   noteImportOpen,
   noteImportTargetBookId,
   onImportBook,
+  onImportSeries,
   onOpenNoteImport,
   onCancelNoteImport,
   onNoteTargetChange,
@@ -266,6 +284,7 @@ function AttachmentCard({
   noteImportOpen: boolean;
   noteImportTargetBookId: string;
   onImportBook: (book: ChatSharedBookSnapshot) => void;
+  onImportSeries: (series: Extract<ChatAttachmentPayload, { type: "series" }>["series"]) => void;
   onOpenNoteImport: () => void;
   onCancelNoteImport: () => void;
   onNoteTargetChange: (bookId: string) => void;
@@ -273,8 +292,10 @@ function AttachmentCard({
 }) {
   const attachment = message.attachment_payload;
   if (!attachment) return null;
+  const href = attachmentHref(attachment);
+  const isClickable = mine && href;
 
-  return (
+  const body = (
     <div className="mt-2 space-y-3 rounded-lg border bg-background p-3 text-foreground shadow-sm">
       <div className="flex items-center gap-2">
         <Badge variant="outline">{attachmentTypeLabel(attachment)}</Badge>
@@ -296,7 +317,7 @@ function AttachmentCard({
           )}
           <div className="min-w-0 flex-1 space-y-2">
             <div>
-              <p className="font-medium leading-snug">{attachment.book.title}</p>
+              <p className="line-clamp-2 font-medium leading-snug">{attachment.book.title}</p>
               <p className="text-xs text-muted-foreground">{attachment.book.authors.join(", ")}</p>
             </div>
             {attachment.book.description && (
@@ -304,11 +325,26 @@ function AttachmentCard({
             )}
             {attachment.book.included_notes && attachment.book.included_notes.length > 0 && (
               <div className="space-y-1">
-                {attachment.book.included_notes.map((note, index) => (
-                  <p key={`${note.id ?? index}-${note.label}`} className="rounded-md bg-muted/50 px-2 py-1 text-xs">
-                    <span className="font-medium">{noteLabel(note.label)}:</span> {note.content}
-                  </p>
-                ))}
+                {attachment.book.included_notes.map((note, index) => {
+                  const noteItem = (
+                    <span className="rounded-md bg-muted/50 px-2 py-1 text-xs">
+                      <span className="font-medium">{noteLabel(note.label)}:</span> {note.content}
+                    </span>
+                  );
+                  return mine ? (
+                    <p key={`${note.id ?? index}-${note.label}`} className="text-xs">
+                      {noteItem}
+                    </p>
+                  ) : (
+                    <Link
+                      key={`${note.id ?? index}-${note.label}`}
+                      to={quoteHref(note) ?? "#"}
+                      className="block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    >
+                      {noteItem}
+                    </Link>
+                  );
+                })}
               </div>
             )}
             {!mine && (
@@ -322,19 +358,39 @@ function AttachmentCard({
 
       {attachment.type === "note" && (
         <div className="space-y-3">
-          <div className="rounded-md bg-muted/50 px-3 py-2">
-            <p className="text-xs font-medium uppercase text-muted-foreground">{noteLabel(attachment.note.label)}</p>
-            {attachment.note.title && <p className="mt-1 text-sm font-medium">{attachment.note.title}</p>}
-            <p className="mt-1 text-sm">{attachment.note.content}</p>
-            {attachment.note.quote_speaker && (
-              <p className="mt-1 text-xs text-muted-foreground">- {attachment.note.quote_speaker}</p>
-            )}
-            {attachment.note.book_title && (
-              <p className="mt-2 text-xs text-muted-foreground">
-                From {attachment.note.book_title}
-              </p>
-            )}
-          </div>
+          {mine ? (
+            <div className="rounded-md bg-muted/50 px-3 py-2">
+              <p className="text-xs font-medium uppercase text-muted-foreground">{noteLabel(attachment.note.label)}</p>
+              {attachment.note.title && <p className="mt-1 text-sm font-medium">{attachment.note.title}</p>}
+              <p className="mt-1 text-sm">{attachment.note.content}</p>
+              {attachment.note.quote_speaker && (
+                <p className="mt-1 text-xs text-muted-foreground">- {attachment.note.quote_speaker}</p>
+              )}
+              {attachment.note.book_title && (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  From {attachment.note.book_title}
+                </p>
+              )}
+            </div>
+          ) : (
+            <Link
+              to={href ?? "#"}
+              className="block rounded-md bg-muted/50 px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              aria-label={`Open ${attachment.note.book_title ?? attachment.note.title ?? "quote"}`}
+            >
+              <p className="text-xs font-medium uppercase text-muted-foreground">{noteLabel(attachment.note.label)}</p>
+              {attachment.note.title && <p className="mt-1 text-sm font-medium">{attachment.note.title}</p>}
+              <p className="mt-1 text-sm">{attachment.note.content}</p>
+              {attachment.note.quote_speaker && (
+                <p className="mt-1 text-xs text-muted-foreground">- {attachment.note.quote_speaker}</p>
+              )}
+              {attachment.note.book_title && (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  From {attachment.note.book_title}
+                </p>
+              )}
+            </Link>
+          )}
 
           {!mine && !noteImportOpen && (
             <Button type="button" size="sm" variant="outline" onClick={onOpenNoteImport}>
@@ -373,7 +429,16 @@ function AttachmentCard({
       {attachment.type === "author" && (
         <div className="space-y-3">
           <div>
-            <p className="font-medium">{attachment.author.name}</p>
+            {mine ? (
+              <p className="font-medium">{attachment.author.name}</p>
+            ) : (
+              <Link
+                to={href ?? "#"}
+                className="font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                {attachment.author.name}
+              </Link>
+            )}
             <p className="text-xs text-muted-foreground">
               {attachment.author.books.length} book{attachment.author.books.length === 1 ? "" : "s"} shared
             </p>
@@ -407,12 +472,27 @@ function AttachmentCard({
           )}
           {attachment.author.included_quotes && attachment.author.included_quotes.length > 0 && (
             <div className="space-y-1">
-              {attachment.author.included_quotes.map((quote, index) => (
-                <p key={`${quote.id ?? index}-${quote.content}`} className="rounded-md bg-muted/50 px-2 py-1 text-xs">
-                  {quote.content}
-                  {quote.book_title && <span className="text-muted-foreground"> - {quote.book_title}</span>}
-                </p>
-              ))}
+              {attachment.author.included_quotes.map((quote, index) => {
+                const quoteItem = (
+                  <span className="rounded-md bg-muted/50 px-2 py-1 text-xs">
+                    {quote.content}
+                    {quote.book_title && <span className="text-muted-foreground"> - {quote.book_title}</span>}
+                  </span>
+                );
+                return mine ? (
+                  <p key={`${quote.id ?? index}-${quote.content}`} className="text-xs">
+                    {quoteItem}
+                  </p>
+                ) : (
+                  <Link
+                    key={`${quote.id ?? index}-${quote.content}`}
+                    to={quoteHref(quote) ?? "#"}
+                    className="block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
+                    {quoteItem}
+                  </Link>
+                );
+              })}
             </div>
           )}
         </div>
@@ -421,7 +501,16 @@ function AttachmentCard({
       {attachment.type === "series" && (
         <div className="space-y-3">
           <div>
-            <p className="font-medium">{attachment.series.name}</p>
+            {mine ? (
+              <p className="font-medium">{attachment.series.name}</p>
+            ) : (
+              <Link
+                to={href ?? "#"}
+                className="font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                {attachment.series.name}
+              </Link>
+            )}
             <p className="text-xs text-muted-foreground">
               {attachment.series.books.length} book{attachment.series.books.length === 1 ? "" : "s"} shared
             </p>
@@ -448,26 +537,61 @@ function AttachmentCard({
               ))}
             </div>
           )}
+          {!mine && (
+            <Button type="button" size="sm" variant="outline" onClick={() => onImportSeries(attachment.series)}>
+              Save to own library
+            </Button>
+          )}
           {attachment.series.included_quotes && attachment.series.included_quotes.length > 0 && (
             <div className="space-y-1">
-              {attachment.series.included_quotes.map((quote, index) => (
-                <p key={`${quote.id ?? index}-${quote.content}`} className="rounded-md bg-muted/50 px-2 py-1 text-xs">
-                  {quote.content}
-                  {quote.book_title && <span className="text-muted-foreground"> - {quote.book_title}</span>}
-                </p>
-              ))}
+              {attachment.series.included_quotes.map((quote, index) => {
+                const quoteLink = mine ? quoteHref(quote) : null;
+                const quoteItem = (
+                  <span className="rounded-md bg-muted/50 px-2 py-1 text-xs">
+                    {quote.content}
+                    {quote.book_title && <span className="text-muted-foreground"> - {quote.book_title}</span>}
+                  </span>
+                );
+                return quoteLink ? (
+                  <Link
+                    key={`${quote.id ?? index}-${quote.content}`}
+                    to={quoteLink}
+                    className="block rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
+                    {quoteItem}
+                  </Link>
+                ) : (
+                  <p key={`${quote.id ?? index}-${quote.content}`} className="text-xs">
+                    {quoteItem}
+                  </p>
+                );
+              })}
             </div>
           )}
         </div>
       )}
     </div>
   );
+
+  if (isClickable) {
+    return (
+      <Link
+        to={href}
+        className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        aria-label={`Open ${attachmentTitle(attachment)}`}
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return body;
 }
 
 export function GroupsManager() {
   const { user } = useAuth();
   const { books, addBook } = useBooksContext();
-  const { series } = useSeries();
+  const { series: librarySeries, addSeries } = useSeries();
   const [threads, setThreads] = useState<ChatThread[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>("");
   const [messages, setMessages] = useState<GroupMessage[]>([]);
@@ -540,7 +664,7 @@ export function GroupsManager() {
   }, [notes]);
 
   const authorSummaries = useMemo(() => buildAuthorSummaries(books, notes), [books, notes]);
-  const seriesById = useMemo(() => new Map(series.map((item) => [item.id, item])), [series]);
+  const seriesById = useMemo(() => new Map(librarySeries.map((item) => [item.id, item])), [librarySeries]);
   const seriesBooksById = useMemo(() => {
     const map = new Map<string, Book[]>();
     books.forEach((book) => {
@@ -590,10 +714,10 @@ export function GroupsManager() {
 
   const filteredSeries = useMemo(() => {
     const query = attachmentSearch.trim().toLowerCase();
-    const sorted = sortSeriesByName(series);
+    const sorted = sortSeriesByName(librarySeries);
     if (!query) return sorted;
     return sorted.filter((item) => item.name.toLowerCase().includes(query));
-  }, [attachmentSearch, series]);
+  }, [attachmentSearch, librarySeries]);
 
   const selectedBook = selectedBookId ? booksById.get(selectedBookId) ?? null : null;
   const selectedNote = selectedNoteId ? notes.find((note) => note.id === selectedNoteId) ?? null : null;
@@ -935,6 +1059,7 @@ export function GroupsManager() {
         .filter((note): note is BookNote => Boolean(note));
       setSelectedAttachment(
         buildSeriesAttachment({
+          seriesId: selectedSeries.id,
           seriesName: selectedSeries.name,
           books: selectedSeriesBooks,
           includedQuotes,
@@ -984,6 +1109,29 @@ export function GroupsManager() {
       setStatusMessage("Book saved to your library.");
     } catch (importError) {
       setError(toChatErrorMessage(importError, "Could not save book."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function importSeriesAttachment(seriesSnapshot: Extract<ChatAttachmentPayload, { type: "series" }>["series"]) {
+    setSaving(true);
+    setError(null);
+    setStatusMessage(null);
+
+    try {
+      const existingSeries = librarySeries.find(
+        (item) => item.name.trim().toLowerCase() === seriesSnapshot.name.trim().toLowerCase(),
+      );
+      const seriesId = existingSeries?.id ?? (await addSeries(seriesSnapshot.name)).id;
+
+      for (const book of seriesSnapshot.books) {
+        await addBook(bookSnapshotToAddBookPayload(book, { series_id: seriesId }));
+      }
+
+      setStatusMessage("Series saved to your library.");
+    } catch (importError) {
+      setError(toChatErrorMessage(importError, "Could not save series."));
     } finally {
       setSaving(false);
     }
@@ -1501,6 +1649,7 @@ export function GroupsManager() {
                                     noteImportOpen={noteImportMessageId === message.id}
                                     noteImportTargetBookId={noteImportTargetBookId}
                                     onImportBook={importBookSnapshot}
+                                    onImportSeries={importSeriesAttachment}
                                     onOpenNoteImport={() => {
                                       setNoteImportMessageId(message.id);
                                       setNoteImportTargetBookId("");

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,0 +1,446 @@
+import { supabase } from "@/lib/supabase";
+import {
+  buildReplySnapshot,
+  countUnreadMessages,
+  getMessagePreview,
+  normalizeChatMessageContent,
+  normalizeMessageContent,
+  summarizeHeartReactions,
+  sortChatThreads,
+} from "@/lib/chatLogic";
+import {
+  addGroupMember,
+  createGroup,
+  getErrorMessage,
+  getGroupMembers,
+  removeGroupMember,
+  updateGroupMemberRole,
+  type GroupPayload,
+} from "@/lib/profiles";
+import type {
+  Group,
+  GroupMembership,
+  GroupMembershipRole,
+  GroupMessage,
+  PublicProfile,
+  ChatAttachmentPayload,
+  ChatAttachmentType,
+  ChatReaction,
+  ChatReplySnapshot,
+} from "@/types";
+
+type NullableGroupRow = Omit<Group, "description" | "avatar_url" | "direct_pair_key"> & {
+  description: string | null;
+  avatar_url: string | null;
+  direct_pair_key: string | null;
+};
+
+type NullablePublicProfileRow = Omit<PublicProfile, "username" | "display_name" | "avatar_url"> & {
+  username: string | null;
+  display_name: string | null;
+  avatar_url: string | null;
+};
+
+type NullableMessageRow = Omit<GroupMessage, "edited_at" | "deleted_at"> & {
+  edited_at: string | null;
+  deleted_at: string | null;
+  attachment_type: ChatAttachmentType | null;
+  attachment_payload: ChatAttachmentPayload | null;
+  reply_to_message_id: string | null;
+  reply_snapshot: ChatReplySnapshot | null;
+};
+
+type ReactionRow = ChatReaction;
+
+export type ChatMember = GroupMembership & {
+  profile?: PublicProfile;
+};
+
+export type ChatThread = {
+  group: Group;
+  currentMembership: GroupMembership;
+  members: ChatMember[];
+  title: string;
+  description?: string;
+  avatarProfile?: PublicProfile;
+  latestMessage?: GroupMessage;
+  unreadCount: number;
+};
+
+export {
+  buildReplySnapshot,
+  countUnreadMessages,
+  getMessagePreview,
+  normalizeChatMessageContent,
+  normalizeMessageContent,
+  summarizeHeartReactions,
+  sortChatThreads,
+};
+
+function normalizeGroup(row: NullableGroupRow): Group {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? undefined,
+    avatar_url: row.avatar_url ?? undefined,
+    created_by: row.created_by,
+    kind: row.kind,
+    direct_pair_key: row.direct_pair_key,
+    created_at: row.created_at,
+  };
+}
+
+function normalizePublicProfile(row: NullablePublicProfileRow): PublicProfile {
+  return {
+    id: row.id,
+    username: row.username ?? undefined,
+    display_name: row.display_name ?? undefined,
+    avatar_url: row.avatar_url ?? undefined,
+    created_at: row.created_at,
+  };
+}
+
+function normalizeMessage(row: NullableMessageRow): GroupMessage {
+  return {
+    id: row.id,
+    group_id: row.group_id,
+    sender_id: row.sender_id,
+    content: row.content,
+    attachment_type: row.attachment_type,
+    attachment_payload: row.attachment_payload,
+    reply_to_message_id: row.reply_to_message_id,
+    reply_snapshot: row.reply_snapshot,
+    reactions: row.reactions ?? [],
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    edited_at: row.edited_at,
+    deleted_at: row.deleted_at,
+  };
+}
+
+function profileDisplayName(profile?: PublicProfile): string {
+  if (!profile) return "Unknown user";
+  return profile.display_name?.trim() || profile.username?.trim() || "Unknown user";
+}
+
+function buildThreadTitle(
+  group: Group,
+  members: ChatMember[],
+  currentUserId: string,
+): { title: string; avatarProfile?: PublicProfile } {
+  if (group.kind === "group") return { title: group.name };
+
+  const otherMember = members.find((member) => member.user_id !== currentUserId);
+  return {
+    title: profileDisplayName(otherMember?.profile),
+    avatarProfile: otherMember?.profile,
+  };
+}
+
+async function getProfilesById(userIds: string[]): Promise<Map<string, PublicProfile>> {
+  const uniqueIds = Array.from(new Set(userIds));
+  if (uniqueIds.length === 0) return new Map();
+
+  const { data, error } = await supabase.rpc("get_public_profiles", {
+    profile_ids: uniqueIds,
+  });
+
+  if (error) throw error;
+
+  return new Map(
+    ((data ?? []) as NullablePublicProfileRow[]).map((row) => {
+      const profile = normalizePublicProfile(row);
+      return [profile.id, profile];
+    }),
+  );
+}
+
+async function getReactionsForMessages(
+  messageIds: string[],
+  currentUserId: string,
+): Promise<Map<string, GroupMessage["reactions"]>> {
+  const uniqueMessageIds = Array.from(new Set(messageIds));
+  if (uniqueMessageIds.length === 0) return new Map();
+
+  const { data, error } = await supabase
+    .from("group_message_reactions")
+    .select("*")
+    .in("message_id", uniqueMessageIds);
+
+  if (error) throw error;
+
+  const reactions = (data ?? []) as ReactionRow[];
+  const profiles = await getProfilesById(reactions.map((reaction) => reaction.user_id));
+  const byMessage = new Map<string, ReactionRow[]>();
+  reactions.forEach((reaction) => {
+    byMessage.set(reaction.message_id, [...(byMessage.get(reaction.message_id) ?? []), reaction]);
+  });
+
+  return new Map(
+    Array.from(byMessage.entries()).map(([messageId, messageReactions]) => [
+      messageId,
+      summarizeHeartReactions({
+        reactions: messageReactions,
+        profiles,
+        currentUserId,
+      }),
+    ]),
+  );
+}
+
+function attachReactionSummaries(
+  messages: GroupMessage[],
+  reactionsByMessageId: Map<string, GroupMessage["reactions"]>,
+): GroupMessage[] {
+  return messages.map((message) => ({
+    ...message,
+    reactions: reactionsByMessageId.get(message.id) ?? [],
+  }));
+}
+
+export async function searchPublicProfiles(
+  query: string,
+): Promise<PublicProfile[]> {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (normalizedQuery.length < 2) return [];
+
+  const { data, error } = await supabase.rpc("search_public_profiles", {
+    search_query: normalizedQuery,
+  });
+
+  if (error) throw error;
+  return ((data ?? []) as NullablePublicProfileRow[]).map(normalizePublicProfile);
+}
+
+export async function getChatThreads(currentUserId: string): Promise<ChatThread[]> {
+  const { data: groupData, error: groupError } = await supabase
+    .from("groups")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (groupError) throw groupError;
+
+  const groups = ((groupData ?? []) as NullableGroupRow[]).map(normalizeGroup);
+  const groupIds = groups.map((group) => group.id);
+  if (groupIds.length === 0) return [];
+
+  const [{ data: membershipData, error: membershipError }, { data: messageData, error: messageError }] =
+    await Promise.all([
+      supabase
+        .from("group_memberships")
+        .select("*")
+        .in("group_id", groupIds)
+        .order("joined_at", { ascending: true }),
+      supabase
+        .from("group_messages")
+        .select("*")
+        .in("group_id", groupIds)
+        .order("created_at", { ascending: false })
+        .limit(500),
+    ]);
+
+  if (membershipError) throw membershipError;
+  if (messageError) throw messageError;
+
+  const memberships = (membershipData ?? []) as GroupMembership[];
+  const messages = ((messageData ?? []) as NullableMessageRow[]).map(normalizeMessage);
+  const profiles = await getProfilesById(memberships.map((member) => member.user_id));
+
+  const threads: ChatThread[] = groups
+      .map((group): ChatThread | null => {
+        const groupMembers = memberships
+          .filter((member) => member.group_id === group.id)
+          .map((member) => ({
+            ...member,
+            profile: profiles.get(member.user_id),
+          }));
+        const currentMembership = groupMembers.find((member) => member.user_id === currentUserId);
+        if (!currentMembership) return null;
+
+        const groupMessages = messages.filter((message) => message.group_id === group.id);
+        const latestMessage = groupMessages[0];
+        const { title, avatarProfile } = buildThreadTitle(group, groupMembers, currentUserId);
+
+        return {
+          group,
+          currentMembership,
+          members: groupMembers,
+          title,
+          description: group.kind === "group" ? group.description : undefined,
+          avatarProfile,
+          latestMessage,
+          unreadCount: countUnreadMessages({
+            messages: groupMessages,
+            membership: currentMembership,
+            currentUserId,
+          }),
+        };
+      })
+      .filter((thread): thread is ChatThread => thread !== null);
+
+  return sortChatThreads(threads);
+}
+
+export async function getChatMessages(groupId: string, currentUserId: string): Promise<GroupMessage[]> {
+  const { data, error } = await supabase
+    .from("group_messages")
+    .select("*")
+    .eq("group_id", groupId)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error) throw error;
+  const messages = ((data ?? []) as NullableMessageRow[]).map(normalizeMessage).reverse();
+  const reactionsByMessageId = await getReactionsForMessages(
+    messages.map((message) => message.id),
+    currentUserId,
+  );
+  return attachReactionSummaries(messages, reactionsByMessageId);
+}
+
+export async function getChatMembers(groupId: string): Promise<ChatMember[]> {
+  const members = await getGroupMembers(groupId);
+  const profiles = await getProfilesById(members.map((member) => member.user_id));
+  return members.map((member) => ({ ...member, profile: profiles.get(member.user_id) }));
+}
+
+export async function createGroupChat(payload: GroupPayload): Promise<Group> {
+  const { group } = await createGroup(payload);
+  return group;
+}
+
+export async function createOrGetDirectChat(profileId: string): Promise<Group> {
+  const { data, error } = await supabase
+    .rpc("create_or_get_direct_group", { other_user_id: profileId })
+    .single();
+
+  if (error) throw error;
+  return normalizeGroup(data as NullableGroupRow);
+}
+
+export async function addGroupMemberByUsername(
+  groupId: string,
+  username: string,
+): Promise<GroupMembership> {
+  const normalizedUsername = username.trim().toLowerCase();
+  if (!normalizedUsername) throw new Error("Username is required.");
+
+  const { data, error } = await supabase
+    .rpc("get_public_profile_by_username", { username_query: normalizedUsername })
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) throw new Error("No user found with that username.");
+
+  return addGroupMember(groupId, (data as NullablePublicProfileRow).id);
+}
+
+export async function sendChatMessage(
+  groupId: string,
+  senderId: string,
+  content: string,
+  attachment?: ChatAttachmentPayload | null,
+  reply?: ChatReplySnapshot | null,
+): Promise<GroupMessage> {
+  const { data, error } = await supabase
+    .from("group_messages")
+    .insert({
+      group_id: groupId,
+      sender_id: senderId,
+      content: normalizeChatMessageContent({ content, attachment }),
+      attachment_type: attachment?.type ?? null,
+      attachment_payload: attachment ?? null,
+      reply_to_message_id: reply?.message_id ?? null,
+      reply_snapshot: reply ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return normalizeMessage(data as NullableMessageRow);
+}
+
+export async function toggleHeartReaction(
+  message: GroupMessage,
+  currentUserId: string,
+): Promise<void> {
+  const currentReaction = message.reactions?.find((reaction) => reaction.reaction === "heart");
+
+  if (currentReaction?.reacted_by_current_user) {
+    const { error } = await supabase
+      .from("group_message_reactions")
+      .delete()
+      .eq("message_id", message.id)
+      .eq("user_id", currentUserId)
+      .eq("reaction", "heart");
+
+    if (error) throw error;
+    return;
+  }
+
+  const { error } = await supabase
+    .from("group_message_reactions")
+    .insert({
+      message_id: message.id,
+      user_id: currentUserId,
+      reaction: "heart",
+    });
+
+  if (error) throw error;
+}
+
+export async function editChatMessage(messageId: string, content: string): Promise<GroupMessage> {
+  const { data, error } = await supabase
+    .from("group_messages")
+    .update({ content: normalizeMessageContent(content) })
+    .eq("id", messageId)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return normalizeMessage(data as NullableMessageRow);
+}
+
+export async function deleteChatMessage(messageId: string): Promise<GroupMessage> {
+  const { data, error } = await supabase
+    .from("group_messages")
+    .update({ deleted_at: new Date().toISOString(), content: "" })
+    .eq("id", messageId)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return normalizeMessage(data as NullableMessageRow);
+}
+
+export async function markChatRead(groupId: string): Promise<void> {
+  const { error } = await supabase.rpc("mark_group_read", { group_uuid: groupId });
+
+  if (error) throw error;
+}
+
+export async function changeGroupMemberRole(
+  groupId: string,
+  userId: string,
+  role: GroupMembershipRole,
+): Promise<GroupMembership> {
+  return updateGroupMemberRole(groupId, userId, role);
+}
+
+export async function removeChatMember(groupId: string, userId: string): Promise<void> {
+  return removeGroupMember(groupId, userId);
+}
+
+export function toChatErrorMessage(error: unknown, fallback: string): string {
+  const message = getErrorMessage(error, fallback);
+
+  if (message.includes("group_memberships_user_id_fkey")) {
+    return "No app user exists for that profile.";
+  }
+
+  if (message.includes("duplicate key")) {
+    return "That person is already in this chat.";
+  }
+
+  return message;
+}

--- a/src/lib/chatAttachments.ts
+++ b/src/lib/chatAttachments.ts
@@ -5,6 +5,7 @@ import type {
   ChatAuthorAttachment,
   ChatBookAttachment,
   ChatNoteAttachment,
+  ChatSeriesAttachment,
   ChatSharedBookSnapshot,
   ChatSharedNoteSnapshot,
 } from "@/types";
@@ -96,6 +97,27 @@ export function buildAuthorAttachment({
   };
 }
 
+export function buildSeriesAttachment({
+  seriesName,
+  books,
+  includedQuotes,
+}: {
+  seriesName: string;
+  books: Book[];
+  includedQuotes: BookNote[];
+}): ChatSeriesAttachment {
+  return {
+    type: "series",
+    series: {
+      name: seriesName,
+      books: books.map((book) => buildSharedBookSnapshot(book)),
+      included_quotes: includedQuotes
+        .slice(0, MAX_INCLUDED_ATTACHMENT_NOTES)
+        .map((note) => buildSharedNoteSnapshot(note, books.find((book) => book.id === note.book_id))),
+    },
+  };
+}
+
 export function bookSnapshotToAddBookPayload(book: ChatSharedBookSnapshot): AddBookPayload {
   return {
     title: book.title,
@@ -141,5 +163,6 @@ export function noteSnapshotToCreateInput({
 export function attachmentTitle(attachment: ChatAttachmentPayload): string {
   if (attachment.type === "book") return attachment.book.title;
   if (attachment.type === "note") return attachment.note.title || attachment.note.book_title || "Shared note";
-  return attachment.author.name;
+  if (attachment.type === "author") return attachment.author.name;
+  return attachment.series.name;
 }

--- a/src/lib/chatAttachments.ts
+++ b/src/lib/chatAttachments.ts
@@ -1,0 +1,145 @@
+import type {
+  Book,
+  BookNote,
+  ChatAttachmentPayload,
+  ChatAuthorAttachment,
+  ChatBookAttachment,
+  ChatNoteAttachment,
+  ChatSharedBookSnapshot,
+  ChatSharedNoteSnapshot,
+} from "@/types";
+import type { AddBookPayload } from "@/hooks/useBooks";
+import type { CreateBookNoteInput } from "@/lib/bookNotes";
+
+export const MAX_INCLUDED_ATTACHMENT_NOTES = 3;
+
+export function buildSharedNoteSnapshot(
+  note: BookNote,
+  book?: Book | null,
+): ChatSharedNoteSnapshot {
+  return {
+    id: note.id,
+    label: note.label,
+    title: note.title ?? null,
+    content: note.content,
+    quote_speaker: note.quote_speaker ?? null,
+    page_start: note.page_start ?? null,
+    note_date: note.note_date ?? null,
+    book_id: note.book_id,
+    book_title: book?.title ?? null,
+    book_authors: book?.authors ?? [],
+  };
+}
+
+export function buildSharedBookSnapshot(
+  book: Book,
+  includedNotes: BookNote[] = [],
+): ChatSharedBookSnapshot {
+  return {
+    id: book.id,
+    title: book.title,
+    authors: book.authors,
+    cover_url: book.cover_url ?? null,
+    genres: book.genres ?? [],
+    total_pages: book.total_pages ?? null,
+    language: book.language ?? null,
+    format: book.format ?? null,
+    isbn: book.isbn ?? null,
+    publisher: book.publisher ?? null,
+    publication_date: book.publication_date ?? null,
+    publication_date_precision: book.publication_date_precision ?? null,
+    description: book.description ?? null,
+    metadata_source: book.metadata_source ?? null,
+    metadata_source_url: book.metadata_source_url ?? null,
+    included_notes: includedNotes
+      .slice(0, MAX_INCLUDED_ATTACHMENT_NOTES)
+      .map((note) => buildSharedNoteSnapshot(note, book)),
+  };
+}
+
+export function buildBookAttachment(
+  book: Book,
+  includedNotes: BookNote[] = [],
+): ChatBookAttachment {
+  return {
+    type: "book",
+    book: buildSharedBookSnapshot(book, includedNotes),
+  };
+}
+
+export function buildNoteAttachment(note: BookNote, book?: Book | null): ChatNoteAttachment {
+  return {
+    type: "note",
+    note: buildSharedNoteSnapshot(note, book),
+    book: book ? buildSharedBookSnapshot(book) : null,
+  };
+}
+
+export function buildAuthorAttachment({
+  authorName,
+  books,
+  includedQuotes,
+}: {
+  authorName: string;
+  books: Book[];
+  includedQuotes: BookNote[];
+}): ChatAuthorAttachment {
+  return {
+    type: "author",
+    author: {
+      name: authorName,
+      books: books.map((book) => buildSharedBookSnapshot(book)),
+      included_quotes: includedQuotes
+        .slice(0, MAX_INCLUDED_ATTACHMENT_NOTES)
+        .map((note) => buildSharedNoteSnapshot(note, books.find((book) => book.id === note.book_id))),
+    },
+  };
+}
+
+export function bookSnapshotToAddBookPayload(book: ChatSharedBookSnapshot): AddBookPayload {
+  return {
+    title: book.title,
+    authors: book.authors.length > 0 ? book.authors : ["Unknown"],
+    genres: book.genres,
+    status: "Wishlist",
+    total_pages: book.total_pages ?? undefined,
+    language: book.language ?? undefined,
+    format: book.format ?? undefined,
+    isbn: book.isbn ?? undefined,
+    publisher: book.publisher ?? null,
+    publication_date: book.publication_date ?? null,
+    publication_date_precision: book.publication_date_precision ?? null,
+    description: book.description ?? null,
+    metadata_source: book.metadata_source ?? null,
+    metadata_source_url: book.metadata_source_url ?? null,
+    is_favorite: false,
+  };
+}
+
+export function noteSnapshotToCreateInput({
+  note,
+  bookId,
+  userId,
+}: {
+  note: ChatSharedNoteSnapshot;
+  bookId: string;
+  userId: string;
+}): CreateBookNoteInput {
+  return {
+    bookId,
+    userId,
+    label: note.label,
+    title: note.title ?? undefined,
+    quoteSpeaker: note.quote_speaker ?? undefined,
+    content: note.content,
+    pageStart: note.page_start ?? undefined,
+    noteDate: note.note_date ?? undefined,
+    isFavorite: false,
+  };
+}
+
+export function attachmentTitle(attachment: ChatAttachmentPayload): string {
+  if (attachment.type === "book") return attachment.book.title;
+  if (attachment.type === "note") return attachment.note.title || attachment.note.book_title || "Shared note";
+  return attachment.author.name;
+}

--- a/src/lib/chatAttachments.ts
+++ b/src/lib/chatAttachments.ts
@@ -52,6 +52,7 @@ export function buildSharedBookSnapshot(
     description: book.description ?? null,
     metadata_source: book.metadata_source ?? null,
     metadata_source_url: book.metadata_source_url ?? null,
+    volume_number: book.volume_number ?? null,
     included_notes: includedNotes
       .slice(0, MAX_INCLUDED_ATTACHMENT_NOTES)
       .map((note) => buildSharedNoteSnapshot(note, book)),
@@ -98,10 +99,12 @@ export function buildAuthorAttachment({
 }
 
 export function buildSeriesAttachment({
+  seriesId,
   seriesName,
   books,
   includedQuotes,
 }: {
+  seriesId?: string | null;
   seriesName: string;
   books: Book[];
   includedQuotes: BookNote[];
@@ -109,6 +112,7 @@ export function buildSeriesAttachment({
   return {
     type: "series",
     series: {
+      id: seriesId ?? undefined,
       name: seriesName,
       books: books.map((book) => buildSharedBookSnapshot(book)),
       included_quotes: includedQuotes
@@ -118,7 +122,10 @@ export function buildSeriesAttachment({
   };
 }
 
-export function bookSnapshotToAddBookPayload(book: ChatSharedBookSnapshot): AddBookPayload {
+export function bookSnapshotToAddBookPayload(
+  book: ChatSharedBookSnapshot,
+  overrides: { series_id?: string | null } = {},
+): AddBookPayload {
   return {
     title: book.title,
     authors: book.authors.length > 0 ? book.authors : ["Unknown"],
@@ -134,6 +141,8 @@ export function bookSnapshotToAddBookPayload(book: ChatSharedBookSnapshot): AddB
     description: book.description ?? null,
     metadata_source: book.metadata_source ?? null,
     metadata_source_url: book.metadata_source_url ?? null,
+    series_id: overrides.series_id ?? undefined,
+    volume_number: book.volume_number ?? undefined,
     is_favorite: false,
   };
 }

--- a/src/lib/chatLogic.ts
+++ b/src/lib/chatLogic.ts
@@ -1,0 +1,114 @@
+import { attachmentTitle } from "@/lib/chatAttachments";
+import type {
+  ChatAttachmentPayload,
+  ChatReaction,
+  ChatReactionSummary,
+  ChatReplySnapshot,
+  GroupMembership,
+  GroupMessage,
+} from "@/types";
+
+export type ChatThreadSortItem = {
+  group: {
+    created_at: string;
+  };
+  latestMessage?: Pick<GroupMessage, "created_at">;
+};
+
+export function normalizeMessageContent(content: string): string {
+  const normalized = content.trim();
+  if (!normalized) throw new Error("Message cannot be blank.");
+  return normalized;
+}
+
+export function normalizeChatMessageContent({
+  content,
+  attachment,
+}: {
+  content: string;
+  attachment?: ChatAttachmentPayload | null;
+}): string {
+  const normalized = content.trim();
+  if (!normalized && !attachment) throw new Error("Message cannot be blank.");
+  return normalized;
+}
+
+export function getMessagePreview(message?: Pick<GroupMessage, "content" | "deleted_at">): string {
+  if (!message) return "No messages yet.";
+  if (message.deleted_at) return "Message deleted";
+  return message.content;
+}
+
+export function buildReplySnapshot({
+  message,
+  senderName,
+}: {
+  message: GroupMessage;
+  senderName: string;
+}): ChatReplySnapshot {
+  const attachment = message.attachment_payload ?? null;
+  return {
+    message_id: message.id,
+    sender_id: message.sender_id,
+    sender_name: senderName,
+    text: message.content.trim() || (attachment ? attachmentTitle(attachment) : "Message"),
+    attachment_type: attachment?.type ?? null,
+    attachment_title: attachment ? attachmentTitle(attachment) : null,
+    created_at: message.created_at,
+  };
+}
+
+export function summarizeHeartReactions({
+  reactions,
+  profiles,
+  currentUserId,
+}: {
+  reactions: ChatReaction[];
+  profiles: Map<string, { display_name?: string; username?: string }>;
+  currentUserId: string;
+}): ChatReactionSummary[] {
+  if (reactions.length === 0) return [];
+
+  return [
+    {
+      reaction: "heart",
+      count: reactions.length,
+      reacted_by_current_user: reactions.some((reaction) => reaction.user_id === currentUserId),
+      participants: reactions.map((reaction) => {
+        const profile = profiles.get(reaction.user_id);
+        return {
+          user_id: reaction.user_id,
+          display_name: profile?.display_name?.trim() || profile?.username?.trim() || "Unknown user",
+        };
+      }),
+    },
+  ];
+}
+
+export function countUnreadMessages({
+  messages,
+  membership,
+  currentUserId,
+}: {
+  messages: Array<Pick<GroupMessage, "sender_id" | "created_at">>;
+  membership: Pick<GroupMembership, "last_read_at">;
+  currentUserId: string;
+}): number {
+  if (!membership.last_read_at) {
+    return messages.filter((message) => message.sender_id !== currentUserId).length;
+  }
+
+  const lastReadAt = new Date(membership.last_read_at).getTime();
+  return messages.filter((message) => {
+    if (message.sender_id === currentUserId) return false;
+    return new Date(message.created_at).getTime() > lastReadAt;
+  }).length;
+}
+
+export function sortChatThreads<T extends ChatThreadSortItem>(threads: T[]): T[] {
+  return [...threads].sort((first, second) => {
+    const firstTime = first.latestMessage?.created_at ?? first.group.created_at;
+    const secondTime = second.latestMessage?.created_at ?? second.group.created_at;
+    return new Date(secondTime).getTime() - new Date(firstTime).getTime();
+  });
+}

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -30,6 +30,8 @@ type NullableProfileRow = Omit<
 type NullableGroupRow = Omit<Group, "description" | "avatar_url"> & {
   description: string | null;
   avatar_url: string | null;
+  kind?: Group["kind"] | null;
+  direct_pair_key?: string | null;
 };
 
 export type ProfilePayload = Partial<
@@ -79,6 +81,8 @@ function normalizeGroup(row: NullableGroupRow): Group {
     description: row.description ?? undefined,
     avatar_url: row.avatar_url ?? undefined,
     created_by: row.created_by,
+    kind: row.kind ?? "group",
+    direct_pair_key: row.direct_pair_key ?? null,
     created_at: row.created_at,
   };
 }

--- a/src/lib/router.tsx
+++ b/src/lib/router.tsx
@@ -67,6 +67,7 @@ export const router = createBrowserRouter([
           { path: "/analytics/:category", element: lazyRoute(<Analytics />) },
           { path: "/notes", element: lazyRoute(<Notes />) },
           { path: "/account", element: <Navigate to="/settings/profile" replace /> },
+          { path: "/group", element: <Navigate to="/groups" replace /> },
           { path: "/groups", element: lazyRoute(<Groups />) },
           { path: "/profile", element: lazyRoute(<Profile />) },
           { path: "/settings", element: lazyRoute(<Settings />) },

--- a/src/pages/Groups.tsx
+++ b/src/pages/Groups.tsx
@@ -1,13 +1,5 @@
 import { GroupsManager } from "@/components/groups/GroupsManager";
 
 export default function Groups() {
-  return (
-    <div className="space-y-4">
-      <div>
-        <h1 className="text-2xl font-heading leading-snug font-medium">Groups</h1>
-      </div>
-
-      <GroupsManager />
-    </div>
-  );
+  return <GroupsManager />;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -229,8 +229,12 @@ export interface Group {
   description?: string;
   avatar_url?: string;
   created_by: string;
+  kind: GroupKind;
+  direct_pair_key?: string | null;
   created_at: string;
 }
+
+export type GroupKind = "direct" | "group";
 
 export type GroupMembershipRole = "owner" | "admin" | "member";
 
@@ -241,5 +245,119 @@ export interface GroupMembership {
   user_id: string;
   role: GroupMembershipRole;
   status: GroupMembershipStatus;
+  last_read_at?: string | null;
   joined_at: string;
 }
+
+export type PublicProfile = Pick<
+  Profile,
+  "id" | "username" | "display_name" | "avatar_url" | "created_at"
+>;
+
+export interface GroupMessage {
+  id: string;
+  group_id: string;
+  sender_id: string;
+  content: string;
+  attachment_type?: ChatAttachmentType | null;
+  attachment_payload?: ChatAttachmentPayload | null;
+  reply_to_message_id?: string | null;
+  reply_snapshot?: ChatReplySnapshot | null;
+  reactions?: ChatReactionSummary[];
+  created_at: string;
+  updated_at: string;
+  edited_at?: string | null;
+  deleted_at?: string | null;
+}
+
+export type ChatReactionType = "heart";
+
+export interface ChatReaction {
+  message_id: string;
+  user_id: string;
+  reaction: ChatReactionType;
+  created_at: string;
+}
+
+export interface ChatReactionParticipant {
+  user_id: string;
+  display_name: string;
+}
+
+export interface ChatReactionSummary {
+  reaction: ChatReactionType;
+  count: number;
+  reacted_by_current_user: boolean;
+  participants: ChatReactionParticipant[];
+}
+
+export interface ChatReplySnapshot {
+  message_id: string;
+  sender_id: string;
+  sender_name: string;
+  text: string;
+  attachment_type?: ChatAttachmentType | null;
+  attachment_title?: string | null;
+  created_at: string;
+}
+
+export type ChatAttachmentType = "book" | "note" | "author";
+
+export type ChatSharedNoteLabel = BookNoteLabel;
+
+export interface ChatSharedNoteSnapshot {
+  id?: string;
+  label: ChatSharedNoteLabel;
+  title?: string | null;
+  content: string;
+  quote_speaker?: string | null;
+  page_start?: number | null;
+  note_date?: string | null;
+  book_id?: string | null;
+  book_title?: string | null;
+  book_authors?: string[];
+}
+
+export interface ChatSharedBookSnapshot {
+  id?: string;
+  title: string;
+  authors: string[];
+  cover_url?: string | null;
+  genres?: string[];
+  total_pages?: number | null;
+  language?: BookLanguage | null;
+  format?: BookFormat | null;
+  isbn?: string | null;
+  publisher?: string | null;
+  publication_date?: string | null;
+  publication_date_precision?: PublicationDatePrecision | null;
+  description?: string | null;
+  metadata_source?: BookMetadataSource | null;
+  metadata_source_url?: string | null;
+  included_notes?: ChatSharedNoteSnapshot[];
+}
+
+export interface ChatBookAttachment {
+  type: "book";
+  book: ChatSharedBookSnapshot;
+}
+
+export interface ChatNoteAttachment {
+  type: "note";
+  note: ChatSharedNoteSnapshot;
+  book?: ChatSharedBookSnapshot | null;
+}
+
+export interface ChatAuthorAttachment {
+  type: "author";
+  author: {
+    name: string;
+    books: ChatSharedBookSnapshot[];
+    included_quotes?: ChatSharedNoteSnapshot[];
+  };
+}
+
+export type ChatAttachmentPayload =
+  | ChatBookAttachment
+  | ChatNoteAttachment
+  | ChatAuthorAttachment;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -301,7 +301,9 @@ export interface ChatReplySnapshot {
   created_at: string;
 }
 
-export type ChatAttachmentType = "book" | "note" | "author";
+// Chat attachments use a stable snapshot shape so sent messages don't change
+// if the underlying book, note, author, or series data changes later.
+export type ChatAttachmentType = "book" | "note" | "author" | "series";
 
 export type ChatSharedNoteLabel = BookNoteLabel;
 
@@ -357,7 +359,20 @@ export interface ChatAuthorAttachment {
   };
 }
 
+export interface ChatSharedSeriesSnapshot {
+  id?: string;
+  name: string;
+  books: ChatSharedBookSnapshot[];
+  included_quotes?: ChatSharedNoteSnapshot[];
+}
+
+export interface ChatSeriesAttachment {
+  type: "series";
+  series: ChatSharedSeriesSnapshot;
+}
+
 export type ChatAttachmentPayload =
   | ChatBookAttachment
   | ChatNoteAttachment
-  | ChatAuthorAttachment;
+  | ChatAuthorAttachment
+  | ChatSeriesAttachment;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -336,6 +336,7 @@ export interface ChatSharedBookSnapshot {
   description?: string | null;
   metadata_source?: BookMetadataSource | null;
   metadata_source_url?: string | null;
+  volume_number?: number | null;
   included_notes?: ChatSharedNoteSnapshot[];
 }
 

--- a/supabase/migrations/20260620_fix_public_profile_rpcs.sql
+++ b/supabase/migrations/20260620_fix_public_profile_rpcs.sql
@@ -1,0 +1,79 @@
+-- Follow-up for chat profile lookup.
+-- If the original chat migration was already applied before these RPCs existed,
+-- Supabase will not rerun that edited migration. This migration creates the
+-- functions explicitly and removes the old public_profiles view.
+
+DROP VIEW IF EXISTS public_profiles;
+
+CREATE OR REPLACE FUNCTION search_public_profiles(search_query text)
+RETURNS TABLE (
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT profiles.id, profiles.username, profiles.display_name, profiles.avatar_url, profiles.created_at
+  FROM profiles
+  WHERE auth.uid() IS NOT NULL
+    AND profiles.id <> auth.uid()
+    AND length(btrim(search_query)) >= 2
+    AND (
+      profiles.username ILIKE '%' || lower(btrim(search_query)) || '%'
+      OR profiles.display_name ILIKE '%' || btrim(search_query) || '%'
+    )
+  ORDER BY profiles.username NULLS LAST, profiles.display_name NULLS LAST
+  LIMIT 8;
+$$;
+
+GRANT EXECUTE ON FUNCTION search_public_profiles(text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION get_public_profile_by_username(username_query text)
+RETURNS TABLE (
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT profiles.id, profiles.username, profiles.display_name, profiles.avatar_url, profiles.created_at
+  FROM profiles
+  WHERE auth.uid() IS NOT NULL
+    AND profiles.username = lower(btrim(username_query))
+  LIMIT 1;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_public_profile_by_username(text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION get_public_profiles(profile_ids uuid[])
+RETURNS TABLE (
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT profiles.id, profiles.username, profiles.display_name, profiles.avatar_url, profiles.created_at
+  FROM profiles
+  WHERE auth.uid() IS NOT NULL
+    AND profiles.id = ANY(profile_ids);
+$$;
+
+GRANT EXECUTE ON FUNCTION get_public_profiles(uuid[]) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260620_group_chats.sql
+++ b/supabase/migrations/20260620_group_chats.sql
@@ -1,0 +1,424 @@
+-- Add chat behavior to the existing groups feature.
+-- Groups are now the shared container for both direct and group chats.
+
+ALTER TABLE groups
+  ADD COLUMN IF NOT EXISTS kind text NOT NULL DEFAULT 'group'
+    CHECK (kind IN ('direct', 'group')),
+  ADD COLUMN IF NOT EXISTS direct_pair_key text;
+
+ALTER TABLE group_memberships
+  ADD COLUMN IF NOT EXISTS last_read_at timestamptz;
+
+CREATE TABLE IF NOT EXISTS group_messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id uuid NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+  sender_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  content text NOT NULL DEFAULT '',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  edited_at timestamptz,
+  deleted_at timestamptz,
+  CHECK (
+    deleted_at IS NOT NULL
+    OR length(btrim(content)) > 0
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS groups_direct_pair_key_unique_idx
+  ON groups (direct_pair_key)
+  WHERE kind = 'direct';
+
+CREATE INDEX IF NOT EXISTS groups_kind_idx ON groups(kind);
+CREATE INDEX IF NOT EXISTS group_memberships_last_read_at_idx ON group_memberships(group_id, last_read_at);
+CREATE INDEX IF NOT EXISTS group_messages_group_created_at_idx ON group_messages(group_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS group_messages_sender_id_idx ON group_messages(sender_id);
+
+DROP VIEW IF EXISTS public_profiles;
+
+ALTER TABLE group_messages ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION direct_pair_key_for(first_user_id uuid, second_user_id uuid)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public
+AS $$
+  SELECT CASE
+    WHEN first_user_id < second_user_id THEN first_user_id::text || ':' || second_user_id::text
+    ELSE second_user_id::text || ':' || first_user_id::text
+  END;
+$$;
+
+CREATE OR REPLACE FUNCTION prevent_invalid_direct_group_membership()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  group_kind text;
+  active_member_count integer;
+BEGIN
+  SELECT kind INTO group_kind
+  FROM groups
+  WHERE id = NEW.group_id;
+
+  IF group_kind <> 'direct' OR NEW.status <> 'active' THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    SELECT count(*) INTO active_member_count
+    FROM group_memberships
+    WHERE group_id = NEW.group_id
+      AND status = 'active';
+  ELSE
+    SELECT count(*) INTO active_member_count
+    FROM group_memberships
+    WHERE group_id = NEW.group_id
+      AND status = 'active'
+      AND user_id <> OLD.user_id;
+  END IF;
+
+  IF active_member_count >= 2 THEN
+    RAISE EXCEPTION 'Direct chats can only have two active members.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS group_memberships_prevent_invalid_direct ON group_memberships;
+
+CREATE TRIGGER group_memberships_prevent_invalid_direct
+  BEFORE INSERT OR UPDATE OF status ON group_memberships
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_invalid_direct_group_membership();
+
+CREATE OR REPLACE FUNCTION set_group_message_update_fields()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  NEW.updated_at = now();
+
+  IF NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL THEN
+    NEW.content = '';
+  ELSIF NEW.deleted_at IS NULL AND NEW.content IS DISTINCT FROM OLD.content THEN
+    NEW.edited_at = now();
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS group_messages_set_update_fields ON group_messages;
+
+CREATE TRIGGER group_messages_set_update_fields
+  BEFORE UPDATE ON group_messages
+  FOR EACH ROW
+  EXECUTE FUNCTION set_group_message_update_fields();
+
+CREATE OR REPLACE FUNCTION search_public_profiles(search_query text)
+RETURNS TABLE (
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT profiles.id, profiles.username, profiles.display_name, profiles.avatar_url, profiles.created_at
+  FROM profiles
+  WHERE auth.uid() IS NOT NULL
+    AND profiles.id <> auth.uid()
+    AND length(btrim(search_query)) >= 2
+    AND (
+      profiles.username ILIKE '%' || lower(btrim(search_query)) || '%'
+      OR profiles.display_name ILIKE '%' || btrim(search_query) || '%'
+    )
+  ORDER BY profiles.username NULLS LAST, profiles.display_name NULLS LAST
+  LIMIT 8;
+$$;
+
+GRANT EXECUTE ON FUNCTION search_public_profiles(text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION get_public_profile_by_username(username_query text)
+RETURNS TABLE (
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT profiles.id, profiles.username, profiles.display_name, profiles.avatar_url, profiles.created_at
+  FROM profiles
+  WHERE auth.uid() IS NOT NULL
+    AND profiles.username = lower(btrim(username_query))
+  LIMIT 1;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_public_profile_by_username(text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION get_public_profiles(profile_ids uuid[])
+RETURNS TABLE (
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT profiles.id, profiles.username, profiles.display_name, profiles.avatar_url, profiles.created_at
+  FROM profiles
+  WHERE auth.uid() IS NOT NULL
+    AND profiles.id = ANY(profile_ids);
+$$;
+
+GRANT EXECUTE ON FUNCTION get_public_profiles(uuid[]) TO authenticated;
+
+CREATE OR REPLACE FUNCTION create_group_with_owner(
+  group_name text,
+  group_description text DEFAULT NULL,
+  group_avatar_url text DEFAULT NULL
+)
+RETURNS SETOF groups
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  new_group_id uuid := gen_random_uuid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  IF NULLIF(btrim(group_name), '') IS NULL THEN
+    RAISE EXCEPTION 'Group name is required.';
+  END IF;
+
+  INSERT INTO profiles (id)
+  VALUES (current_user_id)
+  ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO groups (id, name, description, avatar_url, created_by, kind)
+  VALUES (
+    new_group_id,
+    btrim(group_name),
+    NULLIF(btrim(group_description), ''),
+    NULLIF(btrim(group_avatar_url), ''),
+    current_user_id,
+    'group'
+  );
+
+  INSERT INTO group_memberships (group_id, user_id, role, status, last_read_at)
+  VALUES (new_group_id, current_user_id, 'owner', 'active', now());
+
+  RETURN QUERY
+  SELECT g.*
+  FROM groups AS g
+  WHERE g.id = new_group_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_group_with_owner(text, text, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION create_or_get_direct_group(other_user_id uuid)
+RETURNS SETOF groups
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  pair_key text;
+  existing_group_id uuid;
+  new_group_id uuid := gen_random_uuid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  IF other_user_id IS NULL OR other_user_id = current_user_id THEN
+    RAISE EXCEPTION 'Choose another user to start a chat.';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM profiles WHERE id = other_user_id) THEN
+    RAISE EXCEPTION 'No app user exists for that profile.';
+  END IF;
+
+  INSERT INTO profiles (id)
+  VALUES (current_user_id)
+  ON CONFLICT (id) DO NOTHING;
+
+  pair_key := direct_pair_key_for(current_user_id, other_user_id);
+
+  SELECT id INTO existing_group_id
+  FROM groups
+  WHERE kind = 'direct'
+    AND direct_pair_key = pair_key
+  LIMIT 1;
+
+  IF existing_group_id IS NOT NULL THEN
+    INSERT INTO group_memberships (group_id, user_id, role, status, last_read_at)
+    VALUES
+      (existing_group_id, current_user_id, 'member', 'active', now()),
+      (existing_group_id, other_user_id, 'member', 'active', NULL)
+    ON CONFLICT (group_id, user_id)
+    DO UPDATE SET status = 'active';
+
+    RETURN QUERY
+    SELECT g.*
+    FROM groups AS g
+    WHERE g.id = existing_group_id;
+    RETURN;
+  END IF;
+
+  INSERT INTO groups (id, name, created_by, kind, direct_pair_key)
+  VALUES (new_group_id, 'Direct chat', current_user_id, 'direct', pair_key);
+
+  INSERT INTO group_memberships (group_id, user_id, role, status, last_read_at)
+  VALUES
+    (new_group_id, current_user_id, 'member', 'active', now()),
+    (new_group_id, other_user_id, 'member', 'active', NULL);
+
+  RETURN QUERY
+  SELECT g.*
+  FROM groups AS g
+  WHERE g.id = new_group_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_or_get_direct_group(uuid) TO authenticated;
+
+CREATE POLICY "group_messages: member select"
+  ON group_messages FOR SELECT
+  USING (is_active_group_member(group_id, auth.uid()));
+
+CREATE POLICY "group_messages: member insert"
+  ON group_messages FOR INSERT
+  WITH CHECK (
+    auth.uid() = sender_id
+    AND deleted_at IS NULL
+    AND edited_at IS NULL
+    AND is_active_group_member(group_id, auth.uid())
+  );
+
+CREATE POLICY "group_messages: sender update"
+  ON group_messages FOR UPDATE
+  USING (
+    auth.uid() = sender_id
+    AND is_active_group_member(group_id, auth.uid())
+  )
+  WITH CHECK (
+    auth.uid() = sender_id
+    AND is_active_group_member(group_id, auth.uid())
+  );
+
+CREATE POLICY "group_messages: sender delete"
+  ON group_messages FOR DELETE
+  USING (
+    auth.uid() = sender_id
+    AND is_active_group_member(group_id, auth.uid())
+  );
+
+DROP POLICY IF EXISTS "group_memberships: manager insert" ON group_memberships;
+
+CREATE POLICY "group_memberships: manager insert" ON group_memberships
+  FOR INSERT
+  WITH CHECK (
+    (
+      can_manage_group(group_id, auth.uid())
+      AND EXISTS (
+        SELECT 1
+        FROM groups
+        WHERE groups.id = group_memberships.group_id
+          AND kind = 'group'
+      )
+    )
+    OR (
+      auth.uid() = user_id
+      AND role = 'owner'
+      AND status = 'active'
+      AND is_group_creator(group_id, auth.uid())
+    )
+  );
+
+DROP POLICY IF EXISTS "group_memberships: manager update" ON group_memberships;
+
+CREATE POLICY "group_memberships: manager update" ON group_memberships
+  FOR UPDATE
+  USING (
+    can_manage_group(group_id, auth.uid())
+    AND EXISTS (
+      SELECT 1
+      FROM groups
+      WHERE groups.id = group_memberships.group_id
+        AND kind = 'group'
+    )
+  )
+  WITH CHECK (
+    can_manage_group(group_id, auth.uid())
+    AND EXISTS (
+      SELECT 1
+      FROM groups
+      WHERE groups.id = group_memberships.group_id
+        AND kind = 'group'
+    )
+  );
+
+CREATE OR REPLACE FUNCTION mark_group_read(group_uuid uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  IF NOT is_active_group_member(group_uuid, current_user_id) THEN
+    RAISE EXCEPTION 'You must be an active group member.';
+  END IF;
+
+  UPDATE group_memberships
+  SET last_read_at = now()
+  WHERE group_id = group_uuid
+    AND user_id = current_user_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION mark_group_read(uuid) TO authenticated;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_publication
+    WHERE pubname = 'supabase_realtime'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE group_messages;
+  END IF;
+EXCEPTION
+  WHEN duplicate_object THEN
+    NULL;
+END;
+$$;

--- a/supabase/migrations/20260620_group_message_attachments.sql
+++ b/supabase/migrations/20260620_group_message_attachments.sql
@@ -1,0 +1,53 @@
+-- Add snapshot attachments to chat messages.
+-- Attachment messages may have empty text as long as they carry a valid payload.
+
+ALTER TABLE group_messages
+  ADD COLUMN IF NOT EXISTS attachment_type text
+    CHECK (attachment_type IN ('book', 'note', 'author')),
+  ADD COLUMN IF NOT EXISTS attachment_payload jsonb;
+
+DO $$
+DECLARE
+  constraint_name text;
+BEGIN
+  FOR constraint_name IN
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = 'group_messages'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) LIKE '%btrim(content)%'
+      AND conname <> 'group_messages_content_or_attachment_check'
+  LOOP
+    EXECUTE format('ALTER TABLE group_messages DROP CONSTRAINT %I', constraint_name);
+  END LOOP;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'group_messages_content_or_attachment_check'
+      AND conrelid = 'group_messages'::regclass
+  ) THEN
+    ALTER TABLE group_messages
+      ADD CONSTRAINT group_messages_content_or_attachment_check
+      CHECK (
+        deleted_at IS NOT NULL
+        OR length(btrim(content)) > 0
+        OR (
+          attachment_type IS NOT NULL
+          AND attachment_payload IS NOT NULL
+          AND jsonb_typeof(attachment_payload) = 'object'
+        )
+      );
+  END IF;
+END;
+$$;
+
+CREATE INDEX IF NOT EXISTS group_messages_attachment_type_idx
+  ON group_messages(attachment_type)
+  WHERE attachment_type IS NOT NULL;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260620_group_message_replies_reactions.sql
+++ b/supabase/migrations/20260620_group_message_replies_reactions.sql
@@ -1,0 +1,69 @@
+-- Add reply snapshots and heart reactions to chat messages.
+
+ALTER TABLE group_messages
+  ADD COLUMN IF NOT EXISTS reply_to_message_id uuid REFERENCES group_messages(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS reply_snapshot jsonb;
+
+CREATE TABLE IF NOT EXISTS group_message_reactions (
+  message_id uuid NOT NULL REFERENCES group_messages(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  reaction text NOT NULL CHECK (reaction = 'heart'),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (message_id, user_id, reaction)
+);
+
+CREATE INDEX IF NOT EXISTS group_messages_reply_to_message_id_idx
+  ON group_messages(reply_to_message_id)
+  WHERE reply_to_message_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS group_message_reactions_user_id_idx
+  ON group_message_reactions(user_id);
+
+ALTER TABLE group_message_reactions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "group_message_reactions: member select"
+  ON group_message_reactions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM group_messages
+      WHERE group_messages.id = group_message_reactions.message_id
+        AND is_active_group_member(group_messages.group_id, auth.uid())
+    )
+  );
+
+CREATE POLICY "group_message_reactions: member insert own"
+  ON group_message_reactions FOR INSERT
+  WITH CHECK (
+    auth.uid() = user_id
+    AND EXISTS (
+      SELECT 1
+      FROM group_messages
+      WHERE group_messages.id = group_message_reactions.message_id
+        AND group_messages.deleted_at IS NULL
+        AND is_active_group_member(group_messages.group_id, auth.uid())
+    )
+  );
+
+CREATE POLICY "group_message_reactions: member delete own"
+  ON group_message_reactions FOR DELETE
+  USING (
+    auth.uid() = user_id
+    AND EXISTS (
+      SELECT 1
+      FROM group_messages
+      WHERE group_messages.id = group_message_reactions.message_id
+        AND is_active_group_member(group_messages.group_id, auth.uid())
+    )
+  );
+
+DO $$
+BEGIN
+  ALTER PUBLICATION supabase_realtime ADD TABLE group_message_reactions;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+  WHEN undefined_object THEN NULL;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260621_group_message_series_attachment.sql
+++ b/supabase/migrations/20260621_group_message_series_attachment.sql
@@ -1,0 +1,23 @@
+-- Allow series attachments in chat messages.
+
+DO $$
+DECLARE
+  constraint_name text;
+BEGIN
+  FOR constraint_name IN
+    SELECT conname
+    FROM pg_constraint
+    WHERE conrelid = 'group_messages'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) LIKE '%attachment_type IN%'
+  LOOP
+    EXECUTE format('ALTER TABLE group_messages DROP CONSTRAINT %I', constraint_name);
+  END LOOP;
+END;
+$$;
+
+ALTER TABLE group_messages
+  ADD CONSTRAINT group_messages_attachment_type_check
+  CHECK (attachment_type IN ('book', 'note', 'author', 'series'));
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260621_group_message_series_attachment.sql
+++ b/supabase/migrations/20260621_group_message_series_attachment.sql
@@ -1,20 +1,7 @@
 -- Allow series attachments in chat messages.
 
-DO $$
-DECLARE
-  constraint_name text;
-BEGIN
-  FOR constraint_name IN
-    SELECT conname
-    FROM pg_constraint
-    WHERE conrelid = 'group_messages'::regclass
-      AND contype = 'c'
-      AND pg_get_constraintdef(oid) LIKE '%attachment_type IN%'
-  LOOP
-    EXECUTE format('ALTER TABLE group_messages DROP CONSTRAINT %I', constraint_name);
-  END LOOP;
-END;
-$$;
+ALTER TABLE group_messages
+  DROP CONSTRAINT IF EXISTS group_messages_attachment_type_check;
 
 ALTER TABLE group_messages
   ADD CONSTRAINT group_messages_attachment_type_check

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -324,6 +324,9 @@ CREATE TABLE IF NOT EXISTS groups (
   description text,
   avatar_url text,
   created_by uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  kind text NOT NULL DEFAULT 'group'
+    CHECK (kind IN ('direct', 'group')),
+  direct_pair_key text,
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
@@ -334,8 +337,41 @@ CREATE TABLE IF NOT EXISTS group_memberships (
     CHECK (role IN ('owner', 'admin', 'member')),
   status text NOT NULL DEFAULT 'active'
     CHECK (status IN ('active', 'invited')),
+  last_read_at timestamptz,
   joined_at timestamptz NOT NULL DEFAULT now(),
   PRIMARY KEY (group_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS group_messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  group_id uuid NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+  sender_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  content text NOT NULL DEFAULT '',
+  attachment_type text CHECK (attachment_type IN ('book', 'note', 'author')),
+  attachment_payload jsonb,
+  reply_to_message_id uuid REFERENCES group_messages(id) ON DELETE SET NULL,
+  reply_snapshot jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  edited_at timestamptz,
+  deleted_at timestamptz,
+  CHECK (
+    deleted_at IS NOT NULL
+    OR length(btrim(content)) > 0
+    OR (
+      attachment_type IS NOT NULL
+      AND attachment_payload IS NOT NULL
+      AND jsonb_typeof(attachment_payload) = 'object'
+    )
+  )
+);
+
+CREATE TABLE IF NOT EXISTS group_message_reactions (
+  message_id uuid NOT NULL REFERENCES group_messages(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  reaction text NOT NULL CHECK (reaction = 'heart'),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (message_id, user_id, reaction)
 );
 
 -- ── INDEXES ───────────────────────────────────────────────
@@ -357,8 +393,23 @@ CREATE INDEX IF NOT EXISTS book_notes_book_note_date_idx ON book_notes(book_id, 
 CREATE INDEX IF NOT EXISTS profiles_created_at_idx ON profiles(created_at);
 CREATE UNIQUE INDEX IF NOT EXISTS profiles_username_unique_idx ON profiles (lower(username)) WHERE username IS NOT NULL;
 CREATE INDEX IF NOT EXISTS groups_created_by_idx ON groups(created_by);
+CREATE INDEX IF NOT EXISTS groups_kind_idx ON groups(kind);
+CREATE UNIQUE INDEX IF NOT EXISTS groups_direct_pair_key_unique_idx
+  ON groups (direct_pair_key)
+  WHERE kind = 'direct';
 CREATE INDEX IF NOT EXISTS group_memberships_user_id_idx ON group_memberships(user_id);
 CREATE INDEX IF NOT EXISTS group_memberships_group_id_idx ON group_memberships(group_id);
+CREATE INDEX IF NOT EXISTS group_memberships_last_read_at_idx ON group_memberships(group_id, last_read_at);
+CREATE INDEX IF NOT EXISTS group_messages_group_created_at_idx ON group_messages(group_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS group_messages_sender_id_idx ON group_messages(sender_id);
+CREATE INDEX IF NOT EXISTS group_messages_attachment_type_idx
+  ON group_messages(attachment_type)
+  WHERE attachment_type IS NOT NULL;
+CREATE INDEX IF NOT EXISTS group_messages_reply_to_message_id_idx
+  ON group_messages(reply_to_message_id)
+  WHERE reply_to_message_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS group_message_reactions_user_id_idx
+  ON group_message_reactions(user_id);
 
 CREATE UNIQUE INDEX IF NOT EXISTS genres_unique_system_sibling_name_idx
   ON genres (COALESCE(parent_id, '00000000-0000-0000-0000-000000000000'::uuid), lower(name))
@@ -379,6 +430,10 @@ ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE user_settings ENABLE ROW LEVEL SECURITY;
 ALTER TABLE groups ENABLE ROW LEVEL SECURITY;
 ALTER TABLE group_memberships ENABLE ROW LEVEL SECURITY;
+ALTER TABLE group_messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE group_message_reactions ENABLE ROW LEVEL SECURITY;
+
+DROP VIEW IF EXISTS public_profiles;
 
 CREATE OR REPLACE FUNCTION is_active_group_member(group_uuid uuid, user_uuid uuid)
 RETURNS boolean
@@ -445,6 +500,159 @@ AS $$
   );
 $$;
 
+CREATE OR REPLACE FUNCTION direct_pair_key_for(first_user_id uuid, second_user_id uuid)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public
+AS $$
+  SELECT CASE
+    WHEN first_user_id < second_user_id THEN first_user_id::text || ':' || second_user_id::text
+    ELSE second_user_id::text || ':' || first_user_id::text
+  END;
+$$;
+
+CREATE OR REPLACE FUNCTION prevent_invalid_direct_group_membership()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  group_kind text;
+  active_member_count integer;
+BEGIN
+  SELECT kind INTO group_kind
+  FROM groups
+  WHERE id = NEW.group_id;
+
+  IF group_kind <> 'direct' OR NEW.status <> 'active' THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    SELECT count(*) INTO active_member_count
+    FROM group_memberships
+    WHERE group_id = NEW.group_id
+      AND status = 'active';
+  ELSE
+    SELECT count(*) INTO active_member_count
+    FROM group_memberships
+    WHERE group_id = NEW.group_id
+      AND status = 'active'
+      AND user_id <> OLD.user_id;
+  END IF;
+
+  IF active_member_count >= 2 THEN
+    RAISE EXCEPTION 'Direct chats can only have two active members.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS group_memberships_prevent_invalid_direct ON group_memberships;
+
+CREATE TRIGGER group_memberships_prevent_invalid_direct
+  BEFORE INSERT OR UPDATE OF status ON group_memberships
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_invalid_direct_group_membership();
+
+CREATE OR REPLACE FUNCTION set_group_message_update_fields()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  NEW.updated_at = now();
+
+  IF NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL THEN
+    NEW.content = '';
+  ELSIF NEW.deleted_at IS NULL AND NEW.content IS DISTINCT FROM OLD.content THEN
+    NEW.edited_at = now();
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS group_messages_set_update_fields ON group_messages;
+
+CREATE TRIGGER group_messages_set_update_fields
+  BEFORE UPDATE ON group_messages
+  FOR EACH ROW
+  EXECUTE FUNCTION set_group_message_update_fields();
+
+CREATE OR REPLACE FUNCTION search_public_profiles(search_query text)
+RETURNS TABLE (
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT profiles.id, profiles.username, profiles.display_name, profiles.avatar_url, profiles.created_at
+  FROM profiles
+  WHERE auth.uid() IS NOT NULL
+    AND profiles.id <> auth.uid()
+    AND length(btrim(search_query)) >= 2
+    AND (
+      profiles.username ILIKE '%' || lower(btrim(search_query)) || '%'
+      OR profiles.display_name ILIKE '%' || btrim(search_query) || '%'
+    )
+  ORDER BY profiles.username NULLS LAST, profiles.display_name NULLS LAST
+  LIMIT 8;
+$$;
+
+GRANT EXECUTE ON FUNCTION search_public_profiles(text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION get_public_profile_by_username(username_query text)
+RETURNS TABLE (
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT profiles.id, profiles.username, profiles.display_name, profiles.avatar_url, profiles.created_at
+  FROM profiles
+  WHERE auth.uid() IS NOT NULL
+    AND profiles.username = lower(btrim(username_query))
+  LIMIT 1;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_public_profile_by_username(text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION get_public_profiles(profile_ids uuid[])
+RETURNS TABLE (
+  id uuid,
+  username text,
+  display_name text,
+  avatar_url text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT profiles.id, profiles.username, profiles.display_name, profiles.avatar_url, profiles.created_at
+  FROM profiles
+  WHERE auth.uid() IS NOT NULL
+    AND profiles.id = ANY(profile_ids);
+$$;
+
+GRANT EXECUTE ON FUNCTION get_public_profiles(uuid[]) TO authenticated;
+
 CREATE OR REPLACE FUNCTION create_group_with_owner(
   group_name text,
   group_description text DEFAULT NULL,
@@ -471,17 +679,18 @@ BEGIN
   VALUES (current_user_id)
   ON CONFLICT (id) DO NOTHING;
 
-  INSERT INTO groups (id, name, description, avatar_url, created_by)
+  INSERT INTO groups (id, name, description, avatar_url, created_by, kind)
   VALUES (
     new_group_id,
     btrim(group_name),
     NULLIF(btrim(group_description), ''),
     NULLIF(btrim(group_avatar_url), ''),
-    current_user_id
+    current_user_id,
+    'group'
   );
 
-  INSERT INTO group_memberships (group_id, user_id, role, status)
-  VALUES (new_group_id, current_user_id, 'owner', 'active');
+  INSERT INTO group_memberships (group_id, user_id, role, status, last_read_at)
+  VALUES (new_group_id, current_user_id, 'owner', 'active', now());
 
   RETURN QUERY
   SELECT g.*
@@ -491,6 +700,74 @@ END;
 $$;
 
 GRANT EXECUTE ON FUNCTION create_group_with_owner(text, text, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION create_or_get_direct_group(other_user_id uuid)
+RETURNS SETOF groups
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+  pair_key text;
+  existing_group_id uuid;
+  new_group_id uuid := gen_random_uuid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  IF other_user_id IS NULL OR other_user_id = current_user_id THEN
+    RAISE EXCEPTION 'Choose another user to start a chat.';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM profiles WHERE id = other_user_id) THEN
+    RAISE EXCEPTION 'No app user exists for that profile.';
+  END IF;
+
+  INSERT INTO profiles (id)
+  VALUES (current_user_id)
+  ON CONFLICT (id) DO NOTHING;
+
+  pair_key := direct_pair_key_for(current_user_id, other_user_id);
+
+  SELECT id INTO existing_group_id
+  FROM groups
+  WHERE kind = 'direct'
+    AND direct_pair_key = pair_key
+  LIMIT 1;
+
+  IF existing_group_id IS NOT NULL THEN
+    INSERT INTO group_memberships (group_id, user_id, role, status, last_read_at)
+    VALUES
+      (existing_group_id, current_user_id, 'member', 'active', now()),
+      (existing_group_id, other_user_id, 'member', 'active', NULL)
+    ON CONFLICT (group_id, user_id)
+    DO UPDATE SET status = 'active';
+
+    RETURN QUERY
+    SELECT g.*
+    FROM groups AS g
+    WHERE g.id = existing_group_id;
+    RETURN;
+  END IF;
+
+  INSERT INTO groups (id, name, created_by, kind, direct_pair_key)
+  VALUES (new_group_id, 'Direct chat', current_user_id, 'direct', pair_key);
+
+  INSERT INTO group_memberships (group_id, user_id, role, status, last_read_at)
+  VALUES
+    (new_group_id, current_user_id, 'member', 'active', now()),
+    (new_group_id, other_user_id, 'member', 'active', NULL);
+
+  RETURN QUERY
+  SELECT g.*
+  FROM groups AS g
+  WHERE g.id = new_group_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_or_get_direct_group(uuid) TO authenticated;
 
 CREATE OR REPLACE FUNCTION prevent_genre_cycles()
 RETURNS trigger
@@ -701,7 +978,15 @@ CREATE POLICY "group_memberships: member select" ON group_memberships
 CREATE POLICY "group_memberships: manager insert" ON group_memberships
   FOR INSERT
   WITH CHECK (
-    can_manage_group(group_id, auth.uid())
+    (
+      can_manage_group(group_id, auth.uid())
+      AND EXISTS (
+        SELECT 1
+        FROM groups
+        WHERE groups.id = group_memberships.group_id
+          AND kind = 'group'
+      )
+    )
     OR (
       auth.uid() = user_id
       AND role = 'owner'
@@ -712,8 +997,24 @@ CREATE POLICY "group_memberships: manager insert" ON group_memberships
 
 CREATE POLICY "group_memberships: manager update" ON group_memberships
   FOR UPDATE
-  USING (can_manage_group(group_id, auth.uid()))
-  WITH CHECK (can_manage_group(group_id, auth.uid()));
+  USING (
+    can_manage_group(group_id, auth.uid())
+    AND EXISTS (
+      SELECT 1
+      FROM groups
+      WHERE groups.id = group_memberships.group_id
+        AND kind = 'group'
+    )
+  )
+  WITH CHECK (
+    can_manage_group(group_id, auth.uid())
+    AND EXISTS (
+      SELECT 1
+      FROM groups
+      WHERE groups.id = group_memberships.group_id
+        AND kind = 'group'
+    )
+  );
 
 CREATE POLICY "group_memberships: self delete" ON group_memberships
   FOR DELETE
@@ -722,3 +1023,97 @@ CREATE POLICY "group_memberships: self delete" ON group_memberships
 CREATE POLICY "group_memberships: owner delete" ON group_memberships
   FOR DELETE
   USING (is_group_owner(group_id, auth.uid()));
+
+CREATE OR REPLACE FUNCTION mark_group_read(group_uuid uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  IF NOT is_active_group_member(group_uuid, current_user_id) THEN
+    RAISE EXCEPTION 'You must be an active group member.';
+  END IF;
+
+  UPDATE group_memberships
+  SET last_read_at = now()
+  WHERE group_id = group_uuid
+    AND user_id = current_user_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION mark_group_read(uuid) TO authenticated;
+
+-- group_messages
+CREATE POLICY "group_messages: member select"
+  ON group_messages FOR SELECT
+  USING (is_active_group_member(group_id, auth.uid()));
+
+CREATE POLICY "group_messages: member insert"
+  ON group_messages FOR INSERT
+  WITH CHECK (
+    auth.uid() = sender_id
+    AND deleted_at IS NULL
+    AND edited_at IS NULL
+    AND is_active_group_member(group_id, auth.uid())
+  );
+
+CREATE POLICY "group_messages: sender update"
+  ON group_messages FOR UPDATE
+  USING (
+    auth.uid() = sender_id
+    AND is_active_group_member(group_id, auth.uid())
+  )
+  WITH CHECK (
+    auth.uid() = sender_id
+    AND is_active_group_member(group_id, auth.uid())
+  );
+
+CREATE POLICY "group_messages: sender delete"
+  ON group_messages FOR DELETE
+  USING (
+    auth.uid() = sender_id
+    AND is_active_group_member(group_id, auth.uid())
+  );
+
+CREATE POLICY "group_message_reactions: member select"
+  ON group_message_reactions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM group_messages
+      WHERE group_messages.id = group_message_reactions.message_id
+        AND is_active_group_member(group_messages.group_id, auth.uid())
+    )
+  );
+
+CREATE POLICY "group_message_reactions: member insert own"
+  ON group_message_reactions FOR INSERT
+  WITH CHECK (
+    auth.uid() = user_id
+    AND EXISTS (
+      SELECT 1
+      FROM group_messages
+      WHERE group_messages.id = group_message_reactions.message_id
+        AND group_messages.deleted_at IS NULL
+        AND is_active_group_member(group_messages.group_id, auth.uid())
+    )
+  );
+
+CREATE POLICY "group_message_reactions: member delete own"
+  ON group_message_reactions FOR DELETE
+  USING (
+    auth.uid() = user_id
+    AND EXISTS (
+      SELECT 1
+      FROM group_messages
+      WHERE group_messages.id = group_message_reactions.message_id
+        AND is_active_group_member(group_messages.group_id, auth.uid())
+    )
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -347,7 +347,7 @@ CREATE TABLE IF NOT EXISTS group_messages (
   group_id uuid NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
   sender_id uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
   content text NOT NULL DEFAULT '',
-  attachment_type text CHECK (attachment_type IN ('book', 'note', 'author')),
+  attachment_type text CHECK (attachment_type IN ('book', 'note', 'author', 'series')),
   attachment_payload jsonb,
   reply_to_message_id uuid REFERENCES group_messages(id) ON DELETE SET NULL,
   reply_snapshot jsonb,

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildReplySnapshot,
+  countUnreadMessages,
+  getMessagePreview,
+  normalizeChatMessageContent,
+  normalizeMessageContent,
+  summarizeHeartReactions,
+  sortChatThreads,
+} from "../src/lib/chatLogic";
+import {
+  bookSnapshotToAddBookPayload,
+  buildBookAttachment,
+  noteSnapshotToCreateInput,
+} from "../src/lib/chatAttachments";
+import type { Book, BookNote, Group, GroupMembership, GroupMessage } from "../src/types";
+
+type TestChatThread = {
+  group: Group;
+  currentMembership: GroupMembership;
+  members: GroupMembership[];
+  title: string;
+  description?: string;
+  latestMessage?: GroupMessage;
+  unreadCount: number;
+};
+
+test("normalizes message content before sending", () => {
+  assert.equal(normalizeMessageContent("  Hello there  "), "Hello there");
+});
+
+test("rejects blank messages", () => {
+  assert.throws(() => normalizeMessageContent("   "), /Message cannot be blank/);
+});
+
+test("allows attachment-only messages", () => {
+  const attachment = buildBookAttachment(makeBook({ title: "Shared Book" }));
+  assert.equal(normalizeChatMessageContent({ content: "   ", attachment }), "");
+});
+
+test("rejects empty messages without attachments", () => {
+  assert.throws(() => normalizeChatMessageContent({ content: "   " }), /Message cannot be blank/);
+});
+
+test("uses a placeholder preview for deleted messages", () => {
+  assert.equal(getMessagePreview(makeMessage({ deleted_at: "2026-06-20T10:00:00Z" })), "Message deleted");
+});
+
+test("counts unread messages after the member last-read timestamp", () => {
+  const messages = [
+    makeMessage({
+      id: "old",
+      sender_id: "other-user",
+      created_at: "2026-06-20T09:00:00Z",
+    }),
+    makeMessage({
+      id: "new-own",
+      sender_id: "current-user",
+      created_at: "2026-06-20T11:00:00Z",
+    }),
+    makeMessage({
+      id: "new-other",
+      sender_id: "other-user",
+      created_at: "2026-06-20T11:30:00Z",
+    }),
+  ];
+
+  assert.equal(
+    countUnreadMessages({
+      messages,
+      membership: makeMembership({ last_read_at: "2026-06-20T10:00:00Z" }),
+      currentUserId: "current-user",
+    }),
+    1,
+  );
+});
+
+test("counts all other-user messages as unread when no last-read timestamp exists", () => {
+  assert.equal(
+    countUnreadMessages({
+      messages: [
+        makeMessage({ id: "own", sender_id: "current-user" }),
+        makeMessage({ id: "other", sender_id: "other-user" }),
+      ],
+      membership: makeMembership({ last_read_at: null }),
+      currentUserId: "current-user",
+    }),
+    1,
+  );
+});
+
+test("sorts chat threads by latest message before group creation date", () => {
+  const threads = [
+    makeThread({
+      group: makeGroup({ id: "older", created_at: "2026-06-20T08:00:00Z" }),
+      latestMessage: makeMessage({ id: "older-message", created_at: "2026-06-20T12:00:00Z" }),
+    }),
+    makeThread({
+      group: makeGroup({ id: "newer-created", created_at: "2026-06-20T10:00:00Z" }),
+    }),
+  ];
+
+  assert.deepEqual(
+    sortChatThreads(threads).map((thread) => thread.group.id),
+    ["older", "newer-created"],
+  );
+});
+
+test("builds clean book import payloads without personal reading state", () => {
+  const attachment = buildBookAttachment(
+    makeBook({
+      title: "Private Progress Book",
+      status: "Finished",
+      rating: 5,
+      is_favorite: true,
+      current_page: 120,
+      date_started: "2026-01-01",
+      date_finished: "2026-01-20",
+    }),
+  );
+
+  const payload = bookSnapshotToAddBookPayload(attachment.book);
+
+  assert.equal(payload.title, "Private Progress Book");
+  assert.equal(payload.status, "Wishlist");
+  assert.equal(payload.is_favorite, false);
+  assert.equal("rating" in payload, false);
+  assert.equal("current_page" in payload, false);
+  assert.equal("date_started" in payload, false);
+  assert.equal("date_finished" in payload, false);
+});
+
+test("maps note snapshots to a selected target book", () => {
+  const note = makeNote({ label: "quote", content: "A quote", quote_speaker: "Author" });
+  const attachment = buildBookAttachment(makeBook(), [note]);
+  const input = noteSnapshotToCreateInput({
+    note: attachment.book.included_notes?.[0] as NonNullable<typeof attachment.book.included_notes>[number],
+    bookId: "target-book",
+    userId: "current-user",
+  });
+
+  assert.deepEqual(input, {
+    bookId: "target-book",
+    userId: "current-user",
+    label: "quote",
+    title: undefined,
+    quoteSpeaker: "Author",
+    content: "A quote",
+    pageStart: undefined,
+    noteDate: "2026-06-20",
+    isFavorite: false,
+  });
+});
+
+test("builds reply snapshots from text messages", () => {
+  const snapshot = buildReplySnapshot({
+    message: makeMessage({ id: "reply-source", content: "Original message" }),
+    senderName: "Sabine",
+  });
+
+  assert.deepEqual(snapshot, {
+    message_id: "reply-source",
+    sender_id: "current-user",
+    sender_name: "Sabine",
+    text: "Original message",
+    attachment_type: null,
+    attachment_title: null,
+    created_at: "2026-06-20T09:00:00Z",
+  });
+});
+
+test("builds reply snapshots from attachment-only messages", () => {
+  const attachment = buildBookAttachment(makeBook({ title: "Shared Book" }));
+  const snapshot = buildReplySnapshot({
+    message: makeMessage({ content: "", attachment_type: "book", attachment_payload: attachment }),
+    senderName: "Sabine",
+  });
+
+  assert.equal(snapshot.text, "Shared Book");
+  assert.equal(snapshot.attachment_type, "book");
+  assert.equal(snapshot.attachment_title, "Shared Book");
+});
+
+test("summarizes heart reactions with participant names", () => {
+  const summary = summarizeHeartReactions({
+    currentUserId: "current-user",
+    profiles: new Map([
+      ["current-user", { display_name: "Martina" }],
+      ["other-user", { username: "sabine" }],
+    ]),
+    reactions: [
+      {
+        message_id: "message-1",
+        user_id: "current-user",
+        reaction: "heart",
+        created_at: "2026-06-20T10:00:00Z",
+      },
+      {
+        message_id: "message-1",
+        user_id: "other-user",
+        reaction: "heart",
+        created_at: "2026-06-20T10:01:00Z",
+      },
+    ],
+  });
+
+  assert.deepEqual(summary, [
+    {
+      reaction: "heart",
+      count: 2,
+      reacted_by_current_user: true,
+      participants: [
+        { user_id: "current-user", display_name: "Martina" },
+        { user_id: "other-user", display_name: "sabine" },
+      ],
+    },
+  ]);
+});
+
+function makeGroup(overrides: Partial<Group> = {}): Group {
+  return {
+    id: "group-1",
+    name: "Book Club",
+    description: undefined,
+    avatar_url: undefined,
+    created_by: "current-user",
+    kind: "group",
+    direct_pair_key: null,
+    created_at: "2026-06-20T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeMembership(overrides: Partial<GroupMembership> = {}): GroupMembership {
+  return {
+    group_id: "group-1",
+    user_id: "current-user",
+    role: "member",
+    status: "active",
+    last_read_at: "2026-06-20T08:00:00Z",
+    joined_at: "2026-06-20T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<GroupMessage> = {}): GroupMessage {
+  return {
+    id: "message-1",
+    group_id: "group-1",
+    sender_id: "current-user",
+    content: "Hello",
+    created_at: "2026-06-20T09:00:00Z",
+    updated_at: "2026-06-20T09:00:00Z",
+    edited_at: null,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+function makeBook(overrides: Partial<Book> = {}): Book {
+  return {
+    id: "book-1",
+    title: "Book One",
+    authors: ["Author One"],
+    genres: ["Fantasy"],
+    status: "Wishlist",
+    cover_url: "https://example.com/cover.jpg",
+    rating: null,
+    is_favorite: false,
+    total_pages: 300,
+    language: "English",
+    format: "Hardcover",
+    isbn: "123",
+    publisher: "Publisher",
+    publication_date: "2026-01-01",
+    publication_date_precision: "day",
+    description: "Description",
+    metadata_source: "open_library",
+    metadata_source_url: "https://example.com",
+    user_id: "current-user",
+    created_at: "2026-06-20T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeNote(overrides: Partial<BookNote> = {}): BookNote {
+  return {
+    id: "note-1",
+    user_id: "current-user",
+    book_id: "book-1",
+    label: "note",
+    title: null,
+    quote_speaker: null,
+    content: "A note",
+    page_start: null,
+    is_favorite: false,
+    note_date: "2026-06-20",
+    created_at: "2026-06-20T08:00:00Z",
+    updated_at: "2026-06-20T08:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeThread(overrides: Partial<TestChatThread> = {}): TestChatThread {
+  const group = overrides.group ?? makeGroup();
+  return {
+    group,
+    currentMembership: makeMembership({ group_id: group.id }),
+    members: [],
+    title: group.name,
+    description: group.description,
+    latestMessage: undefined,
+    unreadCount: 0,
+    ...overrides,
+  };
+}

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   bookSnapshotToAddBookPayload,
   buildBookAttachment,
+  buildSeriesAttachment,
   noteSnapshotToCreateInput,
 } from "../src/lib/chatAttachments";
 import type { Book, BookNote, Group, GroupMembership, GroupMessage } from "../src/types";
@@ -216,6 +217,21 @@ test("summarizes heart reactions with participant names", () => {
       ],
     },
   ]);
+});
+
+test("builds series attachments with included quotes", () => {
+  const attachment = buildSeriesAttachment({
+    seriesName: "The Locked Tomb",
+    books: [makeBook({ id: "book-a", title: "Gideon the Ninth" }), makeBook({ id: "book-b", title: "Harrow the Ninth" })],
+    includedQuotes: [
+      makeNote({ id: "quote-1", label: "quote", content: "The quote", book_id: "book-a" }),
+    ],
+  });
+
+  assert.equal(attachment.type, "series");
+  assert.equal(attachment.series.name, "The Locked Tomb");
+  assert.equal(attachment.series.books.length, 2);
+  assert.equal(attachment.series.included_quotes?.[0]?.content, "The quote");
 });
 
 function makeGroup(overrides: Partial<Group> = {}): Group {


### PR DESCRIPTION
## Summary
Add a full chat experience under `/groups`, including direct chats, group chats, attachment messages, reply snapshots, and heart reactions.

## What changed
- Built the chat UI for the existing group feature, with message list, composer, settings panel, and attachment picker.
- Added message attachments for books, notes, and authors, including save-to-library flows for received items.
- Added reply support and a single heart reaction toggle per user/message.
- Added confirmation dialogs for destructive actions and moved message metadata below each bubble.
- Added Supabase migrations, schema updates, and RPC fixes for profile lookup and chat data.

## Verification
- `npm test`
- `npm run build`