### PR TITLE
[codex] add chat attachments and detail actions

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -21,6 +21,7 @@ import { GenresProvider } from "@/context/GenresContext";
 import { ProfileProvider } from "@/context/ProfileContext";
 import { useAuth, useProfile } from "@/context";
 import { cn } from "@/lib/utils";
+import ReleaseNotesDialog from "./ReleaseNotesDialog";
 
 const AddBookDialog = lazy(() => import("./AddBookDialog"));
 
@@ -119,6 +120,8 @@ function AppLayoutContent() {
           <AddBookDialog open={addBookOpen} onOpenChange={setAddBookOpen} />
         )}
       </Suspense>
+
+      <ReleaseNotesDialog />
     </>
   );
 }

--- a/src/components/DetailActionsMenu.tsx
+++ b/src/components/DetailActionsMenu.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { MoreVertical, Pencil, Send, Share2, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+type DetailKind = "book" | "author" | "series";
+
+type MenuPosition = {
+  top: number;
+  left: number;
+};
+
+interface DetailActionsMenuProps {
+  kind: DetailKind;
+  label: string;
+  shareLinkLabel?: string;
+  shareAttachmentLabel: string;
+  onEdit?: () => void;
+  onDelete: () => void | Promise<void>;
+  onSendAttachment: () => void;
+  deleteTitle: string;
+  deleteDescription: string;
+  deleteConfirmLabel?: string;
+  className?: string;
+}
+
+function entityLabel(kind: DetailKind): string {
+  if (kind === "book") return "book";
+  if (kind === "author") return "author";
+  return "series";
+}
+
+export default function DetailActionsMenu({
+  kind,
+  label,
+  shareLinkLabel = "Copy link to this page",
+  shareAttachmentLabel,
+  onEdit,
+  onDelete,
+  onSendAttachment,
+  deleteTitle,
+  deleteDescription,
+  deleteConfirmLabel = "Delete",
+  className,
+}: DetailActionsMenuProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+
+  const currentUrl = useMemo(() => window.location.href, []);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+
+    function handlePointerDown(event: Event) {
+      const target = event.target as Node | null;
+      if (
+        target &&
+        (buttonRef.current?.contains(target) || menuRef.current?.contains(target))
+      ) {
+        return;
+      }
+      setMenuOpen(false);
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setMenuOpen(false);
+    }
+
+    window.addEventListener("mousedown", handlePointerDown);
+    window.addEventListener("scroll", handlePointerDown, true);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("mousedown", handlePointerDown);
+      window.removeEventListener("scroll", handlePointerDown, true);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [menuOpen]);
+
+  useEffect(() => {
+    if (!shareOpen) setCopyStatus(null);
+  }, [shareOpen]);
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(currentUrl);
+      setCopyStatus("Link copied.");
+    } catch {
+      setCopyStatus("Could not copy link.");
+    }
+  }
+
+  function openMenu() {
+    const rect = buttonRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const panelWidth = 200;
+    const panelHeight = onEdit ? 128 : 92;
+    const left = Math.max(8, Math.min(rect.right - panelWidth, window.innerWidth - panelWidth - 8));
+    const top = Math.min(rect.bottom + 8, window.innerHeight - panelHeight - 8);
+    setMenuPosition({ top, left });
+    setMenuOpen(true);
+  }
+
+  async function runDelete() {
+    setDeleteOpen(false);
+    await onDelete();
+  }
+
+  return (
+    <div className={cn("relative", className)}>
+      <Button
+        ref={buttonRef}
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label="More actions"
+        aria-expanded={menuOpen}
+        onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())}
+        className="h-8 w-8 rounded-full border-0 bg-transparent text-foreground/80 shadow-none hover:bg-transparent hover:text-foreground focus-visible:border-transparent focus-visible:ring-0"
+      >
+        <MoreVertical className="h-5 w-5" />
+      </Button>
+
+      {menuOpen && menuPosition && (
+        <div
+          ref={menuRef}
+          className="fixed z-50 w-52 rounded-md border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-popover)]"
+          style={{ top: menuPosition.top, left: menuPosition.left }}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+            onClick={() => {
+              setMenuOpen(false);
+              setShareOpen(true);
+            }}
+          >
+            <Share2 className="h-4 w-4" />
+            Share
+          </button>
+          {onEdit && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+              onClick={() => {
+                setMenuOpen(false);
+                onEdit();
+              }}
+            >
+              <Pencil className="h-4 w-4" />
+              Edit
+            </button>
+          )}
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm text-destructive hover:bg-muted"
+            onClick={() => {
+              setMenuOpen(false);
+              setDeleteOpen(true);
+            }}
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete
+          </button>
+        </div>
+      )}
+
+      <Dialog open={shareOpen} onOpenChange={setShareOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Share this {entityLabel(kind)}</DialogTitle>
+            <DialogDescription>{label}</DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <Button type="button" variant="outline" className="w-full justify-start" onClick={copyLink}>
+              <Share2 className="mr-2 h-4 w-4" />
+              {shareLinkLabel}
+            </Button>
+            <Button type="button" className="w-full justify-start" onClick={onSendAttachment}>
+              <Send className="mr-2 h-4 w-4" />
+              {shareAttachmentLabel}
+            </Button>
+            {copyStatus && <p className="text-xs text-muted-foreground">{copyStatus}</p>}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{deleteTitle}</DialogTitle>
+            <DialogDescription>{deleteDescription}</DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button type="button" variant="outline" onClick={() => setDeleteOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="button" variant="destructive" onClick={() => void runDelete()}>
+              {deleteConfirmLabel}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/ReleaseNotesDialog.tsx
+++ b/src/components/ReleaseNotesDialog.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { CheckCircle2, Sparkles } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useUserSettings } from "@/context";
+import {
+  formatReleaseNoteDate,
+  getLatestReleaseNote,
+  hasUnreadReleaseNote,
+} from "@/lib/releaseNotes";
+import { cn } from "@/lib/utils";
+
+export const RELEASE_NOTES_EVENT = "reading-journal:release-notes";
+
+export default function ReleaseNotesDialog() {
+  const { settings, loading, markReleaseNoteSeen } = useUserSettings();
+  const releaseNote = getLatestReleaseNote();
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!settings) return;
+    setOpen(hasUnreadReleaseNote(settings.last_seen_release_note_version));
+  }, [loading, settings]);
+
+  useEffect(() => {
+    function handleOpenReleaseNotes() {
+      if (!loading && settings && hasUnreadReleaseNote(settings.last_seen_release_note_version)) {
+        setOpen(true);
+      }
+    }
+
+    window.addEventListener(RELEASE_NOTES_EVENT, handleOpenReleaseNotes);
+    return () => {
+      window.removeEventListener(RELEASE_NOTES_EVENT, handleOpenReleaseNotes);
+    };
+  }, [loading, settings]);
+
+  async function handleAcknowledge() {
+    setSaving(true);
+
+    try {
+      await markReleaseNoteSeen(releaseNote.version);
+      setOpen(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <div className="inline-flex w-fit items-center gap-2 rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+            <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+            New release note
+          </div>
+
+          <DialogTitle className="text-2xl">{releaseNote.title}</DialogTitle>
+          <DialogDescription className="max-w-lg text-base">
+            {releaseNote.summary}
+          </DialogDescription>
+          <p className="text-xs text-muted-foreground">
+            Published {formatReleaseNoteDate(releaseNote.published_at)} · {releaseNote.version}
+          </p>
+        </DialogHeader>
+
+        <div className="grid gap-3">
+          {releaseNote.highlights.map((highlight) => (
+            <div
+              key={highlight.title}
+              className={cn(
+                "rounded-lg border border-border bg-muted/30 p-4",
+                "shadow-[var(--shadow-card)]",
+              )}
+            >
+              <div className="flex items-start gap-3">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+                <div className="space-y-1">
+                  <p className="font-medium leading-tight">{highlight.title}</p>
+                  <p className="text-sm text-muted-foreground">{highlight.description}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={saving}
+          >
+            Not now
+          </Button>
+          <Button type="button" onClick={() => void handleAcknowledge()} disabled={saving}>
+            Got it
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/SendAttachmentDialog.tsx
+++ b/src/components/SendAttachmentDialog.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useMemo, useState } from "react";
+import { MessageSquare, Send, Users } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { useAuth } from "@/context";
+import { attachmentTitle } from "@/lib/chatAttachments";
+import { getChatThreads, getMessagePreview, sendChatMessage, type ChatThread } from "@/lib/chat";
+import { cn } from "@/lib/utils";
+import type { ChatAttachmentPayload } from "@/types";
+
+interface SendAttachmentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  attachment: ChatAttachmentPayload;
+  title: string;
+  description?: string;
+  onSent?: () => void;
+}
+
+function threadTypeLabel(thread: ChatThread): string {
+  return thread.group.kind === "group" ? "Group chat" : "Direct chat";
+}
+
+function threadPreview(thread: ChatThread): string {
+  if (thread.latestMessage) return getMessagePreview(thread.latestMessage);
+  return "No messages yet";
+}
+
+export default function SendAttachmentDialog({
+  open,
+  onOpenChange,
+  attachment,
+  title,
+  description,
+  onSent,
+}: SendAttachmentDialogProps) {
+  const { user } = useAuth();
+  const [threads, setThreads] = useState<ChatThread[]>([]);
+  const [selectedThreadId, setSelectedThreadId] = useState<string>("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedThread = useMemo(
+    () => threads.find((thread) => thread.group.id === selectedThreadId) ?? null,
+    [selectedThreadId, threads],
+  );
+
+  useEffect(() => {
+    const currentUser = user;
+    if (!open || !currentUser) return;
+    const userId = currentUser.id;
+
+    let cancelled = false;
+
+    async function loadThreads() {
+      try {
+        setLoading(true);
+        setError(null);
+        const nextThreads = await getChatThreads(userId);
+        if (cancelled) return;
+        setThreads(nextThreads);
+        setSelectedThreadId((current) => current && nextThreads.some((thread) => thread.group.id === current)
+          ? current
+          : nextThreads[0]?.group.id ?? "");
+      } catch (loadError) {
+        if (!cancelled) {
+          setThreads([]);
+          setSelectedThreadId("");
+          setError(loadError instanceof Error ? loadError.message : "Could not load chats.");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    setMessage("");
+    void loadThreads();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, user]);
+
+  async function handleSend() {
+    const currentUser = user;
+    if (!currentUser || !selectedThread) return;
+
+    try {
+      setSending(true);
+      setError(null);
+      await sendChatMessage(selectedThread.group.id, currentUser.id, message, attachment, null);
+      onOpenChange(false);
+      onSent?.();
+    } catch (sendError) {
+      setError(sendError instanceof Error ? sendError.message : "Could not send attachment.");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description ?? attachmentTitle(attachment)}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Message</label>
+            <Textarea
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              placeholder="Add a note to go with this attachment..."
+              rows={4}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <label className="text-sm font-medium">Select chat</label>
+              <p className="text-xs text-muted-foreground">
+                {loading ? "Loading chats..." : `${threads.length} available`}
+              </p>
+            </div>
+
+            <div className="max-h-80 space-y-2 overflow-y-auto pr-1">
+              {!loading && threads.length === 0 ? (
+                <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+                  No chats yet. Start one in Groups first.
+                </div>
+              ) : (
+                threads.map((thread) => {
+                  const selected = thread.group.id === selectedThreadId;
+                  return (
+                    <button
+                      key={thread.group.id}
+                      type="button"
+                      onClick={() => setSelectedThreadId(thread.group.id)}
+                      className={cn(
+                        "flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-colors",
+                        selected ? "border-primary bg-primary/5" : "hover:bg-muted/45",
+                      )}
+                    >
+                      <div className={cn(
+                        "mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border",
+                        selected ? "border-primary text-primary" : "text-muted-foreground",
+                      )}>
+                        {thread.group.kind === "group" ? (
+                          <Users className="h-4 w-4" />
+                        ) : (
+                          <MessageSquare className="h-4 w-4" />
+                        )}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="truncate text-sm font-medium">{thread.title}</span>
+                          {thread.group.kind === "group" && (
+                            <span className="rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                              Group
+                            </span>
+                          )}
+                        </div>
+                        <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+                          {threadPreview(thread)}
+                        </p>
+                        <p className="mt-1 text-[11px] text-muted-foreground">{threadTypeLabel(thread)}</p>
+                      </div>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={() => void handleSend()} disabled={!selectedThread || sending || loading}>
+              <Send className="mr-2 h-4 w-4" />
+              {sending ? "Sending..." : "Send attachment"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/groups/GroupsManager.tsx
+++ b/src/components/groups/GroupsManager.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
   ArrowLeft,
   BookOpen,
@@ -93,6 +93,11 @@ import type {
 
 type ComposeMode = "direct" | "group";
 type AttachmentPickerMode = "book" | "note" | "author" | "series";
+
+type OpenAttachmentState =
+  | { type: "book"; bookId: string }
+  | { type: "author"; authorName: string }
+  | { type: "series"; seriesId: string };
 
 type ConfirmAction =
   | { type: "message"; messageId: string }
@@ -592,6 +597,8 @@ export function GroupsManager() {
   const { user } = useAuth();
   const { books, addBook } = useBooksContext();
   const { series: librarySeries, addSeries } = useSeries();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [threads, setThreads] = useState<ChatThread[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState<string>("");
   const [messages, setMessages] = useState<GroupMessage[]>([]);
@@ -746,6 +753,25 @@ export function GroupsManager() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    const state = location.state as { openAttachmentPicker?: OpenAttachmentState } | null;
+    const launch = state?.openAttachmentPicker;
+    if (!launch) return;
+
+    if (launch.type === "book") {
+      setAttachmentPicker("book");
+      setSelectedBookId(launch.bookId);
+    } else if (launch.type === "author") {
+      setAttachmentPicker("author");
+      setSelectedAuthorName(launch.authorName);
+    } else if (launch.type === "series") {
+      setAttachmentPicker("series");
+      setSelectedSeriesId(launch.seriesId);
+    }
+
+    navigate(location.pathname + location.search, { replace: true });
+  }, [location.key, location.pathname, location.search, location.state, navigate]);
 
   async function loadThreads(preferredGroupId?: string) {
     if (!user) return;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -41,16 +41,22 @@ const buttonVariants = cva(
   }
 )
 
-function Button({
-  className,
-  variant = "default",
-  size = "default",
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean
+    }
+>(function Button(
+  {
+    className,
+    variant = "default",
+    size = "default",
+    asChild = false,
+    ...props
+  },
+  ref,
+) {
   const Comp = asChild ? Slot.Root : "button"
 
   return (
@@ -59,9 +65,10 @@ function Button({
       data-variant={variant}
       data-size={size}
       className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
       {...props}
     />
   )
-}
+})
 
 export { Button, buttonVariants }

--- a/src/context/UserSettingsContext.tsx
+++ b/src/context/UserSettingsContext.tsx
@@ -12,6 +12,7 @@ import { useTheme } from "@/context/ThemeContext";
 import {
   buildSectionUpdate,
   getMySettings,
+  markReleaseNoteAsSeen,
   upsertMySettings,
 } from "@/lib/userSettings";
 import { getErrorMessage } from "@/lib/profiles";
@@ -32,6 +33,7 @@ interface UserSettingsContextValue {
     section: Key,
     values: Partial<UserSettingsSections[Key]>,
   ) => Promise<UserSettings>;
+  markReleaseNoteSeen: (version: string) => Promise<UserSettings>;
 }
 
 const UserSettingsContext = createContext<UserSettingsContextValue | null>(null);
@@ -104,6 +106,16 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
     [saveSettings],
   );
 
+  const markReleaseNoteSeen = useCallback(
+    async (version: string) => {
+      const savedSettings = await markReleaseNoteAsSeen(version);
+      setSettings(savedSettings);
+      setError(null);
+      return savedSettings;
+    },
+    [],
+  );
+
   const value = useMemo<UserSettingsContextValue>(
     () => ({
       settings,
@@ -113,6 +125,7 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
       refreshSettings,
       saveSettings,
       saveSettingsSection,
+      markReleaseNoteSeen,
     }),
     [
       settings,
@@ -122,6 +135,7 @@ export function UserSettingsProvider({ children }: { children: ReactNode }) {
       refreshSettings,
       saveSettings,
       saveSettingsSection,
+      markReleaseNoteSeen,
     ],
   );
 

--- a/src/hooks/useSeries.ts
+++ b/src/hooks/useSeries.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useAuth } from "@/context";
-import { fetchSeries, createSeries } from "@/lib/books";
+import { createSeries, deleteSeries, fetchSeries } from "@/lib/books";
 import type { Series } from "@/types";
 
 export function useSeries() {
@@ -27,5 +27,10 @@ export function useSeries() {
     return created;
   }, [user]);
 
-  return { series, loading, error, addSeries };
+  const removeSeries = useCallback(async (seriesId: string): Promise<void> => {
+    await deleteSeries(seriesId);
+    setSeries((prev) => prev.filter((item) => item.id !== seriesId));
+  }, []);
+
+  return { series, loading, error, addSeries, removeSeries };
 }

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -363,6 +363,17 @@ export async function createSeries(userId: string, name: string): Promise<Series
   return data as Series;
 }
 
+export async function deleteSeries(seriesId: string): Promise<void> {
+  const { error: detachError } = await supabase
+    .from("books")
+    .update({ series_id: null })
+    .eq("series_id", seriesId);
+  if (detachError) throw detachError;
+
+  const { error } = await supabase.from("series").delete().eq("id", seriesId);
+  if (error) throw error;
+}
+
 // ── Reading Logs ──────────────────────────────────────────────────────────
 
 export async function createReadingLog(

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -1,0 +1,48 @@
+export type ReleaseNoteHighlight = {
+  title: string;
+  description: string;
+};
+
+export type ReleaseNote = {
+  version: string;
+  published_at: string;
+  title: string;
+  summary: string;
+  highlights: ReleaseNoteHighlight[];
+};
+
+export const CURRENT_RELEASE_NOTE: ReleaseNote = {
+  version: "2026-06-21-chat-groups",
+  published_at: "2026-06-21",
+  title: "Chat and groups are here",
+  summary:
+    "You can now chat with other readers and organize conversations into groups.",
+  highlights: [
+    {
+      title: "Direct chats and groups",
+      description:
+        "Start one-to-one conversations or create group spaces for reading clubs and friends.",
+    },
+    {
+      title: "Attachments and library saves",
+      description:
+        "Share books, notes, authors, and series in chat, then save shared items to your own library.",
+    },
+  ],
+};
+
+export function getLatestReleaseNote(): ReleaseNote {
+  return CURRENT_RELEASE_NOTE;
+}
+
+export function hasUnreadReleaseNote(lastSeenVersion?: string | null): boolean {
+  return lastSeenVersion !== CURRENT_RELEASE_NOTE.version;
+}
+
+export function formatReleaseNoteDate(publishedAt: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(`${publishedAt}T00:00:00Z`));
+}

--- a/src/lib/userSettings.ts
+++ b/src/lib/userSettings.ts
@@ -23,6 +23,7 @@ type UserSettingsRow = {
   notifications: unknown;
   privacy: unknown;
   backup: unknown;
+  last_seen_release_note_version: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -150,6 +151,7 @@ function normalizeSettings(row: UserSettingsRow): UserSettings {
     notifications: mergeSection(DEFAULT_NOTIFICATION_SETTINGS, row.notifications),
     privacy: mergeSection(DEFAULT_PRIVACY_SETTINGS, row.privacy),
     backup: mergeSection(DEFAULT_BACKUP_SETTINGS, row.backup),
+    last_seen_release_note_version: row.last_seen_release_note_version ?? null,
     created_at: row.created_at,
     updated_at: row.updated_at,
   };
@@ -217,6 +219,21 @@ export async function upsertMySettings(update: UserSettingsUpdate): Promise<User
   const { data, error } = await supabase
     .from("user_settings")
     .upsert(toSettingsPayload(nextSettings), { onConflict: "user_id" })
+    .select("*")
+    .single();
+
+  if (error) throw error;
+  return normalizeSettings(data as UserSettingsRow);
+}
+
+export async function markReleaseNoteAsSeen(
+  version: string,
+): Promise<UserSettings> {
+  const userId = await getCurrentUserId();
+  const { data, error } = await supabase
+    .from("user_settings")
+    .update({ last_seen_release_note_version: version })
+    .eq("user_id", userId)
     .select("*")
     .single();
 

--- a/src/pages/AuthorDetails.tsx
+++ b/src/pages/AuthorDetails.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { ArrowLeft, BookOpen, ChevronRight, Heart, Star } from "lucide-react";
+import DetailActionsMenu from "@/components/DetailActionsMenu";
+import SendAttachmentDialog from "@/components/SendAttachmentDialog";
 import QuoteBlock from "@/components/QuoteBlock";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -14,6 +16,7 @@ import {
   getAuthorInitials,
 } from "@/lib/authorShelf";
 import { fetchAllBookNotes } from "@/lib/bookNotes";
+import { buildAuthorAttachment } from "@/lib/chatAttachments";
 import { cn } from "@/lib/utils";
 import type { Book, BookNote } from "@/types";
 
@@ -97,6 +100,8 @@ export default function AuthorDetails() {
   const { books, loading: booksLoading, error: booksError } = useBooksContext();
   const [notes, setNotes] = useState<BookNote[]>([]);
   const [notesError, setNotesError] = useState<string | null>(null);
+  const [sendAttachmentOpen, setSendAttachmentOpen] = useState(false);
+  const [shareStatus, setShareStatus] = useState<string | null>(null);
 
   useEffect(() => {
     let ignore = false;
@@ -122,6 +127,10 @@ export default function AuthorDetails() {
   const featuredQuoteBook = featuredQuote
     ? author?.books.find((book) => book.id === featuredQuote.book_id)
     : undefined;
+
+  function openAttachmentPicker() {
+    setSendAttachmentOpen(true);
+  }
 
   if (booksLoading) {
     return (
@@ -166,13 +175,30 @@ export default function AuthorDetails() {
             <ArrowLeft className="h-4 w-4" />
             Back to authors
           </Button>
-          {author.isFavorite && (
-            <div className="inline-flex items-center gap-2 rounded-lg border bg-card px-3 py-1.5 text-sm">
-              <Heart className="h-4 w-4 fill-favorite text-favorite" />
-              Favorite
-            </div>
-          )}
+          <div className="flex items-center gap-3">
+            {author.isFavorite && (
+              <div className="inline-flex items-center gap-2 rounded-lg border bg-card px-3 py-1.5 text-sm">
+                <Heart className="h-4 w-4 fill-favorite text-favorite" />
+                Favorite
+              </div>
+            )}
+            <DetailActionsMenu
+              kind="author"
+              label={author.name}
+              shareAttachmentLabel="Send the author as attachment in a chat"
+              onDelete={() => navigate("/authors", { replace: true })}
+              onSendAttachment={openAttachmentPicker}
+              deleteTitle="Delete this author view?"
+              deleteDescription="This only removes the author page from view. The books stay in your library."
+            />
+          </div>
         </div>
+
+        {shareStatus && (
+          <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-sm text-primary">
+            {shareStatus}
+          </div>
+        )}
 
         <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:gap-8">
           <AuthorPlaceholder name={author.name} />
@@ -363,6 +389,19 @@ export default function AuthorDetails() {
           )}
         </TabsContent>
       </Tabs>
+
+      <SendAttachmentDialog
+        open={sendAttachmentOpen}
+        onOpenChange={setSendAttachmentOpen}
+        attachment={buildAuthorAttachment({
+          authorName: author.name,
+          books: author.books,
+          includedQuotes: author.quotes.slice(0, 3),
+        })}
+        title={`Send "${author.name}" to chat`}
+        description="Add a message, then pick the chat you want to send this author to."
+        onSent={() => setShareStatus("Author sent to chat.")}
+      />
     </div>
   );
 }

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from "react";
+import { Fragment, useEffect, useMemo, useState, type ChangeEvent, type ReactNode } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
@@ -13,16 +13,16 @@ import {
   ImagePlus,
   Info,
   MessageSquarePlus,
-  MoreHorizontal,
-  Pencil,
   RefreshCw,
   Star,
   TrendingUp,
   type LucideIcon,
 } from "lucide-react";
 import AnnotationCard from "@/components/AnnotationCard";
+import DetailActionsMenu from "@/components/DetailActionsMenu";
 import GenreMultiSelect from "@/components/GenreMultiSelect";
 import ProgressOverTimeChart from "@/components/ProgressOverTimeChart";
+import SendAttachmentDialog from "@/components/SendAttachmentDialog";
 import ReadingProgressDialog from "@/components/ReadingProgressDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -52,6 +52,7 @@ import {
 } from "@/lib/bookAnalytics";
 import { fetchBookNotes, sortBookNotes } from "@/lib/bookNotes";
 import { fetchReadingLogsForBook } from "@/lib/books";
+import { buildBookAttachment } from "@/lib/chatAttachments";
 import { buildGenreSlugLookup, formatGenrePathForDisplay, getSelectedGenreTags } from "@/lib/genreTree";
 import {
   formatPublicationDateForDisplay,
@@ -210,9 +211,7 @@ export default function BookDetails() {
   const [showRatingGuide, setShowRatingGuide] = useState(false);
   const [isEditMode, setIsEditMode] = useState(false);
   const [isProgressDialogOpen, setIsProgressDialogOpen] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [deleting, setDeleting] = useState(false);
   const [uploadingCover, setUploadingCover] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
@@ -222,8 +221,8 @@ export default function BookDetails() {
   const [notes, setNotes] = useState<BookNote[]>([]);
   const [notesLoading, setNotesLoading] = useState(false);
   const [notesError, setNotesError] = useState<string | null>(null);
-  const coverInputRef = useRef<HTMLInputElement>(null);
-
+  const [sendAttachmentOpen, setSendAttachmentOpen] = useState(false);
+  const [shareStatus, setShareStatus] = useState<string | null>(null);
   const {
     register,
     control,
@@ -246,7 +245,6 @@ export default function BookDetails() {
     setIsFavorite(book.is_favorite);
     setLocalRating(book.rating ?? null);
     setIsEditMode(false);
-    setConfirmDelete(false);
     setErrorMsg(null);
     setDescriptionExpanded(false);
     reset(bookToFormValues(book));
@@ -356,7 +354,6 @@ export default function BookDetails() {
   function exitEditMode() {
     if (!book) return;
     reset(bookToFormValues(book));
-    setConfirmDelete(false);
     setErrorMsg(null);
     setIsEditMode(false);
   }
@@ -411,7 +408,7 @@ export default function BookDetails() {
       setErrorMsg(err instanceof Error ? err.message : "Failed to update cover");
     } finally {
       setUploadingCover(false);
-      if (coverInputRef.current) coverInputRef.current.value = "";
+      event.currentTarget.value = "";
     }
   }
 
@@ -477,7 +474,6 @@ export default function BookDetails() {
       await updateBook(book.id, payload);
       reset(values);
       setIsEditMode(false);
-      setConfirmDelete(false);
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : "Failed to save changes");
     } finally {
@@ -487,20 +483,17 @@ export default function BookDetails() {
 
   async function handleDelete() {
     if (!book) return;
-    if (!confirmDelete) {
-      setConfirmDelete(true);
-      return;
-    }
     try {
-      setDeleting(true);
       setErrorMsg(null);
       await deleteBook(book.id);
       navigate("/library", { replace: true });
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : "Failed to delete book");
-    } finally {
-      setDeleting(false);
     }
+  }
+
+  function openAttachmentPicker() {
+    setSendAttachmentOpen(true);
   }
 
   function updatePublicationDatePrecision(nextPrecision: PublicationDatePrecision | "") {
@@ -555,6 +548,43 @@ export default function BookDetails() {
         <Button asChild size="sm" variant="outline">
           <Link to="/library">Back to Library</Link>
         </Button>
+      </div>
+    );
+  }
+
+  if (isEditMode) {
+    return (
+      <div className="space-y-6">
+        <Button variant="ghost" size="sm" className="px-2" onClick={() => navigate(-1)}>
+          <ArrowLeft className="mr-1.5 h-4 w-4" />
+          Back
+        </Button>
+
+        {errorMsg && (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">
+            {errorMsg}
+          </div>
+        )}
+
+        <EditDetailsForm
+          bookTitle={book.title}
+          coverUrl={book.cover_url}
+          control={control}
+          register={register}
+          handleSubmit={handleSubmit}
+          onSubmit={onSubmit}
+          onCancel={exitEditMode}
+          saving={saving}
+          isDirty={isDirty}
+          errors={errors}
+          series={series}
+          watchedSeriesId={watchedSeriesId}
+          publicationDatePrecision={publicationDatePrecision}
+          updatePublicationDatePrecision={updatePublicationDatePrecision}
+          clearPublicationDateError={() => clearErrors("publication_date")}
+          uploadingCover={uploadingCover}
+          handleCoverChange={handleCoverChange}
+        />
       </div>
     );
   }
@@ -659,19 +689,30 @@ export default function BookDetails() {
 
   return (
     <div className="space-y-8">
-      <Button variant="ghost" size="sm" className="px-2" onClick={() => navigate(-1)}>
-        <ArrowLeft className="mr-1.5 h-4 w-4" />
-        Back
-      </Button>
+      <div className="flex items-start justify-between gap-3">
+        <Button variant="ghost" size="sm" className="px-2" onClick={() => navigate(-1)}>
+          <ArrowLeft className="mr-1.5 h-4 w-4" />
+          Back
+        </Button>
+
+        <DetailActionsMenu
+          kind="book"
+          label={book.title}
+          shareAttachmentLabel="Send the book as attachment in a chat"
+          onEdit={() => {
+            setErrorMsg(null);
+            setIsEditMode(true);
+          }}
+          onDelete={handleDelete}
+          onSendAttachment={openAttachmentPicker}
+          deleteTitle="Delete this book?"
+          deleteDescription="Are you sure you want to delete this book? This cannot be undone."
+        />
+      </div>
 
       <section className="grid gap-6 md:grid-cols-[240px_1fr] md:items-start">
         <div className="mx-auto w-full max-w-[240px]">
-          <label
-            htmlFor="cover-change"
-            className={`relative block aspect-[2/3] overflow-hidden rounded-xl border bg-muted shadow-sm group ${
-              isEditMode ? "cursor-pointer" : "cursor-default"
-            }`}
-          >
+          <div className="relative block aspect-[2/3] overflow-hidden rounded-xl border bg-muted shadow-sm">
             {book.cover_url ? (
               <img src={book.cover_url} alt={book.title} className="h-full w-full object-cover" />
             ) : (
@@ -679,27 +720,7 @@ export default function BookDetails() {
                 <BookOpen className="h-10 w-10 text-muted-foreground/40" />
               </div>
             )}
-            <div
-              className={`absolute inset-0 flex items-center justify-center bg-black/50 transition-opacity ${
-                isEditMode ? "opacity-0 group-hover:opacity-100" : "opacity-0"
-              }`}
-            >
-              {uploadingCover ? (
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
-              ) : (
-                <ImagePlus className="h-5 w-5 text-white" />
-              )}
-            </div>
-            <input
-              id="cover-change"
-              type="file"
-              accept="image/*"
-              className="sr-only"
-              ref={coverInputRef}
-              onChange={handleCoverChange}
-              disabled={uploadingCover || !isEditMode}
-            />
-          </label>
+          </div>
         </div>
 
         <div className="space-y-5">
@@ -883,21 +904,6 @@ export default function BookDetails() {
                 Add Note
               </Link>
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => {
-                setConfirmDelete(false);
-                setErrorMsg(null);
-                setIsEditMode((current) => !current);
-              }}
-            >
-              <Pencil className="mr-1.5 h-4 w-4" />
-              Edit
-            </Button>
-            <Button type="button" variant="outline" size="icon" aria-label="More options">
-              <MoreHorizontal className="h-4 w-4" />
-            </Button>
           </div>
         </div>
       </section>
@@ -908,26 +914,20 @@ export default function BookDetails() {
         </div>
       )}
 
-      {isEditMode && (
-        <EditDetailsForm
-          control={control}
-          register={register}
-          handleSubmit={handleSubmit}
-          onSubmit={onSubmit}
-          onCancel={exitEditMode}
-          onDelete={handleDelete}
-          deleting={deleting}
-          confirmDelete={confirmDelete}
-          saving={saving}
-          isDirty={isDirty}
-          errors={errors}
-          series={series}
-          watchedSeriesId={watchedSeriesId}
-          publicationDatePrecision={publicationDatePrecision}
-          updatePublicationDatePrecision={updatePublicationDatePrecision}
-          clearPublicationDateError={() => clearErrors("publication_date")}
-        />
+      {shareStatus && (
+        <div className="rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm text-primary">
+          {shareStatus}
+        </div>
       )}
+
+      <SendAttachmentDialog
+        open={sendAttachmentOpen}
+        onOpenChange={setSendAttachmentOpen}
+        attachment={buildBookAttachment(book)}
+        title={`Send "${book.title}" to chat`}
+        description="Add a message, then pick the chat you want to send this book to."
+        onSent={() => setShareStatus("Book sent to chat.")}
+      />
 
       {!isEditMode && (
         <>
@@ -1292,14 +1292,13 @@ function RelatedBooksGroup({ title, books }: { title: React.ReactNode; books: Bo
 }
 
 function EditDetailsForm({
+  bookTitle,
+  coverUrl,
   control,
   register,
   handleSubmit,
   onSubmit,
   onCancel,
-  onDelete,
-  deleting,
-  confirmDelete,
   saving,
   isDirty,
   errors,
@@ -1308,15 +1307,16 @@ function EditDetailsForm({
   publicationDatePrecision,
   updatePublicationDatePrecision,
   clearPublicationDateError,
+  uploadingCover,
+  handleCoverChange,
 }: {
+  bookTitle: string;
+  coverUrl?: string | null;
   control: ReturnType<typeof useForm<FormValues>>["control"];
   register: ReturnType<typeof useForm<FormValues>>["register"];
   handleSubmit: ReturnType<typeof useForm<FormValues>>["handleSubmit"];
   onSubmit: (values: FormValues) => Promise<void>;
   onCancel: () => void;
-  onDelete: () => void;
-  deleting: boolean;
-  confirmDelete: boolean;
   saving: boolean;
   isDirty: boolean;
   errors: ReturnType<typeof useForm<FormValues>>["formState"]["errors"];
@@ -1325,168 +1325,199 @@ function EditDetailsForm({
   publicationDatePrecision: PublicationDatePrecision | "";
   updatePublicationDatePrecision: (precision: PublicationDatePrecision | "") => void;
   clearPublicationDateError: () => void;
+  uploadingCover: boolean;
+  handleCoverChange: (event: ChangeEvent<HTMLInputElement>) => Promise<void>;
 }) {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="rounded-xl border bg-card p-5">
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="space-y-1.5 md:col-span-2">
-          <Label htmlFor="detail-title">Title</Label>
-          <Input id="detail-title" {...register("title", { required: true })} />
-        </div>
-
-        <div className="space-y-1.5 md:col-span-2">
-          <Label htmlFor="detail-authors">Authors</Label>
-          <Input
-            id="detail-authors"
-            {...register("authorsInput", {
-              validate: (value) =>
-                parseAuthorsInput(value).length > 0 || "At least one author is required",
-            })}
-          />
-          {errors.authorsInput && (
-            <p className="text-xs text-destructive">{errors.authorsInput.message}</p>
-          )}
-        </div>
-
-        <div className="space-y-1.5 md:col-span-2">
-          <Label>Genres</Label>
-          <Controller
-            name="genres"
-            control={control}
-            render={({ field }) => (
-              <GenreMultiSelect value={field.value ?? []} onChange={field.onChange} />
+      <div className="grid gap-6 md:grid-cols-[240px_1fr] md:items-start">
+        <div className="mx-auto w-full max-w-[240px]">
+          <label
+            htmlFor="cover-change"
+            className="relative block aspect-[2/3] overflow-hidden rounded-xl border bg-muted shadow-sm group cursor-pointer"
+          >
+            {coverUrl ? (
+              <img src={coverUrl} alt={bookTitle} className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center">
+                <ImagePlus className="h-10 w-10 text-muted-foreground/40" />
+              </div>
             )}
-          />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
+              {uploadingCover ? (
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+              ) : (
+                <ImagePlus className="h-5 w-5 text-white" />
+              )}
+            </div>
+            <input
+              id="cover-change"
+              type="file"
+              accept="image/*"
+              className="sr-only"
+              onChange={handleCoverChange}
+              disabled={uploadingCover}
+            />
+          </label>
         </div>
 
-        <SelectField control={control} name="language" label="Language" options={["German", "Spanish", "English"]} />
-        <SelectField control={control} name="format" label="Format" options={["eBook", "Audiobook", "Paperback", "Hardcover"]} />
-        <SelectField control={control} name="source" label="Source" options={SOURCE_OPTIONS} />
-
-        <div className="space-y-1.5">
-          <Label htmlFor="detail-total-pages">Total pages</Label>
-          <Input id="detail-total-pages" type="number" min={1} {...register("total_pages")} />
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="detail-publisher">Publisher</Label>
-          <Input id="detail-publisher" {...register("publisher")} />
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="detail-publication-date">Publication date</Label>
-          <Input
-            id="detail-publication-date"
-            placeholder="YYYY, YYYY-MM, or YYYY-MM-DD"
-            aria-invalid={!!errors.publication_date}
-            {...register("publication_date", {
-              onChange: clearPublicationDateError,
-            })}
-          />
-          <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
-            <label className="flex items-center gap-1.5">
-              <input
-                type="checkbox"
-                className="h-3.5 w-3.5 accent-primary"
-                checked={!!publicationDatePrecision}
-                onChange={(event) =>
-                  updatePublicationDatePrecision(event.target.checked ? "year" : "")
-                }
-              />
-              Year
-            </label>
-            <label className="flex items-center gap-1.5">
-              <input
-                type="checkbox"
-                className="h-3.5 w-3.5 accent-primary"
-                checked={publicationDatePrecision === "month" || publicationDatePrecision === "day"}
-                onChange={(event) =>
-                  updatePublicationDatePrecision(event.target.checked ? "month" : "year")
-                }
-              />
-              Month
-            </label>
-            <label className="flex items-center gap-1.5">
-              <input
-                type="checkbox"
-                className="h-3.5 w-3.5 accent-primary"
-                checked={publicationDatePrecision === "day"}
-                onChange={(event) =>
-                  updatePublicationDatePrecision(event.target.checked ? "day" : "month")
-                }
-              />
-              Day
-            </label>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor="detail-title">Title</Label>
+            <Input id="detail-title" {...register("title", { required: true })} />
           </div>
-          {errors.publication_date && (
-            <p className="text-xs text-destructive">{errors.publication_date.message}</p>
-          )}
-        </div>
 
-        <div className="space-y-1.5">
-          <Label htmlFor="detail-date-started">Date started</Label>
-          <Input id="detail-date-started" type="date" {...register("date_started")} />
-        </div>
-
-        <div className="space-y-1.5">
-          <Label htmlFor="detail-date-finished">Date finished</Label>
-          <Input id="detail-date-finished" type="date" {...register("date_finished")} />
-        </div>
-
-        <div className="space-y-1.5">
-          <Label>Series</Label>
-          <Controller
-            name="series_id"
-            control={control}
-            render={({ field }) => (
-              <Select
-                value={field.value || "__none__"}
-                onValueChange={(value) => field.onChange(value === "__none__" ? "" : value)}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="None" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">None</SelectItem>
-                  {series.map((item) => (
-                    <SelectItem key={item.id} value={item.id}>
-                      {item.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor="detail-authors">Authors</Label>
+            <Input
+              id="detail-authors"
+              {...register("authorsInput", {
+                validate: (value) =>
+                  parseAuthorsInput(value).length > 0 || "At least one author is required",
+              })}
+            />
+            {errors.authorsInput && (
+              <p className="text-xs text-destructive">{errors.authorsInput.message}</p>
             )}
-          />
-        </div>
+          </div>
 
-        {watchedSeriesId && (
+          <div className="space-y-1.5 md:col-span-2">
+            <Label>Genres</Label>
+            <Controller
+              name="genres"
+              control={control}
+              render={({ field }) => (
+                <GenreMultiSelect value={field.value ?? []} onChange={field.onChange} />
+              )}
+            />
+          </div>
+
+          <SelectField control={control} name="language" label="Language" options={["German", "Spanish", "English"]} />
+          <SelectField control={control} name="format" label="Format" options={["eBook", "Audiobook", "Paperback", "Hardcover"]} />
+          <SelectField control={control} name="source" label="Source" options={SOURCE_OPTIONS} />
+
           <div className="space-y-1.5">
-            <Label htmlFor="detail-volume-number">Volume number</Label>
-            <Input id="detail-volume-number" type="number" min={0.5} step="any" {...register("volume_number")} />
+            <Label htmlFor="detail-total-pages">Total pages</Label>
+            <Input id="detail-total-pages" type="number" min={1} {...register("total_pages")} />
           </div>
-        )}
 
-        <div className="space-y-1.5 md:col-span-2">
-          <Label htmlFor="detail-isbn">ISBN</Label>
-          <Input id="detail-isbn" inputMode="numeric" autoComplete="off" {...register("isbn")} />
-        </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="detail-publisher">Publisher</Label>
+            <Input id="detail-publisher" {...register("publisher")} />
+          </div>
 
-        <div className="space-y-1.5 md:col-span-2">
-          <Label htmlFor="detail-description">Description</Label>
-          <Textarea id="detail-description" rows={6} {...register("description")} />
+          <div className="space-y-1.5">
+            <Label htmlFor="detail-publication-date">Publication date</Label>
+            <Input
+              id="detail-publication-date"
+              placeholder="YYYY, YYYY-MM, or YYYY-MM-DD"
+              aria-invalid={!!errors.publication_date}
+              {...register("publication_date", {
+                onChange: clearPublicationDateError,
+              })}
+            />
+            <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+              <label className="flex items-center gap-1.5">
+                <input
+                  type="checkbox"
+                  className="h-3.5 w-3.5 accent-primary"
+                  checked={!!publicationDatePrecision}
+                  onChange={(event) =>
+                    updatePublicationDatePrecision(event.target.checked ? "year" : "")
+                  }
+                />
+                Year
+              </label>
+              <label className="flex items-center gap-1.5">
+                <input
+                  type="checkbox"
+                  className="h-3.5 w-3.5 accent-primary"
+                  checked={publicationDatePrecision === "month" || publicationDatePrecision === "day"}
+                  onChange={(event) =>
+                    updatePublicationDatePrecision(event.target.checked ? "month" : "year")
+                  }
+                />
+                Month
+              </label>
+              <label className="flex items-center gap-1.5">
+                <input
+                  type="checkbox"
+                  className="h-3.5 w-3.5 accent-primary"
+                  checked={publicationDatePrecision === "day"}
+                  onChange={(event) =>
+                    updatePublicationDatePrecision(event.target.checked ? "day" : "month")
+                  }
+                />
+                Day
+              </label>
+            </div>
+            {errors.publication_date && (
+              <p className="text-xs text-destructive">{errors.publication_date.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="detail-date-started">Date started</Label>
+            <Input id="detail-date-started" type="date" {...register("date_started")} />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="detail-date-finished">Date finished</Label>
+            <Input id="detail-date-finished" type="date" {...register("date_finished")} />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Series</Label>
+            <Controller
+              name="series_id"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  value={field.value || "__none__"}
+                  onValueChange={(value) => field.onChange(value === "__none__" ? "" : value)}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="None" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">None</SelectItem>
+                    {series.map((item) => (
+                      <SelectItem key={item.id} value={item.id}>
+                        {item.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          </div>
+
+          {watchedSeriesId && (
+            <div className="space-y-1.5">
+              <Label htmlFor="detail-volume-number">Volume number</Label>
+              <Input id="detail-volume-number" type="number" min={0.5} step="any" {...register("volume_number")} />
+            </div>
+          )}
+
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor="detail-isbn">ISBN</Label>
+            <Input id="detail-isbn" inputMode="numeric" autoComplete="off" {...register("isbn")} />
+          </div>
+
+          <div className="space-y-1.5 md:col-span-2">
+            <Label htmlFor="detail-description">Description</Label>
+            <Textarea id="detail-description" rows={6} {...register("description")} />
+          </div>
         </div>
       </div>
 
-      <div className="mt-5 flex flex-wrap items-center justify-between gap-2">
-        <Button type="button" variant="destructive" size="sm" disabled={deleting} onClick={onDelete}>
-          {deleting ? "Deleting..." : confirmDelete ? "Are you sure?" : "Delete"}
-        </Button>
-        <div className="ml-auto flex items-center gap-2">
+      <div className="sticky bottom-0 mt-5 border-t bg-card/95 px-0 py-4 backdrop-blur">
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <Button type="button" variant="outline" size="sm" disabled={saving} onClick={onCancel}>
+            Cancel
+          </Button>
           <Button type="submit" size="sm" disabled={saving || !isDirty}>
             {saving ? "Saving..." : "Save Changes"}
-          </Button>
-          <Button type="button" variant="outline" size="sm" disabled={saving || deleting} onClick={onCancel}>
-            Cancel
           </Button>
         </div>
       </div>

--- a/src/pages/SeriesDetails.tsx
+++ b/src/pages/SeriesDetails.tsx
@@ -7,8 +7,10 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { ArrowLeft, BookOpen, Check, Flag, Heart, Star } from "lucide-react";
+import DetailActionsMenu from "@/components/DetailActionsMenu";
+import SendAttachmentDialog from "@/components/SendAttachmentDialog";
 import QuoteBlock from "@/components/QuoteBlock";
 import ReadingProgressDialog from "@/components/ReadingProgressDialog";
 import { Button } from "@/components/ui/button";
@@ -19,6 +21,7 @@ import { useSeries } from "@/hooks/useSeries";
 import { parseLocalDateOnly, type CalendarSpan } from "@/lib/bookAnalytics";
 import { fetchAllBookNotes } from "@/lib/bookNotes";
 import { fetchReadingLogs } from "@/lib/books";
+import { buildSeriesAttachment } from "@/lib/chatAttachments";
 import {
   filterSeriesLogs,
   getAverageSeriesRating,
@@ -757,12 +760,16 @@ function PageLoading() {
 
 export default function SeriesDetails() {
   const { seriesId } = useParams<{ seriesId: string }>();
+  const navigate = useNavigate();
   const { books, loading: booksLoading, error: booksError, updateBook } = useBooksContext();
-  const { series, loading: seriesLoading, error: seriesError } = useSeries();
+  const { series, loading: seriesLoading, error: seriesError, removeSeries } = useSeries();
   const [logs, setLogs] = useState<ReadingLog[]>([]);
   const [logsLoading, setLogsLoading] = useState(true);
   const [logsError, setLogsError] = useState<string | null>(null);
   const [notes, setNotes] = useState<BookNote[]>([]);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [sendAttachmentOpen, setSendAttachmentOpen] = useState(false);
+  const [shareStatus, setShareStatus] = useState<string | null>(null);
 
   const seriesRecord = series.find((item) => item.id === seriesId) ?? null;
   const seriesBooks = useMemo(
@@ -839,6 +846,21 @@ export default function SeriesDetails() {
     [notes, seriesBooks, seriesLogs],
   );
 
+  function openAttachmentPicker() {
+    setSendAttachmentOpen(true);
+  }
+
+  async function handleDeleteSeries() {
+    if (!seriesRecord) return;
+    try {
+      setActionError(null);
+      await removeSeries(seriesRecord.id);
+      navigate("/series", { replace: true });
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Failed to delete series");
+    }
+  }
+
   async function saveProgress(book: Book, newPage: number) {
     const shouldFinish = Boolean(book.total_pages && newPage >= book.total_pages);
 
@@ -881,12 +903,29 @@ export default function SeriesDetails() {
 
   return (
     <div className="space-y-6">
-      <Button variant="ghost" size="sm" className="px-2" asChild>
-        <Link to="/series">
-          <ArrowLeft className="mr-1.5 h-4 w-4" />
-          Back to Series
-        </Link>
-      </Button>
+      {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+      {shareStatus && (
+        <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-sm text-primary">
+          {shareStatus}
+        </div>
+      )}
+      <div className="flex items-start justify-between gap-3">
+        <Button variant="ghost" size="sm" className="px-2" asChild>
+          <Link to="/series">
+            <ArrowLeft className="mr-1.5 h-4 w-4" />
+            Back to Series
+          </Link>
+        </Button>
+        <DetailActionsMenu
+          kind="series"
+          label={seriesRecord.name}
+          shareAttachmentLabel="Send the series as attachment in a chat"
+          onDelete={handleDeleteSeries}
+          onSendAttachment={openAttachmentPicker}
+          deleteTitle="Delete this series?"
+          deleteDescription="Are you sure you want to delete this series? The books will stay in your library and be detached from this series."
+        />
+      </div>
 
       <header className="relative flex min-h-64 items-end overflow-hidden rounded-2xl border bg-muted">
         <div
@@ -1264,6 +1303,21 @@ export default function SeriesDetails() {
           )}
         </TabsContent>
       </Tabs>
+      <SendAttachmentDialog
+        open={sendAttachmentOpen}
+        onOpenChange={setSendAttachmentOpen}
+        attachment={buildSeriesAttachment({
+          seriesId: seriesRecord.id,
+          seriesName: seriesRecord.name,
+          books: seriesBooks,
+          includedQuotes: notes
+            .filter((note) => note.label === "quote" && seriesBookIds.has(note.book_id))
+            .slice(0, 3),
+        })}
+        title={`Send "${seriesRecord.name}" to chat`}
+        description="Add a message, then pick the chat you want to send this series to."
+        onSent={() => setShareStatus("Series sent to chat.")}
+      />
     </div>
   );
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -42,6 +42,7 @@ import { useAuth, useProfile, useTheme, useUserSettings } from "@/context";
 import { useGenresContext } from "@/context/GenresContext";
 import { getErrorMessage } from "@/lib/profiles";
 import { flattenGenreTree, getGenrePathLabel, isGenreRoot } from "@/lib/genres";
+import { RELEASE_NOTES_EVENT } from "@/components/ReleaseNotesDialog";
 import { supabase } from "@/lib/supabase";
 import {
   DEFAULT_APPEARANCE_SETTINGS,
@@ -74,6 +75,7 @@ import type {
   ReadingPaceCalculation,
   ReadingSettings as ReadingSettingsValues,
 } from "@/types";
+import { getLatestReleaseNote, hasUnreadReleaseNote } from "@/lib/releaseNotes";
 
 type SettingsTab =
   | "profile"
@@ -1034,6 +1036,10 @@ function AccountSettings() {
 }
 
 function AboutSettings() {
+  const { settings, loading } = useUserSettings();
+  const latestReleaseNote = getLatestReleaseNote();
+  const showReleaseNotes = !loading && hasUnreadReleaseNote(settings?.last_seen_release_note_version);
+
   return (
     <SettingsSection
       title="About"
@@ -1042,13 +1048,23 @@ function AboutSettings() {
     >
       <SettingsRows>
         <SettingRow title="App version">
-          <span className="text-sm text-muted-foreground">{APP_VERSION}</span>
+          <span className="text-sm text-muted-foreground">
+            {APP_VERSION}
+            {showReleaseNotes ? ` · update ${latestReleaseNote.version} available` : ""}
+          </span>
         </SettingRow>
-        <SettingRow title="Changelog">
-          <Button type="button" variant="outline" size="sm" disabled>
-            View changelog
-          </Button>
-        </SettingRow>
+        {showReleaseNotes && (
+          <SettingRow title="What's new">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => window.dispatchEvent(new Event(RELEASE_NOTES_EVENT))}
+            >
+              Open release notes
+            </Button>
+          </SettingRow>
+        )}
         <SettingRow title="Documentation">
           <Button type="button" variant="outline" size="sm" disabled>
             Open docs

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,6 +210,7 @@ export interface UserSettings {
   notifications: NotificationSettings;
   privacy: PrivacySettings;
   backup: BackupSettings;
+  last_seen_release_note_version: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/supabase/migrations/20260621_release_notes.sql
+++ b/supabase/migrations/20260621_release_notes.sql
@@ -1,0 +1,3 @@
+-- One-time release notes shown after login until the user acknowledges them.
+ALTER TABLE user_settings
+  ADD COLUMN IF NOT EXISTS last_seen_release_note_version text;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -283,6 +283,7 @@ CREATE TABLE IF NOT EXISTS user_settings (
     "backup_frequency": "manual",
     "last_backup_at": null
   }'::jsonb,
+  last_seen_release_note_version text,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
   CHECK (jsonb_typeof(appearance) = 'object'),


### PR DESCRIPTION
## Summary
- Added reusable detail actions and attachment-sharing dialogs for book, author, and series detail pages.
- Wired book, author, and series detail pages to send attachments into chats and keep the new menu consistent across entities.
- Updated shared button styling and series/book helpers to support the new detail interactions.

## Verification
- `npm run build`

## Notes
- This PR contains the committed UI and chat-related changes on `codex/release-notes`.