### PR TITLE
[codex] add pause books mode

### DIFF
--- a/src/components/BookAnalyticsPanel.tsx
+++ b/src/components/BookAnalyticsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useMemo, useState } from "react";
-import { BarChart3, ChevronDown, ChevronUp } from "lucide-react";
+import { BarChart3, ChevronDown, ChevronUp, PauseCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { fetchReadingLogsForBook } from "@/lib/books";
@@ -185,8 +185,8 @@ export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
   );
 
   const progressTimeline = useMemo(
-    () => buildProgressTimeline(logs, book.total_pages),
-    [book.total_pages, logs]
+    () => buildProgressTimeline(logs, book.total_pages, book.pause_periods),
+    [book.pause_periods, book.total_pages, logs]
   );
 
   const totalPagesRead = useMemo(
@@ -208,8 +208,9 @@ export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
         currentPage: book.current_page,
         totalPages: book.total_pages,
         logs,
+        pausePeriods: book.pause_periods,
       }),
-    [book.current_page, book.status, book.total_pages, logs]
+    [book.current_page, book.pause_periods, book.status, book.total_pages, logs]
   );
 
   const readingDuration = useMemo(
@@ -217,8 +218,9 @@ export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
       getReadingDuration({
         dateStarted: book.date_started,
         dateFinished: book.date_finished,
+        pausePeriods: book.pause_periods,
       }),
-    [book.date_finished, book.date_started]
+    [book.date_finished, book.date_started, book.pause_periods]
   );
 
   const readingDurationLabel = useMemo(() => {
@@ -322,6 +324,16 @@ export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
     if (progressDatePoints.length <= 56) return 4;
     return 7;
   }, [progressDatePoints.length]);
+  const pauseBands = progressTimeline.pauseSegments.map((segment, index) => {
+    const startX = getProgressXPercent(segment.startDayKey);
+    const endX = Math.max(startX + 3, getProgressXPercent(segment.endDayKey));
+    return {
+      key: `${segment.startDayKey}-${segment.endDayKey}-${index}`,
+      startX,
+      endX,
+      segment,
+    };
+  });
 
   const maxPages = Math.max(...chartPoints.map((p) => p.pagesRead), 0);
   const yAxisMax = maxPages > 0 ? maxPages : 1;
@@ -462,6 +474,24 @@ export default function BookAnalyticsPanel({ book }: BookAnalyticsPanelProps) {
                     <div className="border-t border-border/50" />
                     <div className="border-t border-border/70" />
                   </div>
+
+                  {pauseBands.map(({ key, startX, endX, segment }) => (
+                    <div
+                      key={key}
+                      className="pointer-events-none absolute inset-y-0 z-[1] overflow-hidden rounded-md border border-dashed border-muted-foreground/25 bg-muted/20"
+                      style={{ left: `${startX}%`, width: `${Math.max(4, endX - startX)}%` }}
+                    >
+                      <div className="flex h-full items-center justify-center px-2 text-center text-[11px] text-muted-foreground">
+                        <span className="inline-flex flex-col items-center gap-1">
+                          <PauseCircle className="h-5 w-5 text-muted-foreground/70" />
+                          <span>
+                            Paused for {segment.durationDays}
+                            {segment.durationDays === 1 ? " day" : " days"}
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  ))}
 
                   {activeProgressPoint && (
                     <div

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Heart } from "lucide-react";
+import { BookOpen, Heart, PauseCircle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
@@ -6,6 +6,7 @@ import ReadingProgressDialog from "@/components/ReadingProgressDialog";
 import { Button } from "@/components/ui/button";
 import { useBooksContext } from "@/context/BooksContext";
 import { getTodayLocalDate, statusVariant } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import type { Book } from "@/types";
 
 interface BookCardProps {
@@ -26,6 +27,7 @@ export default function BookCard({
   const currentPage = Math.max(0, book.current_page ?? 0);
   const totalPages = Math.max(0, book.total_pages ?? 0);
   const hasTotalPages = totalPages > 0;
+  const isPaused = book.status === "Paused";
   const progressPercent = hasTotalPages
     ? Math.min(100, Math.max(0, Math.round((currentPage / totalPages) * 100)))
     : 0;
@@ -52,17 +54,27 @@ export default function BookCard({
       }}
     >
       {/* Cover */}
-      <div className="relative aspect-[2/3] w-full bg-muted flex-shrink-0">
+      <div
+        className={cn(
+          "relative aspect-[2/3] w-full bg-muted flex-shrink-0",
+          isPaused && "opacity-70",
+        )}
+      >
         {book.cover_url ? (
           <img
             src={book.cover_url}
             alt={book.title}
             loading="lazy"
-            className="h-full w-full object-cover"
+            className={cn("h-full w-full object-cover", isPaused && "grayscale")}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center">
             <BookOpen className="h-10 w-10 text-muted-foreground/40" />
+          </div>
+        )}
+        {isPaused && (
+          <div className="absolute inset-0 flex items-center justify-center bg-background/45 backdrop-blur-[1px]">
+            <PauseCircle className="h-8 w-8 text-muted-foreground" />
           </div>
         )}
         {book.is_favorite && (

--- a/src/components/DetailActionsMenu.tsx
+++ b/src/components/DetailActionsMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { MoreVertical, Pencil, Send, Share2, Trash2 } from "lucide-react";
+import { MoreVertical, PauseCircle, Pencil, Play, Send, Share2, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -22,6 +22,8 @@ interface DetailActionsMenuProps {
   label: string;
   shareLinkLabel?: string;
   shareAttachmentLabel: string;
+  onPause?: () => void;
+  onResume?: () => void;
   onEdit?: () => void;
   onDelete: () => void | Promise<void>;
   onSendAttachment: () => void;
@@ -42,6 +44,8 @@ export default function DetailActionsMenu({
   label,
   shareLinkLabel = "Copy link to this page",
   shareAttachmentLabel,
+  onPause,
+  onResume,
   onEdit,
   onDelete,
   onSendAttachment,
@@ -105,7 +109,7 @@ export default function DetailActionsMenu({
     const rect = buttonRef.current?.getBoundingClientRect();
     if (!rect) return;
     const panelWidth = 200;
-    const panelHeight = onEdit ? 128 : 92;
+    const panelHeight = (onEdit ? 42 : 0) + ((onPause || onResume) ? 42 : 0) + 92;
     const left = Math.max(8, Math.min(rect.right - panelWidth, window.innerWidth - panelWidth - 8));
     const top = Math.min(rect.bottom + 8, window.innerHeight - panelHeight - 8);
     setMenuPosition({ top, left });
@@ -150,6 +154,32 @@ export default function DetailActionsMenu({
             <Share2 className="h-4 w-4" />
             Share
           </button>
+          {onPause && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+              onClick={() => {
+                setMenuOpen(false);
+                onPause();
+              }}
+            >
+              <PauseCircle className="h-4 w-4" />
+              Pause
+            </button>
+          )}
+          {onResume && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+              onClick={() => {
+                setMenuOpen(false);
+                onResume();
+              }}
+            >
+              <Play className="h-4 w-4" />
+              Resume
+            </button>
+          )}
           {onEdit && (
             <button
               type="button"

--- a/src/components/ProgressOverTimeChart.tsx
+++ b/src/components/ProgressOverTimeChart.tsx
@@ -1,10 +1,12 @@
 import { useId, useMemo, useState } from "react";
+import { PauseCircle } from "lucide-react";
 import { buildProgressTimeline } from "@/lib/bookAnalytics";
-import type { ReadingLog } from "@/types";
+import type { BookPausePeriod, ReadingLog } from "@/types";
 
 interface ProgressOverTimeChartProps {
   logs: ReadingLog[];
   totalPages?: number;
+  pausePeriods?: BookPausePeriod[];
 }
 
 function dayFromKey(dayKey: string): Date {
@@ -27,12 +29,13 @@ function formatFullDayLabel(dayKey: string): string {
 export default function ProgressOverTimeChart({
   logs,
   totalPages,
+  pausePeriods = [],
 }: ProgressOverTimeChartProps) {
   const [activeProgressIndex, setActiveProgressIndex] = useState<number | null>(null);
   const gradientId = `progress-fill-${useId().replace(/:/g, "")}`;
   const progressTimeline = useMemo(
-    () => buildProgressTimeline(logs, totalPages),
-    [logs, totalPages],
+    () => buildProgressTimeline(logs, totalPages, pausePeriods),
+    [logs, pausePeriods, totalPages],
   );
 
   const progressChartHeight = 176;
@@ -44,7 +47,14 @@ export default function ProgressOverTimeChart({
 
   const getProgressXPercent = (dayKey: string, isStart = false): number => {
     const index = progressDatePoints.findIndex((point) => point.dayKey === dayKey);
-    if (index < 0) return 0;
+    if (index < 0) {
+      if (progressDatePoints.length === 0) return 0;
+      const firstDayKey = progressDatePoints[0].dayKey;
+      const lastDayKey = progressDatePoints[progressDatePoints.length - 1].dayKey;
+      if (dayKey < firstDayKey) return 0;
+      if (dayKey > lastDayKey) return 100;
+      return 0;
+    }
     if (progressDatePoints.length === 1) {
       return isStart ? 50 - progressStartOffsetPercent : 50;
     }
@@ -54,6 +64,17 @@ export default function ProgressOverTimeChart({
       (index / (progressDatePoints.length - 1)) * (100 - progressStartOffsetPercent);
     return isStart ? Math.max(0, dateX - progressStartOffsetPercent) : dateX;
   };
+
+  const pauseBands = progressTimeline.pauseSegments.map((segment, index) => {
+    const startX = getProgressXPercent(segment.startDayKey);
+    const endX = Math.max(startX + 3, getProgressXPercent(segment.endDayKey));
+    return {
+      key: `${segment.startDayKey}-${segment.endDayKey}-${index}`,
+      startX,
+      endX,
+      segment,
+    };
+  });
 
   const progressPoints = progressTimeline.points.map((point) => {
     const x = getProgressXPercent(point.dayKey, point.isStart);
@@ -128,6 +149,24 @@ export default function ProgressOverTimeChart({
               <div className="border-t border-border/70" />
             </div>
 
+            {pauseBands.map(({ key, startX, endX, segment }) => (
+              <div
+                key={key}
+                className="pointer-events-none absolute inset-y-0 z-[1] overflow-hidden rounded-md border border-dashed border-muted-foreground/25 bg-muted/20"
+                style={{ left: `${startX}%`, width: `${Math.max(4, endX - startX)}%` }}
+              >
+                <div className="flex h-full items-center justify-center px-2 text-center text-[11px] text-muted-foreground">
+                  <span className="inline-flex flex-col items-center gap-1">
+                    <PauseCircle className="h-5 w-5 text-muted-foreground/70" />
+                    <span>
+                      Paused for {segment.durationDays}
+                      {segment.durationDays === 1 ? " day" : " days"}
+                    </span>
+                  </span>
+                </div>
+              </div>
+            ))}
+
             {activeProgressPoint && (
               <div
                 className="pointer-events-none absolute top-2 z-10 rounded-md border bg-background/95 px-2 py-1 text-[11px] shadow-sm"
@@ -145,7 +184,7 @@ export default function ProgressOverTimeChart({
             )}
 
             <svg
-              className="absolute inset-0 overflow-visible"
+              className="absolute inset-0 z-[2] overflow-visible"
               width="100%"
               height={progressChartHeight}
               viewBox={`0 0 100 ${progressChartHeight}`}
@@ -194,8 +233,8 @@ export default function ProgressOverTimeChart({
                   type="button"
                   className={
                     showMarker
-                      ? "absolute h-[clamp(0.4rem,0.65vw,0.55rem)] w-[clamp(0.4rem,0.65vw,0.55rem)] -translate-x-1/2 -translate-y-1/2 rounded-full border bg-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
-                      : "absolute h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border border-transparent bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                      ? "absolute z-[3] h-[clamp(0.4rem,0.65vw,0.55rem)] w-[clamp(0.4rem,0.65vw,0.55rem)] -translate-x-1/2 -translate-y-1/2 rounded-full border bg-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+                      : "absolute z-[3] h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border border-transparent bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
                   }
                   style={{
                     left: `${x}%`,

--- a/src/context/BooksContext.tsx
+++ b/src/context/BooksContext.tsx
@@ -9,6 +9,8 @@ interface BooksContextValue {
   addBook: (payload: AddBookPayload, coverFile?: File) => Promise<AddBookResult>;
   updateBook: (id: string, payload: BookUpdate) => Promise<void>;
   updateCover: (id: string, file: File) => Promise<void>;
+  pauseBook: (id: string) => Promise<void>;
+  resumeBook: (id: string) => Promise<void>;
   deleteBook: (id: string) => Promise<void>;
   reload: () => Promise<void>;
 }

--- a/src/hooks/useBooks.ts
+++ b/src/hooks/useBooks.ts
@@ -4,6 +4,8 @@ import {
   fetchBooks,
   createBook,
   updateBook as updateBookDb,
+  pauseBook as pauseBookDb,
+  resumeBook as resumeBookDb,
   deleteBook as deleteBookDb,
   uploadCover,
   deleteCover,
@@ -97,6 +99,16 @@ export function useBooks() {
     [user]
   );
 
+  const pauseBook = useCallback(async (id: string): Promise<void> => {
+    const updated = await pauseBookDb(id);
+    setBooks((prev) => prev.map((book) => (book.id === id ? updated : book)));
+  }, []);
+
+  const resumeBook = useCallback(async (id: string): Promise<void> => {
+    const updated = await resumeBookDb(id);
+    setBooks((prev) => prev.map((book) => (book.id === id ? updated : book)));
+  }, []);
+
   const deleteBook = useCallback(
     async (id: string): Promise<void> => {
       if (!user) throw new Error("Not authenticated");
@@ -108,5 +120,16 @@ export function useBooks() {
     [user]
   );
 
-  return { books, loading, error, addBook, updateBook, updateCover, deleteBook, reload: load };
+  return {
+    books,
+    loading,
+    error,
+    addBook,
+    updateBook,
+    updateCover,
+    pauseBook,
+    resumeBook,
+    deleteBook,
+    reload: load,
+  };
 }

--- a/src/lib/analyticsDashboard.ts
+++ b/src/lib/analyticsDashboard.ts
@@ -1,4 +1,5 @@
 import type { Book, ReadingLog } from "@/types";
+import { getActiveDaysBetween } from "@/lib/bookAnalytics";
 
 export type YearComparisonMetric = "books" | "pages" | "hours";
 
@@ -210,8 +211,7 @@ function getCompletionDays(book: Book): number | null {
   const finished = parseDate(book.date_finished);
   if (!started || !finished || finished < started) return null;
 
-  const dayMs = 24 * 60 * 60 * 1000;
-  return Math.max(1, Math.round((finished.getTime() - started.getTime()) / dayMs));
+  return Math.max(1, getActiveDaysBetween(started, finished, book.pause_periods, new Date()));
 }
 
 function buildPageDeltas(logs: ReadingLog[]): PageDelta[] {
@@ -546,7 +546,7 @@ function buildHallOfFame(books: Book[], logs: ReadingLog[], pageDeltas: PageDelt
   };
 }
 
-function buildReadingGaps(logs: ReadingLog[]): number | null {
+function buildReadingGaps(books: Book[], logs: ReadingLog[], now = new Date()): number | null {
   const dayKeys = Array.from(new Set(logs.map((log) => {
     const loggedAt = parseDate(log.logged_at);
     return loggedAt ? toDayKey(loggedAt) : null;
@@ -555,12 +555,12 @@ function buildReadingGaps(logs: ReadingLog[]): number | null {
   if (dayKeys.length < 2) return null;
 
   const gaps: number[] = [];
+  const pausePeriods = books.flatMap((book) => book.pause_periods ?? []);
   for (let index = 1; index < dayKeys.length; index += 1) {
     const previous = parseDate(dayKeys[index - 1]);
     const current = parseDate(dayKeys[index]);
     if (!previous || !current) continue;
-    const diffDays = Math.round((current.getTime() - previous.getTime()) / (24 * 60 * 60 * 1000));
-    gaps.push(Math.max(0, diffDays - 1));
+    gaps.push(Math.max(0, getActiveDaysBetween(previous, current, pausePeriods, now) - 1));
   }
 
   if (gaps.length === 0) return null;
@@ -634,7 +634,7 @@ export function buildAnalyticsDashboardData(books: Book[], logs: ReadingLog[]): 
   const finishedBooks = books.filter((book) => book.status === "Finished");
   const dnfBooks = books.filter((book) => book.status === "DNF");
   const activeBookIds = new Set(
-    books.filter((book) => book.status === "Finished" || book.status === "Reading").map((book) => book.id)
+    books.filter((book) => book.status === "Finished" || book.status === "Reading" || book.status === "Paused").map((book) => book.id)
   );
   const pageDeltas = buildPageDeltas(logs);
   const totalPageDeltas = pageDeltas.reduce((sum, delta) => sum + delta.pages, 0);
@@ -860,7 +860,7 @@ export function buildAnalyticsDashboardData(books: Book[], logs: ReadingLog[]): 
     },
     hallOfFame: buildHallOfFame(books, logs, pageDeltas),
     insights: {
-      averageReadingGapDays: buildReadingGaps(logs),
+      averageReadingGapDays: buildReadingGaps(books, logs),
       favoriteGenre: topPercentages(finishedGenreCounts, 1)[0]?.label ?? null,
       favoriteAuthor: topPercentages(finishedAuthorCounts, 1)[0]?.label ?? null,
       mostProductiveMonth: mostProductiveMonth?.value > 0 ? formatRecordMonth(mostProductiveMonth.key) : null,

--- a/src/lib/authorShelf.ts
+++ b/src/lib/authorShelf.ts
@@ -93,7 +93,7 @@ function getReadingDateBounds(books: Book[]): {
 
 function shelfKeyForStatus(status: BookStatus): AuthorShelfGroupKey {
   if (status === "Finished") return "read";
-  if (status === "Reading") return "reading";
+  if (status === "Reading" || status === "Paused") return "reading";
   if (["Wishlist", "Not Started", "Up Next"].includes(status)) return "want-to-read";
   return "uncategorized";
 }
@@ -172,7 +172,7 @@ export function buildAuthorSummaries(books: Book[], notes: BookNote[] = []): Aut
         coverBooks: getCoverBooks(sortedBooks),
         statusCounts: {
           read: sortedBooks.filter((book) => book.status === "Finished").length,
-          reading: sortedBooks.filter((book) => book.status === "Reading").length,
+          reading: sortedBooks.filter((book) => book.status === "Reading" || book.status === "Paused").length,
           wantToRead: sortedBooks.filter((book) =>
             ["Wishlist", "Not Started", "Up Next"].includes(book.status),
           ).length,

--- a/src/lib/bookAnalytics.ts
+++ b/src/lib/bookAnalytics.ts
@@ -1,4 +1,4 @@
-import type { BookStatus, ReadingLog } from "@/types";
+import type { BookPausePeriod, BookStatus, ReadingLog } from "@/types";
 
 export interface CalendarSpan {
   months: number;
@@ -29,9 +29,17 @@ export interface ProgressTimelinePoint {
   hasProgressIncrease: boolean;
 }
 
+export interface PauseTimelineSegment {
+  startDayKey: string;
+  endDayKey: string;
+  durationDays: number;
+  isOpenEnded: boolean;
+}
+
 export interface ProgressTimelineResult {
   isAvailable: boolean;
   points: ProgressTimelinePoint[];
+  pauseSegments: PauseTimelineSegment[];
 }
 
 export const MIN_READING_LOGS_FOR_ESTIMATED_FINISH = 3;
@@ -58,10 +66,79 @@ function toLocalDayKey(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+function parseTimestamp(value?: string | null): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return isValidDate(parsed) ? parsed : null;
+}
+
 function wholeDaysBetween(startDate: Date, endDate: Date): number {
   const start = startOfLocalDay(startDate);
   const end = startOfLocalDay(endDate);
   return Math.floor((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000));
+}
+
+function getPauseSegments(
+  pausePeriods: BookPausePeriod[] | undefined,
+  now: Date,
+): PauseTimelineSegment[] {
+  return (pausePeriods ?? [])
+    .flatMap((period) => {
+      const pausedAt = parseTimestamp(period.paused_at);
+      if (!pausedAt) return [];
+
+      const resumedAt = parseTimestamp(period.resumed_at ?? undefined) ?? startOfLocalDay(now);
+      const start = startOfLocalDay(pausedAt);
+      const end = startOfLocalDay(resumedAt);
+      if (end < start) return [];
+
+      return [
+        {
+          startDayKey: toLocalDayKey(start),
+          endDayKey: toLocalDayKey(end),
+          durationDays: wholeDaysBetween(start, end),
+          isOpenEnded: !period.resumed_at,
+        },
+      ];
+    })
+    .sort((a, b) => a.startDayKey.localeCompare(b.startDayKey));
+}
+
+function getPauseDaysBetween(
+  startDate: Date,
+  endDate: Date,
+  pausePeriods: BookPausePeriod[] | undefined,
+  now: Date,
+): number {
+  const start = startOfLocalDay(startDate);
+  const end = startOfLocalDay(endDate);
+  if (end < start) return 0;
+
+  let pausedDays = 0;
+
+  for (const segment of getPauseSegments(pausePeriods, now)) {
+    const pauseStart = parseLocalDateOnly(segment.startDayKey);
+    const pauseEnd = parseLocalDateOnly(segment.endDayKey);
+    if (!pauseStart || !pauseEnd) continue;
+
+    const overlapStart = pauseStart > start ? pauseStart : start;
+    const overlapEnd = pauseEnd < end ? pauseEnd : end;
+    if (overlapEnd < overlapStart) continue;
+
+    pausedDays += wholeDaysBetween(overlapStart, overlapEnd);
+  }
+
+  return Math.max(0, pausedDays);
+}
+
+export function getActiveDaysBetween(
+  startDate: Date,
+  endDate: Date,
+  pausePeriods: BookPausePeriod[] | undefined,
+  now: Date,
+): number {
+  const totalDays = wholeDaysBetween(startOfLocalDay(startDate), startOfLocalDay(endDate));
+  return Math.max(0, totalDays - getPauseDaysBetween(startDate, endDate, pausePeriods, now));
 }
 
 function addMonthsClamped(date: Date, months: number): Date {
@@ -123,6 +200,7 @@ export function getCalendarPagesPerDay(params: {
   pages?: number;
   dateStarted?: string;
   dateEnded?: string;
+  pausePeriods?: BookPausePeriod[];
   now?: Date;
 }): number | null {
   const pages = params.pages ?? 0;
@@ -133,7 +211,10 @@ export function getCalendarPagesPerDay(params: {
 
   if (pages <= 0 || !started || !ended || ended < started) return null;
 
-  const elapsedDays = Math.max(1, wholeDaysBetween(started, ended));
+  const elapsedDays = Math.max(
+    1,
+    getActiveDaysBetween(started, ended, params.pausePeriods, params.now ?? new Date()),
+  );
   return pages / elapsedDays;
 }
 
@@ -144,12 +225,14 @@ export function formatPagesPerDay(value: number | null): string {
 
 export function buildProgressTimeline(
   logs: ReadingLog[],
-  totalPages?: number
+  totalPages?: number,
+  pausePeriods: BookPausePeriod[] = [],
 ): ProgressTimelineResult {
   if (!totalPages || totalPages <= 0) {
     return {
       isAvailable: false,
       points: [],
+      pauseSegments: [],
     };
   }
 
@@ -186,6 +269,7 @@ export function buildProgressTimeline(
     return {
       isAvailable: true,
       points: [],
+      pauseSegments: getPauseSegments(pausePeriods, new Date()),
     };
   }
 
@@ -196,14 +280,23 @@ export function buildProgressTimeline(
     return {
       isAvailable: true,
       points: [],
+      pauseSegments: getPauseSegments(pausePeriods, new Date()),
     };
   }
+
+  const pauseSegments = getPauseSegments(pausePeriods, new Date());
+  const latestPauseDay = pauseSegments.reduce((latest, segment) => {
+    const end = parseLocalDateOnly(segment.endDayKey);
+    if (!end) return latest;
+    return !latest || end > latest ? end : latest;
+  }, null as Date | null);
+  const lastVisibleDay = latestPauseDay && latestPauseDay > lastDay ? latestPauseDay : lastDay;
 
   const progressPoints: ProgressTimelinePoint[] = [];
   const cursor = new Date(firstDay);
   let carriedPage = 0;
 
-  while (cursor <= lastDay) {
+  while (cursor <= lastVisibleDay) {
     const dayKey = toLocalDayKey(cursor);
     const increasedPage = progressByDay.get(dayKey);
     const hasProgressIncrease = typeof increasedPage === "number" && increasedPage > carriedPage;
@@ -234,6 +327,7 @@ export function buildProgressTimeline(
       },
       ...progressPoints,
     ],
+    pauseSegments,
   };
 }
 
@@ -279,6 +373,7 @@ export function formatCalendarSpan(span: CalendarSpan): string {
 export function getReadingDuration(params: {
   dateStarted?: string;
   dateFinished?: string;
+  pausePeriods?: BookPausePeriod[];
   now?: Date;
 }): ReadingDurationResult {
   const started = parseLocalDateOnly(params.dateStarted);
@@ -303,10 +398,14 @@ export function getReadingDuration(params: {
     };
   }
 
+  const pausedDays = getPauseDaysBetween(started, endDate, params.pausePeriods, fallbackNow);
+  const effectiveEndDate = new Date(endDate);
+  effectiveEndDate.setDate(effectiveEndDate.getDate() - pausedDays);
+
   return {
     isAvailable: true,
     isInProgress,
-    span: calculateCalendarSpan(started, endDate),
+    span: calculateCalendarSpan(started, effectiveEndDate),
   };
 }
 
@@ -315,6 +414,7 @@ export function getEstimatedFinish(params: {
   currentPage?: number;
   totalPages?: number;
   logs: ReadingLog[];
+  pausePeriods?: BookPausePeriod[];
   now?: Date;
 }): EstimatedFinishResult {
   if (params.status !== "Reading") {
@@ -355,7 +455,12 @@ export function getEstimatedFinish(params: {
   const lastLog = sortedLogs[sortedLogs.length - 1];
   const firstLogDate = new Date(firstLog.logged_at);
   const lastLogDate = new Date(lastLog.logged_at);
-  const loggedDays = wholeDaysBetween(firstLogDate, lastLogDate);
+  const loggedDays = getActiveDaysBetween(
+    firstLogDate,
+    lastLogDate,
+    params.pausePeriods,
+    params.now ?? new Date(),
+  );
   const loggedProgress = lastLog.current_page - firstLog.current_page;
 
   if (!isValidDate(firstLogDate) || !isValidDate(lastLogDate) || loggedDays <= 0 || loggedProgress <= 0) {

--- a/src/lib/books.ts
+++ b/src/lib/books.ts
@@ -1,12 +1,13 @@
 import { supabase } from "./supabase";
 import { getSelectedGenreTags } from "@/lib/genres";
-import type { Book, BookUpdate, Genre, Series, ReadingLog } from "@/types";
+import type { Book, BookPausePeriod, BookUpdate, Genre, Series, ReadingLog } from "@/types";
 
 type LegacyAuthorBookRow = Omit<Book, "authors"> & {
   authors?: string[] | null;
   author?: string | null;
   genre?: string | null;
   book_genres?: Array<{ genre?: Genre | null }>;
+  pause_periods?: BookPausePeriod[] | null;
 };
 
 function parseLegacyGenre(genre?: string | null): string[] | undefined {
@@ -35,6 +36,12 @@ function normalizeBook(row: LegacyAuthorBookRow): Book {
     .map((item) => item.genre)
     .filter((genre): genre is Genre => Boolean(genre));
   const displayGenres = selectedGenres.length > 0 ? getSelectedGenreTags(selectedGenres) : [];
+  const pausePeriods = (row.pause_periods ?? [])
+    .map((period) => ({
+      ...period,
+      resumed_at: period.resumed_at ?? null,
+    }))
+    .sort((a, b) => new Date(a.paused_at).getTime() - new Date(b.paused_at).getTime());
   const genres =
     displayGenres.length > 0
       ? displayGenres.map((genre) => genre.name)
@@ -55,6 +62,7 @@ function normalizeBook(row: LegacyAuthorBookRow): Book {
     selected_genres: selectedGenres,
     genre_paths: displayGenres.length > 0 ? displayGenres.map((genre) => genre.name) : genres,
     genres,
+    pause_periods: pausePeriods,
   };
 }
 
@@ -96,6 +104,15 @@ function isMissingGenreTablesError(error: unknown): boolean {
     combined.includes("relationship") && combined.includes("genres") ||
     combined.includes("relation") && combined.includes("genres")
   );
+}
+
+function isMissingPausePeriodsRelationError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const message = "message" in error ? String((error as { message: unknown }).message).toLowerCase() : "";
+  const details = "details" in error ? String((error as { details: unknown }).details).toLowerCase() : "";
+  const combined = `${message} ${details}`;
+
+  return combined.includes("book_pause_periods") || combined.includes("pause_periods");
 }
 
 function withoutMetadataSourcePayload<
@@ -142,9 +159,19 @@ function isMissingAuthorsColumnError(error: unknown): boolean {
 export async function fetchBooks(): Promise<Book[]> {
   const { data, error } = await supabase
     .from("books")
-    .select("*, book_genres(genre:genres(*))")
+    .select("*, book_genres(genre:genres(*)), book_pause_periods(*)")
     .order("created_at", { ascending: false });
   if (error) {
+    if (isMissingPausePeriodsRelationError(error)) {
+      const { data: pauseLegacyData, error: pauseLegacyError } = await supabase
+        .from("books")
+        .select("*, book_genres(genre:genres(*))")
+        .order("created_at", { ascending: false });
+      if (!pauseLegacyError) {
+        return ((pauseLegacyData ?? []) as LegacyAuthorBookRow[]).map((row) => normalizeBook(row));
+      }
+      if (!isMissingGenreTablesError(pauseLegacyError)) throw pauseLegacyError;
+    }
     if (!isMissingGenreTablesError(error)) throw error;
 
     const { data: legacyData, error: legacyError } = await supabase
@@ -258,14 +285,40 @@ async function updateBookPayload(
   return normalizeBook(legacyData as LegacyAuthorBookRow);
 }
 
+async function runPauseBookMutation(
+  fnName: "pause_book" | "resume_book",
+  bookId: string,
+): Promise<Book> {
+  const { error } = await supabase.rpc(fnName, { book_uuid: bookId });
+  if (error) throw error;
+  return fetchBookById(bookId);
+}
+
+export async function pauseBook(id: string): Promise<Book> {
+  return runPauseBookMutation("pause_book", id);
+}
+
+export async function resumeBook(id: string): Promise<Book> {
+  return runPauseBookMutation("resume_book", id);
+}
+
 async function fetchBookById(id: string): Promise<Book> {
   const { data, error } = await supabase
     .from("books")
-    .select("*, book_genres(genre:genres(*))")
+    .select("*, book_genres(genre:genres(*)), book_pause_periods(*)")
     .eq("id", id)
     .single();
 
   if (error) {
+    if (isMissingPausePeriodsRelationError(error)) {
+      const { data: pauseLegacyData, error: pauseLegacyError } = await supabase
+        .from("books")
+        .select("*, book_genres(genre:genres(*))")
+        .eq("id", id)
+        .single();
+      if (!pauseLegacyError) return normalizeBook(pauseLegacyData as LegacyAuthorBookRow);
+      if (!isMissingGenreTablesError(pauseLegacyError)) throw pauseLegacyError;
+    }
     if (!isMissingGenreTablesError(error)) throw error;
 
     const { data: legacyData, error: legacyError } = await supabase

--- a/src/lib/releaseNotes.ts
+++ b/src/lib/releaseNotes.ts
@@ -12,11 +12,11 @@ export type ReleaseNote = {
 };
 
 export const CURRENT_RELEASE_NOTE: ReleaseNote = {
-  version: "2026-06-21-chat-groups",
+  version: "2026-06-21-pause-books",
   published_at: "2026-06-21",
-  title: "Chat and groups are here",
+  title: "Chat, groups, and pause mode",
   summary:
-    "You can now chat with other readers and organize conversations into groups.",
+    "You can now chat with other readers, organize conversations into groups, and pause books when you need to step away.",
   highlights: [
     {
       title: "Direct chats and groups",
@@ -27,6 +27,11 @@ export const CURRENT_RELEASE_NOTE: ReleaseNote = {
       title: "Attachments and library saves",
       description:
         "Share books, notes, authors, and series in chat, then save shared items to your own library.",
+    },
+    {
+      title: "Pause and resume books",
+      description:
+        "Pause a book when you are away, then resume later so that paused time does not affect your reading analytics.",
     },
   ],
 };

--- a/src/lib/seriesDetails.ts
+++ b/src/lib/seriesDetails.ts
@@ -1,5 +1,6 @@
 import {
   calculateCalendarSpan,
+  getActiveDaysBetween,
   parseLocalDateOnly,
   sumReadingMinutes,
   type CalendarSpan,
@@ -190,7 +191,7 @@ export function getSeriesProgress(books: Book[]): SeriesProgress {
   const readPages = books.reduce((sum, book) => {
     const total = book.total_pages ?? 0;
     if (book.status === "Finished") return sum + total;
-    if (book.status === "Reading" || book.status === "DNF") {
+    if (book.status === "Reading" || book.status === "Paused" || book.status === "DNF") {
       return sum + Math.min(total, Math.max(0, book.current_page ?? 0));
     }
     return sum;
@@ -208,7 +209,7 @@ export function getSeriesProgress(books: Book[]): SeriesProgress {
 export function getNextUpBook(books: Book[]): Book | null {
   return (
     sortSeriesBooks(books).find(
-      (book) => !["Finished", "DNF", "Reading"].includes(book.status),
+      (book) => !["Finished", "DNF", "Reading", "Paused"].includes(book.status),
     ) ?? null
   );
 }
@@ -262,10 +263,14 @@ export function getJourneyDurationDays(
 
   const finished =
     dates.finished ??
-    (book.status === "Reading" ? dateToDateOnly(now) : null);
+    (book.status === "Reading" || book.status === "Paused" ? dateToDateOnly(now) : null);
   if (!finished) return null;
 
-  return daysBetween(dates.started, finished);
+  const startedDate = parseLocalDateOnly(dates.started);
+  const finishedDate = parseLocalDateOnly(finished);
+  if (!startedDate || !finishedDate) return null;
+
+  return getActiveDaysBetween(startedDate, finishedDate, book.pause_periods, now);
 }
 
 export function getSeriesJourneyRecap(
@@ -327,7 +332,7 @@ function getSeriesPagesRead(books: Book[]): number | null {
     if (book.status === "Finished") {
       if (typeof book.total_pages !== "number" || book.total_pages <= 0) return null;
       pagesRead += book.total_pages;
-    } else if (book.status === "Reading") {
+    } else if (book.status === "Reading" || book.status === "Paused") {
       if (
         typeof book.current_page !== "number" ||
         !Number.isFinite(book.current_page) ||
@@ -353,7 +358,8 @@ function getSeriesJourneySpan(
   const startDate = parseLocalDateOnly(started ?? undefined);
   if (!startDate) return { journeySpan: null, journeyDays: null };
 
-  const hasActiveBook = books.some((book) => book.status === "Reading");
+  const hasActiveBook = books.some((book) => book.status === "Reading" || book.status === "Paused");
+  const pausePeriods = books.flatMap((book) => book.pause_periods ?? []);
   const finishedDates = dates
     .flatMap((date) => (date.finished ? [date.finished] : []))
     .sort();
@@ -368,7 +374,7 @@ function getSeriesJourneySpan(
 
   return {
     journeySpan: calculateCalendarSpan(startDate, endDate),
-    journeyDays: daysBetween(dateToDateOnly(startDate), dateToDateOnly(endDate)),
+    journeyDays: getActiveDaysBetween(startDate, endDate, pausePeriods, now),
   };
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,6 +10,7 @@ export function statusVariant(
   status: BookStatus
 ): "default" | "secondary" | "outline" | "destructive" {
   if (status === "Reading") return "default";
+  if (status === "Paused") return "secondary";
   if (status === "DNF") return "destructive";
   if (status === "Up Next") return "secondary";
   return "outline";

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1059,7 +1059,7 @@ function buildSeriesAnalytics(books: Book[], series: Series[]) {
         totalBooks: seriesBooks.length,
         finishedBooks,
         completed: seriesBooks.length > 0 && finishedBooks === seriesBooks.length,
-        ongoing: seriesBooks.some((book) => book.status === "Reading" || book.status === "Up Next" || book.status === "Not Started"),
+        ongoing: seriesBooks.some((book) => book.status === "Reading" || book.status === "Paused" || book.status === "Up Next" || book.status === "Not Started"),
         pagesRead,
         averageRating,
       };

--- a/src/pages/AuthorDetails.tsx
+++ b/src/pages/AuthorDetails.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, BookOpen, ChevronRight, Heart, Star } from "lucide-react";
+import { ArrowLeft, BookOpen, ChevronRight, Heart, PauseCircle, Star } from "lucide-react";
 import DetailActionsMenu from "@/components/DetailActionsMenu";
 import SendAttachmentDialog from "@/components/SendAttachmentDialog";
 import QuoteBlock from "@/components/QuoteBlock";
@@ -25,6 +25,7 @@ function countLabel(count: number, singular: string): string {
 }
 
 function BookCover({ book, size = "md" }: { book: Book; size?: "sm" | "md" }) {
+  const isPaused = book.status === "Paused";
   return (
     <Link
       to={`/books/${book.id}`}
@@ -37,6 +38,7 @@ function BookCover({ book, size = "md" }: { book: Book; size?: "sm" | "md" }) {
         className={cn(
           "overflow-hidden rounded-md border bg-muted shadow-sm",
           size === "sm" ? "h-20 w-14" : "h-[120px] w-20",
+          isPaused && "opacity-70",
         )}
       >
         {book.cover_url ? (
@@ -44,11 +46,19 @@ function BookCover({ book, size = "md" }: { book: Book; size?: "sm" | "md" }) {
             src={book.cover_url}
             alt={book.title}
             loading="lazy"
-            className="h-full w-full object-cover transition-transform group-hover:scale-105"
+            className={cn(
+              "h-full w-full object-cover transition-transform group-hover:scale-105",
+              isPaused && "grayscale",
+            )}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center">
             <BookOpen className="h-5 w-5 text-muted-foreground/50" />
+          </div>
+        )}
+        {isPaused && (
+          <div className="absolute inset-0 flex items-center justify-center bg-background/45 backdrop-blur-[1px]">
+            <PauseCircle className="h-5 w-5 text-muted-foreground" />
           </div>
         )}
       </div>

--- a/src/pages/BookDetails.tsx
+++ b/src/pages/BookDetails.tsx
@@ -13,6 +13,7 @@ import {
   ImagePlus,
   Info,
   MessageSquarePlus,
+  PauseCircle,
   RefreshCw,
   Star,
   TrendingUp,
@@ -64,6 +65,7 @@ import {
   formatAuthorsInput,
   getTodayLocalDate,
   parseAuthorsInput,
+  cn,
 } from "@/lib/utils";
 import type {
   Book,
@@ -188,7 +190,17 @@ function getPublicationYear(value?: string | null): string | null {
 export default function BookDetails() {
   const { bookId } = useParams<{ bookId: string }>();
   const navigate = useNavigate();
-  const { books, loading, error, updateBook, updateCover, deleteBook, reload } = useBooksContext();
+  const {
+    books,
+    loading,
+    error,
+    updateBook,
+    pauseBook,
+    resumeBook,
+    updateCover,
+    deleteBook,
+    reload,
+  } = useBooksContext();
   const { genres } = useGenresContext();
   const { series } = useSeries();
 
@@ -308,8 +320,9 @@ export default function BookDetails() {
       getReadingDuration({
         dateStarted: book?.date_started,
         dateFinished: book?.date_finished,
+        pausePeriods: book?.pause_periods,
       }),
-    [book?.date_finished, book?.date_started],
+    [book?.date_finished, book?.date_started, book?.pause_periods],
   );
   const daysReading =
     readingDuration.isAvailable && readingDuration.span
@@ -322,8 +335,9 @@ export default function BookDetails() {
         currentPage: book?.current_page,
         totalPages: book?.total_pages,
         logs: readingLogs,
+        pausePeriods: book?.pause_periods,
       }),
-    [book?.current_page, book?.status, book?.total_pages, readingLogs],
+    [book?.current_page, book?.pause_periods, book?.status, book?.total_pages, readingLogs],
   );
 
   const relatedByAuthor = useMemo(() => {
@@ -393,6 +407,26 @@ export default function BookDetails() {
       reset(bookToFormValues({ ...book, ...payload }));
     } catch (err) {
       setErrorMsg(err instanceof Error ? err.message : "Failed to update status");
+    }
+  }
+
+  async function handlePause() {
+    if (!book || book.status !== "Reading") return;
+    try {
+      setErrorMsg(null);
+      await pauseBook(book.id);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed to pause book");
+    }
+  }
+
+  async function handleResume() {
+    if (!book || book.status !== "Paused") return;
+    try {
+      setErrorMsg(null);
+      await resumeBook(book.id);
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Failed to resume book");
     }
   }
 
@@ -591,8 +625,10 @@ export default function BookDetails() {
 
   const currentPage = book.current_page ?? 0;
   const totalPages = book.total_pages ?? 0;
+  const isPaused = book.status === "Paused";
+  const isReading = book.status === "Reading";
   const readingProgressStats: ProgressStat[] =
-    book.status === "Reading"
+    isReading || isPaused
       ? [
           {
             icon: Calendar,
@@ -602,27 +638,28 @@ export default function BookDetails() {
           {
             icon: TrendingUp,
             label: "Current Pace",
-            value: formatPagesPerDay(
-              getCalendarPagesPerDay({
-                pages: currentPage,
-                dateStarted: book.date_started,
-              }),
-            ),
-          },
-          {
-            icon: Clock,
-            label: "Time Reading",
-            value: formatTotalReadingTime(totalReadingMinutes),
-          },
-          {
-            icon: CalendarClock,
-            label: "Estimated Finish",
-            value:
-              estimatedFinish.isAvailable && estimatedFinish.finishDate
-                ? formatDateObjectForDisplay(estimatedFinish.finishDate)
-                : "Not available",
-          },
-        ]
+              value: formatPagesPerDay(
+                getCalendarPagesPerDay({
+                  pages: currentPage,
+                  dateStarted: book.date_started,
+                  pausePeriods: book.pause_periods,
+                }),
+              ),
+            },
+            {
+              icon: Clock,
+              label: "Time Reading",
+              value: formatTotalReadingTime(totalReadingMinutes),
+            },
+            {
+              icon: CalendarClock,
+              label: "Estimated Finish",
+              value:
+                estimatedFinish.isAvailable && estimatedFinish.finishDate
+                  ? formatDateObjectForDisplay(estimatedFinish.finishDate)
+                  : "Not available",
+            },
+          ]
       : book.status === "Finished"
         ? [
             {
@@ -648,6 +685,7 @@ export default function BookDetails() {
                   pages: totalPages,
                   dateStarted: book.date_started,
                   dateEnded: book.date_finished,
+                  pausePeriods: book.pause_periods,
                 }),
               ),
             },
@@ -699,6 +737,8 @@ export default function BookDetails() {
           kind="book"
           label={book.title}
           shareAttachmentLabel="Send the book as attachment in a chat"
+          onPause={isReading ? () => void handlePause() : undefined}
+          onResume={isPaused ? () => void handleResume() : undefined}
           onEdit={() => {
             setErrorMsg(null);
             setIsEditMode(true);
@@ -712,12 +752,26 @@ export default function BookDetails() {
 
       <section className="grid gap-6 md:grid-cols-[240px_1fr] md:items-start">
         <div className="mx-auto w-full max-w-[240px]">
-          <div className="relative block aspect-[2/3] overflow-hidden rounded-xl border bg-muted shadow-sm">
+          <div
+            className={cn(
+              "relative block aspect-[2/3] overflow-hidden rounded-xl border bg-muted shadow-sm",
+              isPaused && "opacity-70",
+            )}
+          >
             {book.cover_url ? (
-              <img src={book.cover_url} alt={book.title} className="h-full w-full object-cover" />
+              <img
+                src={book.cover_url}
+                alt={book.title}
+                className={cn("h-full w-full object-cover", isPaused && "grayscale")}
+              />
             ) : (
               <div className="flex h-full w-full items-center justify-center">
                 <BookOpen className="h-10 w-10 text-muted-foreground/40" />
+              </div>
+            )}
+            {isPaused && (
+              <div className="absolute inset-0 flex items-center justify-center bg-background/45 backdrop-blur-[1px]">
+                <PauseCircle className="h-8 w-8 text-muted-foreground" />
               </div>
             )}
           </div>
@@ -836,18 +890,25 @@ export default function BookDetails() {
             </div>
 
             <div className="mt-3">
-              <Select value={book.status} onValueChange={(value) => handleStatusChange(value as BookStatus)}>
-                <SelectTrigger className="h-10 w-40 bg-muted/50">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {STATUS_OPTIONS.map((option) => (
-                    <SelectItem key={option} value={option}>
-                      {option}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              {isPaused ? (
+                <Badge variant="secondary" className="gap-1.5 px-3 py-1.5 text-sm">
+                  <PauseCircle className="h-3.5 w-3.5" />
+                  Paused
+                </Badge>
+              ) : (
+                <Select value={book.status} onValueChange={(value) => handleStatusChange(value as BookStatus)}>
+                  <SelectTrigger className="h-10 w-40 bg-muted/50">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {STATUS_OPTIONS.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
             </div>
           </div>
 
@@ -862,7 +923,11 @@ export default function BookDetails() {
           </div>
 
           <div className="flex flex-wrap gap-2">
-            {book.status === "Reading" ? (
+            {isPaused ? (
+              <Button type="button" onClick={() => void handleResume()}>
+                Resume
+              </Button>
+            ) : isReading ? (
               <ReadingProgressDialog
                 book={book}
                 open={isProgressDialogOpen}
@@ -1077,7 +1142,11 @@ export default function BookDetails() {
                 ) : logsError ? (
                   <p className="text-sm text-destructive">{logsError}</p>
                 ) : (
-                  <ProgressOverTimeChart logs={readingLogs} totalPages={book.total_pages} />
+                  <ProgressOverTimeChart
+                    logs={readingLogs}
+                    totalPages={book.total_pages}
+                    pausePeriods={book.pause_periods}
+                  />
                 )}
               </div>
             </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -67,6 +67,7 @@ export default function Dashboard() {
   }
 
   const currentlyReading = books.filter((b) => b.status === "Reading");
+  const pausedBooks = books.filter((b) => b.status === "Paused");
   const upNext = books.filter((b) => b.status === "Up Next");
   const recentlyFinished = books
     .filter((book) => isRecentlyFinished(book))
@@ -100,7 +101,7 @@ export default function Dashboard() {
     );
   }
 
-  const hasActiveBooks = currentlyReading.length > 0 || upNext.length > 0;
+  const hasActiveBooks = currentlyReading.length > 0 || pausedBooks.length > 0 || upNext.length > 0;
 
   return (
     <div className="space-y-8">
@@ -126,6 +127,22 @@ export default function Dashboard() {
                 book={book}
                 onClick={openBook}
                 showQuickProgress
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {pausedBooks.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-heading leading-snug font-medium">Paused</h2>
+          <div className="grid grid-cols-3 gap-2.5 md:max-w-[calc(100%-12rem-1rem)] md:grid-cols-4 md:gap-3 lg:max-w-[calc(100%-13rem-1rem)]">
+            {pausedBooks.map((book) => (
+              <BookCard
+                key={book.id}
+                book={book}
+                onClick={openBook}
+                textSize="compact"
               />
             ))}
           </div>

--- a/src/pages/ExploreLibrary.tsx
+++ b/src/pages/ExploreLibrary.tsx
@@ -137,7 +137,17 @@ type SmartShelf = {
   emptyMessage: string;
 };
 
-const bookStatuses: BookStatus[] = [
+const filterableBookStatuses: BookStatus[] = [
+  "Wishlist",
+  "Not Started",
+  "Up Next",
+  "Reading",
+  "Paused",
+  "Finished",
+  "DNF",
+];
+
+const bulkEditableBookStatuses: BookStatus[] = [
   "Wishlist",
   "Not Started",
   "Up Next",
@@ -258,13 +268,14 @@ const statusFilterLabels: Record<BookStatus, string> = {
   "Not Started": "Not Started",
   "Up Next": "Up Next",
   Reading: "Currently Reading",
+  Paused: "Paused",
   Finished: "Finished",
   DNF: "DNF",
 };
 
 const statusFilterOptions = [
   "Want to Read",
-  ...bookStatuses.map((status) => statusFilterLabels[status]),
+  ...filterableBookStatuses.map((status) => statusFilterLabels[status]),
 ];
 
 const progressFilterOptions = [
@@ -667,7 +678,7 @@ function ManagementMode({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {bookStatuses.map((status) => (
+                {bulkEditableBookStatuses.map((status) => (
                   <SelectItem key={status} value={status}>
                     {status}
                   </SelectItem>
@@ -943,7 +954,7 @@ function matchesAnyFilterValue(values: string[], matches: (value: string) => boo
 function bookMatchesLibraryFilters(book: Book, filters: LibraryFilters, series: Series[]): boolean {
   if (!matchesAnyFilterValue(filters.status, (filter) => {
     if (filter === "Want to Read") return ["Wishlist", "Not Started", "Up Next"].includes(book.status);
-    const matchingStatus = bookStatuses.find((status) => statusFilterLabels[status] === filter);
+    const matchingStatus = filterableBookStatuses.find((status) => statusFilterLabels[status] === filter);
     return Boolean(matchingStatus && book.status === matchingStatus);
   })) return false;
 

--- a/src/pages/SeriesDetails.tsx
+++ b/src/pages/SeriesDetails.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, BookOpen, Check, Flag, Heart, Star } from "lucide-react";
+import { ArrowLeft, BookOpen, Check, Flag, Heart, PauseCircle, Star } from "lucide-react";
 import DetailActionsMenu from "@/components/DetailActionsMenu";
 import SendAttachmentDialog from "@/components/SendAttachmentDialog";
 import QuoteBlock from "@/components/QuoteBlock";
@@ -81,13 +81,28 @@ function formatDaysSpent(days: number | null): string {
 }
 
 function BookThumbnail({ book }: { book: Book }) {
+  const isPaused = book.status === "Paused";
   return (
-    <div className="h-16 w-11 shrink-0 overflow-hidden rounded-md bg-muted shadow-sm">
+    <div
+      className={cn(
+        "relative h-16 w-11 shrink-0 overflow-hidden rounded-md bg-muted shadow-sm",
+        isPaused && "opacity-70",
+      )}
+    >
       {book.cover_url ? (
-        <img src={book.cover_url} alt="" className="h-full w-full object-cover" />
+        <img
+          src={book.cover_url}
+          alt=""
+          className={cn("h-full w-full object-cover", isPaused && "grayscale")}
+        />
       ) : (
         <div className="flex h-full w-full items-center justify-center">
           <BookOpen className="h-4 w-4 text-muted-foreground/40" />
+        </div>
+      )}
+      {isPaused && (
+        <div className="absolute inset-0 flex items-center justify-center bg-background/45 backdrop-blur-[1px]">
+          <PauseCircle className="h-4 w-4 text-muted-foreground" />
         </div>
       )}
     </div>
@@ -355,15 +370,18 @@ function FavoriteQuoteCard({ book, note }: { book: Book; note: BookNote }) {
 function SeriesOverviewBookTile({ book, index }: { book: Book; index: number }) {
   const isFinished = book.status === "Finished";
   const isReading = book.status === "Reading";
+  const isPaused = book.status === "Paused";
   const sequenceNumber = book.volume_number ?? index + 1;
   const percent = getBookProgressPercent(book);
   const statusLabel = isFinished
     ? "Completed"
-    : isReading
-      ? "Currently Reading"
-      : book.status === "DNF"
-        ? "DNF"
-        : "Unread";
+      : isReading
+        ? "Currently Reading"
+        : isPaused
+          ? "Paused"
+        : book.status === "DNF"
+          ? "DNF"
+          : "Unread";
 
   return (
     <Link
@@ -371,6 +389,7 @@ function SeriesOverviewBookTile({ book, index }: { book: Book; index: number }) 
       className={cn(
         "group relative flex min-w-0 flex-col items-center rounded-lg border bg-card px-3 pb-4 pt-3 text-foreground shadow-[var(--shadow-card)] transition-[background-color,border-color,transform] duration-200 hover:-translate-y-0.5 hover:bg-surface-hover/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         isReading && "border-foreground ring-1 ring-foreground",
+        isPaused && "border-muted-foreground/70 bg-muted/10",
       )}
       aria-label={`Open ${book.title}`}
     >
@@ -379,6 +398,7 @@ function SeriesOverviewBookTile({ book, index }: { book: Book; index: number }) 
           "absolute left-3 top-3 z-10 flex h-6 w-6 items-center justify-center rounded-full border text-xs font-semibold shadow-sm",
           isFinished && "border-primary bg-primary text-primary-foreground",
           isReading && "border-foreground bg-foreground text-background",
+          isPaused && "border-muted-foreground bg-muted text-muted-foreground",
           !isFinished && !isReading && "border-border bg-background text-muted-foreground",
         )}
       >
@@ -386,18 +406,29 @@ function SeriesOverviewBookTile({ book, index }: { book: Book; index: number }) 
       </span>
 
       <div
-        className="h-[190px] w-[126px] overflow-hidden rounded-md bg-muted shadow-sm sm:h-[210px] sm:w-[140px]"
+        className={cn(
+          "relative h-[190px] w-[126px] overflow-hidden rounded-md bg-muted shadow-sm sm:h-[210px] sm:w-[140px]",
+          isPaused && "opacity-70",
+        )}
       >
         {book.cover_url ? (
           <img
             src={book.cover_url}
             alt={book.title}
             loading="lazy"
-            className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.025]"
+            className={cn(
+              "h-full w-full object-cover transition-transform duration-200 group-hover:scale-[1.025]",
+              isPaused && "grayscale",
+            )}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center">
             <BookOpen className="h-8 w-8 text-muted-foreground/40" />
+          </div>
+        )}
+        {isPaused && (
+          <div className="absolute inset-0 flex items-center justify-center bg-background/45 backdrop-blur-[1px]">
+            <PauseCircle className="h-7 w-7 text-muted-foreground" />
           </div>
         )}
       </div>
@@ -598,6 +629,7 @@ function SeriesJourneyItem({
 }) {
   const isFinished = book.status === "Finished";
   const isReading = book.status === "Reading";
+  const isPaused = book.status === "Paused";
   const percent = getBookProgressPercent(book);
   const dates = getJourneyBookDates(book, logs);
   const durationDays = getJourneyDurationDays(book, logs);
@@ -616,7 +648,7 @@ function SeriesJourneyItem({
             <span
               className={cn(
                 "absolute top-0 h-7 w-px",
-                isReading ? "bg-foreground" : "bg-border",
+                isReading ? "bg-foreground" : isPaused ? "bg-muted-foreground" : "bg-border",
               )}
               aria-hidden
             />
@@ -626,19 +658,20 @@ function SeriesJourneyItem({
               "relative z-10 mt-7 flex h-7 w-7 items-center justify-center rounded-full border bg-background",
               isFinished && "border-primary bg-primary text-primary-foreground",
               isReading && "border-foreground bg-foreground text-background",
+              isPaused && "border-muted-foreground bg-muted text-muted-foreground",
               !isFinished && !isReading && "border-muted-foreground/70 text-muted-foreground",
             )}
             aria-hidden
           >
-            {isFinished ? (
-              <Check className="h-3.5 w-3.5 stroke-[3]" />
-            ) : null}
+            {isFinished ? <Check className="h-3.5 w-3.5 stroke-[3]" /> : isPaused ? <PauseCircle className="h-3.5 w-3.5" /> : null}
           </span>
           <p className="mt-3 text-center text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             {isFinished
               ? formatDate(dates.finished)
               : isReading
                 ? formatDate(dates.started)
+                : isPaused
+                  ? "Paused"
                 : book.status === "Up Next"
                   ? "Up next"
                   : "Future"}
@@ -647,7 +680,7 @@ function SeriesJourneyItem({
             <span
               className={cn(
                 "-mb-6 mt-4 min-h-4 w-px flex-1",
-                isReading || nextBookIsReading ? "bg-foreground" : "bg-border",
+                isReading || nextBookIsReading ? "bg-foreground" : isPaused ? "bg-muted-foreground" : "bg-border",
               )}
               aria-hidden
             />
@@ -658,18 +691,31 @@ function SeriesJourneyItem({
           className={cn(
             "grid min-w-0 gap-5 rounded-lg border bg-card p-4 shadow-[var(--shadow-card)] sm:grid-cols-[7rem_minmax(13rem,1fr)] lg:grid-cols-[7rem_minmax(17rem,1fr)_minmax(13rem,17rem)]",
             isReading && "border-foreground ring-1 ring-foreground",
+            isPaused && "border-muted-foreground bg-muted/10",
           )}
         >
           <Link
             to={`/books/${book.id}`}
-            className="h-[168px] w-28 overflow-hidden rounded-lg bg-muted shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className={cn(
+              "relative h-[168px] w-28 overflow-hidden rounded-lg bg-muted shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              book.status === "Paused" && "opacity-70",
+            )}
             aria-label={`Open ${book.title}`}
           >
             {book.cover_url ? (
-              <img src={book.cover_url} alt={book.title} className="h-full w-full object-cover" />
+              <img
+                src={book.cover_url}
+                alt={book.title}
+                className={cn("h-full w-full object-cover", book.status === "Paused" && "grayscale")}
+              />
             ) : (
               <div className="flex h-full w-full items-center justify-center">
                 <BookOpen className="h-8 w-8 text-muted-foreground/40" />
+              </div>
+            )}
+            {book.status === "Paused" && (
+              <div className="absolute inset-0 flex items-center justify-center bg-background/45 backdrop-blur-[1px]">
+                <PauseCircle className="h-7 w-7 text-muted-foreground" />
               </div>
             )}
           </Link>
@@ -696,7 +742,7 @@ function SeriesJourneyItem({
               </div>
             )}
 
-            {isReading && (
+            {(isReading || isPaused) && (
               <div className="grid gap-4 sm:grid-cols-3">
                 <TimelineMetric label="Started" value={formatDate(dates.started)} />
                 <TimelineMetric
@@ -722,12 +768,12 @@ function SeriesJourneyItem({
               </div>
             )}
 
-            {!isFinished && !isReading && (
+            {!isFinished && !isReading && !isPaused && (
               <p className="text-sm text-muted-foreground">Not started yet</p>
             )}
           </div>
 
-          {(isFinished || isReading) && (
+          {(isFinished || isReading || isPaused) && (
             <div className="flex min-h-full flex-col gap-5 border-t pt-4 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-2">
               <RatingStars rating={book.rating} />
               <JourneyFeaturedNote bookId={book.id} notes={notes} />

--- a/src/pages/library/CompactBookCard.tsx
+++ b/src/pages/library/CompactBookCard.tsx
@@ -1,7 +1,8 @@
-import { BookOpen, Heart, Star } from "lucide-react";
+import { BookOpen, Heart, PauseCircle, Star } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { statusVariant } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import type { Book } from "@/types";
 
 interface CompactBookCardProps {
@@ -21,6 +22,7 @@ function getProgress(book: Book) {
 
 export default function CompactBookCard({ book, onBook }: CompactBookCardProps) {
   const progress = getProgress(book);
+  const isPaused = book.status === "Paused";
 
   return (
     <button
@@ -34,11 +36,19 @@ export default function CompactBookCard({ book, onBook }: CompactBookCardProps) 
             src={book.cover_url}
             alt={book.title}
             loading="lazy"
-            className="h-full w-full object-cover transition duration-200 ease-out group-hover:scale-[1.015]"
+            className={cn(
+              "h-full w-full object-cover transition duration-200 ease-out group-hover:scale-[1.015]",
+              isPaused && "grayscale opacity-70",
+            )}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center">
             <BookOpen className="h-5 w-5 text-muted-foreground/40" />
+          </div>
+        )}
+        {isPaused && (
+          <div className="absolute inset-0 flex items-center justify-center bg-background/45 backdrop-blur-[1px]">
+            <PauseCircle className="h-5 w-5 text-muted-foreground" />
           </div>
         )}
         {book.is_favorite && (

--- a/src/pages/library/LibraryBookCard.tsx
+++ b/src/pages/library/LibraryBookCard.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Heart, Star } from "lucide-react";
+import { BookOpen, Heart, PauseCircle, Star } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { cn, statusVariant } from "@/lib/utils";
@@ -27,6 +27,7 @@ export default function LibraryBookCard({
 }: LibraryBookCardProps) {
   const progress = getProgress(book);
   const isShelf = variant === "shelf";
+  const isPaused = book.status === "Paused";
 
   return (
     <button
@@ -43,6 +44,7 @@ export default function LibraryBookCard({
         className={cn(
           "relative h-[135px] w-[90px] overflow-hidden bg-muted shadow-sm sm:h-[168px] sm:w-[112px]",
           isShelf && "rounded-md",
+          isPaused && "opacity-70",
         )}
       >
         {book.cover_url ? (
@@ -50,11 +52,19 @@ export default function LibraryBookCard({
             src={book.cover_url}
             alt={book.title}
             loading="lazy"
-            className="absolute inset-0 block h-full w-full scale-[1.035] object-cover transition duration-200 ease-out group-hover:scale-[1.055]"
+            className={cn(
+              "absolute inset-0 block h-full w-full scale-[1.035] object-cover transition duration-200 ease-out group-hover:scale-[1.055]",
+              isPaused && "grayscale",
+            )}
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center">
             <BookOpen className="h-8 w-8 text-muted-foreground/40" />
+          </div>
+        )}
+        {isPaused && (
+          <div className="absolute inset-0 flex items-center justify-center bg-background/45 backdrop-blur-[1px]">
+            <PauseCircle className="h-8 w-8 text-muted-foreground" />
           </div>
         )}
         {book.is_favorite && (

--- a/src/pages/library/SeriesStackCard.tsx
+++ b/src/pages/library/SeriesStackCard.tsx
@@ -1,4 +1,4 @@
-import { BookOpen } from "lucide-react";
+import { BookOpen, PauseCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SeriesBookGroup } from "@/lib/libraryShelves";
 import type { Book } from "@/types";
@@ -26,6 +26,7 @@ function SeriesCoverLayer({
       className={cn(
         "absolute left-0 top-2 h-[135px] w-[90px] overflow-hidden rounded-md bg-muted shadow-sm ring-1 ring-border transition-transform duration-300 ease-out motion-reduce:transition-none sm:h-[168px] sm:w-[112px]",
         layerStyles[index],
+        book.status === "Paused" && "opacity-70",
       )}
     >
       {book.cover_url ? (
@@ -33,11 +34,16 @@ function SeriesCoverLayer({
           src={book.cover_url}
           alt={index === 0 ? book.title : ""}
           loading="lazy"
-          className="block h-full w-full scale-[1.035] object-cover"
+          className={cn("block h-full w-full scale-[1.035] object-cover", book.status === "Paused" && "grayscale")}
         />
       ) : (
         <div className="flex h-full w-full items-center justify-center">
           <BookOpen className="h-8 w-8 text-muted-foreground/40" />
+        </div>
+      )}
+      {book.status === "Paused" && index === 0 && (
+        <div className="absolute inset-0 flex items-center justify-center bg-background/45 backdrop-blur-[1px]">
+          <PauseCircle className="h-7 w-7 text-muted-foreground" />
         </div>
       )}
     </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,7 @@ export type BookStatus =
   | "Not Started"
   | "Up Next"
   | "Reading"
+  | "Paused"
   | "Finished"
   | "DNF";
 
@@ -69,7 +70,17 @@ export interface Book {
   metadata_source_url?: string | null;
   series_id?: string;
   volume_number?: number;
+  pause_periods?: BookPausePeriod[];
   user_id: string;
+  created_at: string;
+}
+
+export interface BookPausePeriod {
+  id: string;
+  book_id: string;
+  user_id: string;
+  paused_at: string;
+  resumed_at?: string | null;
   created_at: string;
 }
 

--- a/supabase/migrations/20260621_pause_books.sql
+++ b/supabase/migrations/20260621_pause_books.sql
@@ -1,0 +1,120 @@
+-- Pause/resume support for books.
+
+ALTER TABLE books
+  DROP CONSTRAINT IF EXISTS books_status_check;
+
+ALTER TABLE books
+  ADD CONSTRAINT books_status_check
+  CHECK (status IN ('Wishlist','Not Started','Up Next','Reading','Paused','Finished','DNF'));
+
+CREATE TABLE IF NOT EXISTS book_pause_periods (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  book_id    uuid NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+  paused_at  timestamptz NOT NULL DEFAULT now(),
+  resumed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (resumed_at IS NULL OR resumed_at >= paused_at)
+);
+
+CREATE INDEX IF NOT EXISTS book_pause_periods_user_id_idx ON book_pause_periods(user_id);
+CREATE INDEX IF NOT EXISTS book_pause_periods_book_id_idx ON book_pause_periods(book_id);
+CREATE UNIQUE INDEX IF NOT EXISTS book_pause_periods_open_book_idx
+  ON book_pause_periods(book_id)
+  WHERE resumed_at IS NULL;
+
+ALTER TABLE book_pause_periods ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "book_pause_periods: owner select" ON book_pause_periods;
+DROP POLICY IF EXISTS "book_pause_periods: owner insert" ON book_pause_periods;
+DROP POLICY IF EXISTS "book_pause_periods: owner update" ON book_pause_periods;
+DROP POLICY IF EXISTS "book_pause_periods: owner delete" ON book_pause_periods;
+
+CREATE POLICY "book_pause_periods: owner select"
+  ON book_pause_periods FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "book_pause_periods: owner insert"
+  ON book_pause_periods FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "book_pause_periods: owner update"
+  ON book_pause_periods FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "book_pause_periods: owner delete"
+  ON book_pause_periods FOR DELETE
+  USING (auth.uid() = user_id);
+
+CREATE OR REPLACE FUNCTION pause_book(book_uuid uuid)
+RETURNS SETOF books
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  UPDATE books
+  SET status = 'Paused'
+  WHERE id = book_uuid
+    AND user_id = current_user_id
+    AND status = 'Reading';
+
+  IF FOUND THEN
+    INSERT INTO book_pause_periods (user_id, book_id, paused_at)
+    VALUES (current_user_id, book_uuid, now())
+    ON CONFLICT DO NOTHING;
+  END IF;
+
+  RETURN QUERY
+  SELECT books.*
+  FROM books
+  WHERE id = book_uuid
+    AND user_id = current_user_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION pause_book(uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION resume_book(book_uuid uuid)
+RETURNS SETOF books
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  UPDATE book_pause_periods
+  SET resumed_at = now()
+  WHERE book_id = book_uuid
+    AND user_id = current_user_id
+    AND resumed_at IS NULL;
+
+  UPDATE books
+  SET status = 'Reading'
+  WHERE id = book_uuid
+    AND user_id = current_user_id
+    AND status = 'Paused';
+
+  RETURN QUERY
+  SELECT books.*
+  FROM books
+  WHERE id = book_uuid
+    AND user_id = current_user_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION resume_book(uuid) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS books (
   authors         text[] NOT NULL CHECK (cardinality(authors) > 0),
   genres          text[],
   status          text NOT NULL DEFAULT 'Wishlist'
-                    CHECK (status IN ('Wishlist','Not Started','Up Next','Reading','Finished','DNF')),
+                    CHECK (status IN ('Wishlist','Not Started','Up Next','Reading','Paused','Finished','DNF')),
   cover_url       text,
   rating          smallint CHECK (rating BETWEEN 1 AND 5),
   is_favorite     boolean NOT NULL DEFAULT false,
@@ -146,6 +146,17 @@ CREATE TABLE IF NOT EXISTS reading_logs (
   current_page         integer NOT NULL CHECK (current_page >= 0),
   reading_time_minutes integer CHECK (reading_time_minutes > 0),
   logged_at            timestamptz NOT NULL DEFAULT now()
+);
+
+-- ── BOOK PAUSE PERIODS ────────────────────────────────────
+CREATE TABLE IF NOT EXISTS book_pause_periods (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  book_id    uuid NOT NULL REFERENCES books(id) ON DELETE CASCADE,
+  paused_at  timestamptz NOT NULL DEFAULT now(),
+  resumed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (resumed_at IS NULL OR resumed_at >= paused_at)
 );
 
 -- ── BOOK NOTES ────────────────────────────────────────────
@@ -387,6 +398,11 @@ CREATE INDEX IF NOT EXISTS book_genres_genre_id_idx ON book_genres(genre_id);
 CREATE INDEX IF NOT EXISTS series_user_id_idx       ON series(user_id);
 CREATE INDEX IF NOT EXISTS reading_logs_user_id_idx ON reading_logs(user_id);
 CREATE INDEX IF NOT EXISTS reading_logs_book_id_idx ON reading_logs(book_id);
+CREATE INDEX IF NOT EXISTS book_pause_periods_user_id_idx ON book_pause_periods(user_id);
+CREATE INDEX IF NOT EXISTS book_pause_periods_book_id_idx ON book_pause_periods(book_id);
+CREATE UNIQUE INDEX IF NOT EXISTS book_pause_periods_open_book_idx
+  ON book_pause_periods(book_id)
+  WHERE resumed_at IS NULL;
 CREATE INDEX IF NOT EXISTS book_notes_user_id_idx ON book_notes(user_id);
 CREATE INDEX IF NOT EXISTS book_notes_book_id_idx ON book_notes(book_id);
 CREATE INDEX IF NOT EXISTS book_notes_book_created_at_idx ON book_notes(book_id, created_at DESC);
@@ -426,6 +442,7 @@ ALTER TABLE books        ENABLE ROW LEVEL SECURITY;
 ALTER TABLE genres       ENABLE ROW LEVEL SECURITY;
 ALTER TABLE book_genres  ENABLE ROW LEVEL SECURITY;
 ALTER TABLE reading_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE book_pause_periods ENABLE ROW LEVEL SECURITY;
 ALTER TABLE book_notes ENABLE ROW LEVEL SECURITY;
 ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE user_settings ENABLE ROW LEVEL SECURITY;
@@ -841,6 +858,76 @@ AS $$
   SELECT parent_uuid IS NULL OR can_use_genre(parent_uuid, user_uuid);
 $$;
 
+CREATE OR REPLACE FUNCTION pause_book(book_uuid uuid)
+RETURNS SETOF books
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  UPDATE books
+  SET status = 'Paused'
+  WHERE id = book_uuid
+    AND user_id = current_user_id
+    AND status = 'Reading';
+
+  IF FOUND THEN
+    INSERT INTO book_pause_periods (user_id, book_id, paused_at)
+    VALUES (current_user_id, book_uuid, now())
+    ON CONFLICT DO NOTHING;
+  END IF;
+
+  RETURN QUERY
+  SELECT books.*
+  FROM books
+  WHERE id = book_uuid
+    AND user_id = current_user_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION pause_book(uuid) TO authenticated;
+
+CREATE OR REPLACE FUNCTION resume_book(book_uuid uuid)
+RETURNS SETOF books
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  current_user_id uuid := auth.uid();
+BEGIN
+  IF current_user_id IS NULL THEN
+    RAISE EXCEPTION 'You must be signed in.';
+  END IF;
+
+  UPDATE book_pause_periods
+  SET resumed_at = now()
+  WHERE book_id = book_uuid
+    AND user_id = current_user_id
+    AND resumed_at IS NULL;
+
+  UPDATE books
+  SET status = 'Reading'
+  WHERE id = book_uuid
+    AND user_id = current_user_id
+    AND status = 'Paused';
+
+  RETURN QUERY
+  SELECT books.*
+  FROM books
+  WHERE id = book_uuid
+    AND user_id = current_user_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION resume_book(uuid) TO authenticated;
+
 -- series
 CREATE POLICY "series: owner select" ON series FOR SELECT USING (auth.uid() = user_id);
 CREATE POLICY "series: owner insert" ON series FOR INSERT WITH CHECK (auth.uid() = user_id);
@@ -919,6 +1006,24 @@ CREATE POLICY "reading_logs: owner select" ON reading_logs FOR SELECT USING (aut
 CREATE POLICY "reading_logs: owner insert" ON reading_logs FOR INSERT WITH CHECK (auth.uid() = user_id);
 CREATE POLICY "reading_logs: owner update" ON reading_logs FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
 CREATE POLICY "reading_logs: owner delete" ON reading_logs FOR DELETE USING (auth.uid() = user_id);
+
+-- book_pause_periods
+CREATE POLICY "book_pause_periods: owner select"
+  ON book_pause_periods FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "book_pause_periods: owner insert"
+  ON book_pause_periods FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "book_pause_periods: owner update"
+  ON book_pause_periods FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "book_pause_periods: owner delete"
+  ON book_pause_periods FOR DELETE
+  USING (auth.uid() = user_id);
 
 -- book_notes
 CREATE POLICY "book_notes: owner select"


### PR DESCRIPTION
## Summary
- Added pause/resume support for books, including paused analytics handling and a pause-aware detail/menu flow.
- Added a paused shelf on Home and a pause release note that follows the chat/groups note.
- Updated the library and detail views so paused books look inactive and can be resumed from the dropdown or main button.

## Verification
- `npm run build`